### PR TITLE
Add option to pad an image to a square

### DIFF
--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -1,10 +1,10 @@
 
 /**
  * @file Core utility functions/classes for Transformers.js.
- * 
+ *
  * These are only used internally, meaning an end-user shouldn't
  * need to access anything here.
- * 
+ *
  * @module utils/core
  */
 
@@ -46,7 +46,7 @@ export function escapeRegExp(string) {
  * Check if a value is a typed array.
  * @param {*} val The value to check.
  * @returns {boolean} True if the value is a `TypedArray`, false otherwise.
- * 
+ *
  * Adapted from https://stackoverflow.com/a/71091338/13989043
  */
 export function isTypedArray(val) {
@@ -61,6 +61,15 @@ export function isTypedArray(val) {
  */
 export function isIntegralNumber(x) {
     return Number.isInteger(x) || typeof x === 'bigint'
+}
+
+/**
+ * Determine if a provided width or height is nullish.
+ * @param {*} x The value to check.
+ * @returns {boolean} True if the value is `null`, `undefined` or `-1`, false otherwise.
+ */
+export function isNullishDimension(x) {
+    return x === null || x === undefined || x === -1 || x === '-1';
 }
 
 /**
@@ -132,9 +141,9 @@ export function calculateReflectOffset(i, w) {
 }
 
 /**
- * 
- * @param {Object} o 
- * @param {string[]} props 
+ *
+ * @param {Object} o
+ * @param {string[]} props
  * @returns {Object}
  */
 export function pick(o, props) {
@@ -151,7 +160,7 @@ export function pick(o, props) {
 /**
  * Calculate the length of a string, taking multi-byte characters into account.
  * This mimics the behavior of Python's `len` function.
- * @param {string} s The string to calculate the length of. 
+ * @param {string} s The string to calculate the length of.
  * @returns {number} The length of the string.
  */
 export function len(s) {

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -438,6 +438,31 @@ export class RawImage {
         }
     }
 
+    /**
+     * Pad the image to a square.
+     * @param {*} dim The length of one of the square's side.
+     * @returns {Promise<RawImage>} `this` to support chaining.
+     */
+    async padToSquare(dim) {
+        // We cannot pad to a square if the image is larger than provided size.
+        if (this.width > dim || this.height > dim) {
+            return this;
+        }
+
+        // If no value was provided, then use the largest side.
+        if (dim === undefined) {
+            dim = Math.max(this.width, this.height);
+        }
+
+        // Odd numbers will add extra padding to the right and bottom.
+        return this.pad([
+            Math.floor((dim - this.width) / 2),
+            Math.ceil((dim - this.width) / 2),
+            Math.floor((dim - this.height) / 2),
+            Math.ceil((dim - this.height) / 2),
+        ]);
+    }
+
     async crop([x_min, y_min, x_max, y_max]) {
         // Ensure crop bounds are within the image
         x_min = Math.max(x_min, 0);

--- a/tests/utils/utils.test.js
+++ b/tests/utils/utils.test.js
@@ -1,5 +1,6 @@
 import { AutoProcessor, hamming, hanning, mel_filter_bank } from "../../src/transformers.js";
 import { getFile } from "../../src/utils/hub.js";
+import { RawImage } from "../../src/utils/image.js";
 
 import { MAX_TEST_EXECUTION_TIME } from "../init.js";
 import { compare } from "../test_utils.js";
@@ -57,6 +58,36 @@ describe("Utilities", () => {
       const blobUrl = URL.createObjectURL(blob);
       const data = await getFile(blobUrl);
       expect(await data.text()).toBe("Hello, world!");
+    });
+  });
+
+  describe("Image utilities", () => {
+    it("Read image from URL", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      expect(image.width).toBe(300);
+      expect(image.height).toBe(200);
+      expect(image.channels).toBe(3);
+    });
+
+    it("Can resize image", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(150, 100);
+      expect(resized.width).toBe(150);
+      expect(resized.height).toBe(100);
+    });
+
+    it("Can resize with aspect ratio", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(150, null);
+      expect(resized.width).toBe(150);
+      expect(resized.height).toBe(100);
+    });
+
+    it("Returns original image if width and height are null", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(null, null);
+      expect(resized.width).toBe(300);
+      expect(resized.height).toBe(200);
     });
   });
 });

--- a/tests/utils/utils.test.js
+++ b/tests/utils/utils.test.js
@@ -89,5 +89,26 @@ describe("Utilities", () => {
       expect(resized.width).toBe(300);
       expect(resized.height).toBe(200);
     });
+
+    it("Can pad to a square with no args", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const padded = await image.padToSquare();
+      expect(padded.width).toBe(300);
+      expect(padded.height).toBe(300);
+    });
+
+    it("Can pad to a square with larger sides", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const padded = await image.padToSquare(400);
+      expect(padded.width).toBe(400);
+      expect(padded.height).toBe(400);
+    });
+
+    it("Cannot pad to square if dim is smaller than image", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const padded = await image.padToSquare(100);
+      expect(padded.width).toBe(300);
+      expect(padded.height).toBe(200);
+    });
   });
 });


### PR DESCRIPTION
This PR is stacked on [PR 971](https://github.com/xenova/transformers.js/pull/971).  
On my fork, this was branched off the other PR, but I couldn't find a way to do this with PRs - sorry 😅

---

It's common to want to create a square image, currently we need to do some manual calculations.

With this PR, we can do something like this, with no arguments to just fill the blank area.
```js
const image = await RawImage.fromURL("https://picsum.photos/600/400");
const resized = await image.resize(300, null); // 300x200
const padded = await resized.padToSquare();    // 300x300
```

Or we can provide a value, and make the image pad to that size.
```js
const image = await RawImage.fromURL("https://picsum.photos/600/400");
const resized = await image.resize(300, null); // 300x200
const padded = await resized.padToSquare(400); // 400x400
```

Providing a value that is smaller than either the width or height will just return the image unchanged.
```js
const image = await RawImage.fromURL("https://picsum.photos/600/400");
const resized = await image.resize(300, null); // 300x200
const padded = await resized.padToSquare(100); // 300x200
```