### PR TITLE
filter cache puts to http(s)

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -535,7 +535,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     if (
         // Only cache web responses
         // i.e., do not cache FileResponses (prevents duplication)
-        toCacheResponse && cacheKey
+        response.url.startsWith('http') && toCacheResponse && cacheKey
         &&
         // Check again whether request is in cache. If not, we add the response to the cache
         (await cache.match(cacheKey) === undefined)


### PR DESCRIPTION
I am bundeling my model within a chrome extension, and as a result I am getting a bunch of these warnings. Since Cache.put only takes http/s, I thought you may as well filter out other requests