### PR TITLE
Improvements on Exposed ORT support

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -59,11 +59,11 @@ const supportedDevices = [];
 /** @type {ONNXExecutionProviders[]} */
 let defaultDevices;
 let ONNX;
-const ORT_SYMBOL = Symbol.for('onnxruntime');
 
-if (ORT_SYMBOL in globalThis) {
-  // If the JS runtime exposes their own ONNX runtime, use it
-  ONNX = globalThis[ORT_SYMBOL];
+if (apis.IS_EXPOSED_RUNTIME_ENV) {
+    // If the JS runtime exposes their own ONNX runtime, use it
+    ONNX = globalThis[apis.EXPOSED_RUNTIME_SYMBOL];
+    defaultDevices = ['auto'];
 
 } else if (apis.IS_NODE_ENV) {
     ONNX = ONNX_NODE.default ?? ONNX_NODE;

--- a/src/env.js
+++ b/src/env.js
@@ -35,6 +35,9 @@ const IS_WEB_CACHE_AVAILABLE = IS_BROWSER_ENV && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;
 
+const EXPOSED_RUNTIME_SYMBOL = Symbol.for('onnxruntime');
+const IS_EXPOSED_RUNTIME_ENV = EXPOSED_RUNTIME_SYMBOL in globalThis;
+
 const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
 const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
 const IS_FS_AVAILABLE = !isEmpty(fs);
@@ -58,6 +61,12 @@ export const apis = Object.freeze({
 
     /** Whether the WebNN API is available */
     IS_WEBNN_AVAILABLE,
+
+    /** Symbol from JS environment that exposes their own ONNX runtime */
+    EXPOSED_RUNTIME_SYMBOL,
+
+    /** Whether we are running in a JS environment that exposes their own ONNX runtime */
+    IS_EXPOSED_RUNTIME_ENV,
 
     /** Whether the Node.js process API is available */
     IS_PROCESS_AVAILABLE,

--- a/src/models.js
+++ b/src/models.js
@@ -166,7 +166,10 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
 
     // If the device is not specified, we use the default (supported) execution providers.
     const selectedDevice = /** @type {import("./utils/devices.js").DeviceType} */(
-        device ?? (apis.IS_NODE_ENV ? 'cpu' : 'wasm')
+        device ?? (
+          apis.IS_EXPOSED_RUNTIME_ENV ? 'auto' : (
+            apis.IS_NODE_ENV ? 'cpu' : 'wasm'
+        ))
     );
     const executionProviders = deviceToExecutionProviders(selectedDevice);
 


### PR DESCRIPTION
Hey there 🙏,
Coming from #947, I did test the new `Exposed ORT` feature in `alpha-v20` and `alpha-21` releases. I'd notice that to make it work we must specify `'auto'` as inference `device`:

<details>
<summary>Current behaviour:</summary>

Without specify a device:
```js
import { pipeline } from '@huggingface/transformers';

let pipe = await pipeline('sentiment-analysis');
// The exposed runtime is loaded 
// but when trying to inference:
let out = await pipe('I love transformers!');
//Error: Unsupported device: "wasm". Should be one of: 
```

Explicit using `auto` as device:
```js
import { pipeline } from '@huggingface/transformers';

let pipe = await pipeline('sentiment-analysis', null, { device: 'auto' });

let out = await pipe('I love transformers!');
// [{'label': 'POSITIVE', 'score': 0.999817686}]
```
---

</details>

To solve this annoying config, the PR improves the environment support for `Exposed ORT` by implicitly selecting `'auto'` as the default fallback instead of `'wasm'`.
```js
import { pipeline } from '@huggingface/transformers';

let pipe = await pipeline('sentiment-analysis');

let out = await pipe('I love transformers!');
// [{'label': 'POSITIVE', 'score': 0.999817686}]
```