### PR TITLE
Cache path vs Local path

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -392,8 +392,9 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     const revision = options.revision ?? 'main';
 
     let requestURL = pathJoin(path_or_repo_id, filename);
-    let localPath = pathJoin(env.localModelPath, requestURL);
+    let cachePath = pathJoin(env.localModelPath, requestURL);
 
+    let localPath = requestURL; // Hoisted before below mutation
     let remoteURL = pathJoin(
         env.remoteHost,
         env.remotePathTemplate
@@ -422,7 +423,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         //  1. We first try to get from cache using the local path. In some environments (like deno),
         //     non-URL cache keys are not allowed. In these cases, `response` will be undefined.
         //  2. If no response is found, we try to get from cache using the remote URL or file system cache.
-        response = await tryCache(cache, localPath, proposedCacheKey);
+        response = await tryCache(cache, cachePath, proposedCacheKey);
     }
 
     const cacheHit = response !== undefined;
@@ -444,9 +445,9 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
                     console.warn(`Unable to load from local path "${localPath}": "${e}"`);
                 }
             } else if (options.local_files_only) {
-                throw new Error(`\`local_files_only=true\`, but attempted to load a remote file from: ${requestURL}.`);
+                throw new Error(`\`local_files_only=true\`, but attempted to load a remote file from: ${localPath}.`);
             } else if (!env.allowRemoteModels) {
-                throw new Error(`\`env.allowRemoteModels=false\`, but attempted to load a remote file from: ${requestURL}.`);
+                throw new Error(`\`env.allowRemoteModels=false\`, but attempted to load a remote file from: ${localPath}.`);
             }
         }
 

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -394,7 +394,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     let requestURL = pathJoin(path_or_repo_id, filename);
     let cachePath = pathJoin(env.localModelPath, requestURL);
 
-    let localPath = requestURL; // Hoisted before below mutation
+    let localPath = requestURL;
     let remoteURL = pathJoin(
         env.remoteHost,
         env.remotePathTemplate


### PR DESCRIPTION
This aims to fix an issue where providing a directory for a model in a different parent directory/tree results in an error. 

There is a split handling between cache path and local path - mostly because I wasn't sure behind all use case implementations (browser vs local vs X). This solutions solves providing file paths such as `../../your_model_dir` as the `env.localModelPath` variable.