### PR TITLE
fix(scale): add missing scale element

### DIFF
--- a/examples/video-object-detection/index.html
+++ b/examples/video-object-detection/index.html
@@ -34,6 +34,12 @@
       <br>
       <input id="threshold" type="range" min="0.01" max="1" step="0.01" value="0.25" disabled>
     </div>
+    <div>
+      <label>Image scale</label>
+      (<label id="scale-value">0.5</label>)
+      <br>
+      <input id="scale" type="range" min="0" max="1" step="0.01" value="0.5" disabled>
+    </div>
   </div>
   <label id="status"></label>
 


### PR DESCRIPTION
Fixes bug:  `Uncaught TypeError: Cannot read properties of null (reading 'addEventListener') at main.js:38:13`

### Cause
While `scaleSlider` and `scaleLabel` are defined in `main.js`, there are missing in the `index.html` dom
```javascript
const scaleSlider = document.getElementById('scale');
const scaleLabel = document.getElementById('scale-value');
```

This leads to a uncaught error which doesn't allow the example to work in the line below:
```javascript
// Set up controls
let scale = 0.5;
scaleSlider.addEventListener('input', () => {
    scale = Number(scaleSlider.value);
    setStreamSize(video.videoWidth * scale, video.videoHeight * scale);
    scaleLabel.textContent = scale;
});
scaleSlider.disabled = false;
```