### PR TITLE
Avoid resizing images when they already have the desired size

### DIFF
--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -316,6 +316,11 @@ export class RawImage {
         resample = 2,
     } = {}) {
 
+        // Do nothing if the image already has the desired size
+        if (this.width === width && this.height === height) {
+            return this;
+        }
+
         // Ensure resample method is a string
         let resampleMethod = RESAMPLING_MAPPING[resample] ?? resample;
 


### PR DESCRIPTION
This turns the resize method of RawImage to a no-op when the image already has the right size, saving some (or a lot of) CPU cycles.