### PR TITLE
fix(docs): fixed a broken link to quantization guide

### DIFF
--- a/docs/snippets/1_quick-tour.snippet
+++ b/docs/snippets/1_quick-tour.snippet
@@ -62,7 +62,7 @@ In resource-constrained environments, such as web browsers, it is advisable to u
 the model to lower bandwidth and optimize performance. This can be achieved by adjusting the `dtype` option,
 which allows you to select the appropriate data type for your model. While the available options may vary
 depending on the specific model, typical choices include `"fp32"` (default for WebGPU), `"fp16"`, `"q8"`
-(default for WASM), and `"q4"`. For more information, check out the [quantization guide](/guides/dtypes).
+(default for WASM), and `"q4"`. For more information, check out the [quantization guide](../guides/dtypes).
 ```javascript
 // Run the model at 4-bit quantization
 const pipe = await pipeline('sentiment-analysis', 'Xenova/distilbert-base-uncased-finetuned-sst-2-english', {


### PR DESCRIPTION
quantization guide link was absolute and pointed to root `/guides/dtype` which would send the user all the way to the root of the url.

Clicking on the link from https://huggingface.co/docs/transformers.js/index took you to https://huggingface.co/guides/dtypes

Now takes you to the right page https://huggingface.co/docs/transformers.js/guides/dtypes