### PR TITLE
Add support for Split pretokenizer w/ `behavior=removed` & `invert=false`

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -1518,6 +1518,8 @@ class SplitPreTokenizer extends PreTokenizer {
 
         if (this.config.invert) {
             return text.match(this.pattern) || [];
+        } else if (this.config.behavior?.toLowerCase() === 'removed') {
+            return text.split(this.pattern).filter(x => x);
         } else {
             return regexSplit(text, this.pattern);
         }

--- a/tests/models/roberta/tokenization.js
+++ b/tests/models/roberta/tokenization.js
@@ -691,4 +691,14 @@ export const TEST_CONFIG = {
       decoded: "<s> \tH\u00e4LLo!how  \n Are yoU?  </s>",
     },
   },
+
+  // Split tokenizer with behavior="Removed" and invert=false
+  "onnx-community/camembertv2-base": {
+    SIMPLE: {
+      text: BASE_TEST_STRINGS.SIMPLE,
+      tokens: ['How', 'are', 'you', 'doi', '##ng', '?'],
+      ids: [1, 14473, 9556, 10577, 6471, 9274, 38, 2],
+      decoded: "[CLS] How are you doing? [SEP]",
+    }
+  },
 };


### PR DESCRIPTION
This means we can run the new CamemBERT 2.0 models

```js
import { pipeline } from '@huggingface/transformers';

// Create a question-answering pipeline
const answerer = await pipeline('question-answering', 'onnx-community/camembertv2-base-fquad');

// Generate a response
const question = 'Quelle est la capitale de la France ?';
const context = 'La capitale de la France est Paris.';
const result = await answerer(question, context);
console.log(result); // { answer: 'Paris', score: 0.9173286837656189 }
```