### PR TITLE
fix memory leak in BPE

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -668,9 +668,6 @@ class BPE extends TokenizerModel {
         }
 
         this.ignore_merges = this.config.ignore_merges ?? false;
-
-        /** @type {Map<string, string[]>} */
-        this.cache = new Map();
     }
 
     /**
@@ -682,11 +679,6 @@ class BPE extends TokenizerModel {
     bpe(token) {
         if (token.length === 0) {
             return [];
-        }
-
-        const cached = this.cache.get(token);
-        if (cached !== undefined) {
-            return cached;
         }
 
         const word = Array.from(token);
@@ -796,9 +788,6 @@ class BPE extends TokenizerModel {
                 result[i] += this.continuing_subword_suffix;
             }
         }
-
-        // Save the result to the cache
-        this.cache.set(token, result);
 
         return result;
     }


### PR DESCRIPTION
turns out this isn't much of a cache. just a memory leak in disguise.

```
> let {LlamaTokenizer} = await import('./src/transformers.js')
> var tok = await LlamaTokenizer.from_pretrained('TinyLlama/TinyLlama-1.1B-Chat-v0.4')
> tok.encode("very long user input ".repeat(10))
[
     1, 1407, 1472, 1404, 1881,  1407,
  1472, 1404, 1881, 1407, 1472,  1404,
  1881, 1407, 1472, 1404, 1881,  1407,
  1472, 1404, 1881, 1407, 1472,  1404,
  1881, 1407, 1472, 1404, 1881,  1407,
  1472, 1404, 1881, 1407, 1472,  1404,
  1881, 1407, 1472, 1404, 1881, 29871
]
> tok.model.cache
Map(1) {
  '▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁very▁long▁user▁input▁' => [
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁very', '▁long', '▁user', '▁input',
    '▁'
  ]
}
```
