### PR TITLE
[BUG] When padding an image, the dimensions get stretched

### DIFF
--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -1,10 +1,10 @@
 
 /**
- * @file Helper module for image processing. 
- * 
- * These functions and classes are only used internally, 
+ * @file Helper module for image processing.
+ *
+ * These functions and classes are only used internally,
  * meaning an end-user shouldn't need to access anything here.
- * 
+ *
  * @module utils/image
  */
 
@@ -91,7 +91,7 @@ export class RawImage {
         this.channels = channels;
     }
 
-    /** 
+    /**
      * Returns the size of the image (width, height).
      * @returns {[number, number]} The size of the image (width, height).
      */
@@ -101,9 +101,9 @@ export class RawImage {
 
     /**
      * Helper method for reading an image from a variety of input types.
-     * @param {RawImage|string|URL} input 
+     * @param {RawImage|string|URL} input
      * @returns The image object.
-     * 
+     *
      * **Example:** Read image from a URL.
      * ```javascript
      * let image = await RawImage.read('https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/football-match.jpg');
@@ -181,7 +181,7 @@ export class RawImage {
 
     /**
      * Helper method to create a new Image from a tensor
-     * @param {Tensor} tensor 
+     * @param {Tensor} tensor
      */
     static fromTensor(tensor, channel_format = 'CHW') {
         if (tensor.dims.length !== 3) {
@@ -355,7 +355,7 @@ export class RawImage {
                 case 'nearest':
                 case 'bilinear':
                 case 'bicubic':
-                    // Perform resizing using affine transform. 
+                    // Perform resizing using affine transform.
                     // This matches how the python Pillow library does it.
                     img = img.affine([width / this.width, 0, 0, height / this.height], {
                         interpolator: resampleMethod
@@ -368,7 +368,7 @@ export class RawImage {
                     img = img.resize({
                         width, height,
                         fit: 'fill',
-                        kernel: 'lanczos3', // PIL Lanczos uses a kernel size of 3 
+                        kernel: 'lanczos3', // PIL Lanczos uses a kernel size of 3
                     });
                     break;
 
@@ -408,13 +408,14 @@ export class RawImage {
             // Draw image to context, padding in the process
             ctx.drawImage(canvas,
                 0, 0, this.width, this.height,
-                left, top, newWidth, newHeight
+                left, top, this.width, this.height
             );
 
             // Create image from the padded data
             const paddedImage = new RawImage(
                 ctx.getImageData(0, 0, newWidth, newHeight).data,
-                newWidth, newHeight, 4);
+                newWidth, newHeight, 4
+            );
 
             // Convert back so that image has the same number of channels as before
             return paddedImage.convert(numChannels);
@@ -447,7 +448,7 @@ export class RawImage {
             // Create canvas object for this image
             const canvas = this.toCanvas();
 
-            // Create a new canvas of the desired size. This is needed since if the 
+            // Create a new canvas of the desired size. This is needed since if the
             // image is too small, we need to pad it with black pixels.
             const ctx = createCanvasFunction(crop_width, crop_height).getContext('2d');
 
@@ -495,7 +496,7 @@ export class RawImage {
             // Create canvas object for this image
             const canvas = this.toCanvas();
 
-            // Create a new canvas of the desired size. This is needed since if the 
+            // Create a new canvas of the desired size. This is needed since if the
             // image is too small, we need to pad it with black pixels.
             const ctx = createCanvasFunction(crop_width, crop_height).getContext('2d');
 


### PR DESCRIPTION
Fix that padding was stretching the original image, and the right side was overflowing the container.

## Example
This is the code I used to generate the images.  
I resize the images, so that they can be padded again to the same height as the original image.
```javascript
RawImage.fromBlob(file)
.then(image => image.resize((256 / image.height) * image.width, 256))
.then(image => image.pad([128, 128, 128, 128]))
.then(image => image.save('padded.png'));
```

| Original image | Old solution | New solution |
|----------------|--------------|--------------|
| <img src="https://github.com/user-attachments/assets/a819473d-f7d3-474c-a32f-baa60e6bb5dd" alt="A Moana Loungefly backpack on a white background"> | <img src="https://github.com/user-attachments/assets/3fbf3226-b00c-4aa9-9f7a-5488cb1a9c1c" alt="A Moana Loungefly backpack, where this is 128 pixels of padding along the top and left, however the image is cropped on the right and bottom"> | <img src="https://github.com/user-attachments/assets/121075be-0abe-4f76-8a60-9e6a4fc1b779" alt="A Moana Loungefly backpack where there is an even 128 pixels of padding all around, and the image is still 256 pixels tall"> |

As you can see above, the old solution will add the 128 pixel padding to the top and left, however the image is resized and drawn with the same size as the canvas, hence it is cropped by 128 pixels on the right and bottom.

However, the new solution will correctly draw the image with the provided padding all around as we now draw the image with the same dimensions that it was passed in with.

## Explanation
The current implementation was drawing the image with a width of `newWidth`, where `newWidth` will be the entire width.  
This is incorrect, since the width should remain unchanged when drawing, otherwise the image will become stretched.

As a result, we are getting the correct left padding and top padding, but the right and bottom of the image are getting cropped off since the image is being stretched out.  

[From the docs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage), the `sWidth` and `sHeight` should match `dWidth` and `dHeight`.