### PR TITLE
Add support for op_block_list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .vscode
 node_modules
 .cache
+.DS_STORE
 
 # Do not track build artifacts/generated files
 /dist

--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from tqdm import tqdm
-from typing import Set
+from typing import Set, List, Optional
 import onnx
 import os
 
@@ -110,6 +110,16 @@ class QuantizationArguments:
         },
     )
 
+    op_block_list: List[str] = field(
+        default=None,
+        metadata={
+            "help": "List of operators to exclude from quantization."
+            "Can be any standard ONNX operator (see https://onnx.ai/onnx/operators/)"
+            "or your custom implemented operators.",
+            "nargs": "+",
+        },
+    )
+
 
 def get_operators(model: onnx.ModelProto) -> Set[str]:
     operators = set()
@@ -131,6 +141,7 @@ def quantize_q8(
     per_channel: bool,
     reduce_range: bool,
     weight_type: QuantType,
+    op_block_list: Optional[List[str]]
 ):
     """
     Quantize the weights of the model from float32 to int8/uint8
@@ -139,6 +150,10 @@ def quantize_q8(
     https://onnxruntime.ai/docs/performance/quantization.html#data-type-selection
     it is faster on most CPU architectures
     """
+
+    op_types_to_quantize = set(IntegerOpsRegistry.keys())
+    if op_block_list is not None:
+        op_types_to_quantize.difference_update(op_block_list)
 
     quantizer = ONNXQuantizer(
         model,
@@ -151,7 +166,7 @@ def quantize_q8(
         tensors_range=None,
         nodes_to_quantize=[],
         nodes_to_exclude=[],
-        op_types_to_quantize=list(IntegerOpsRegistry.keys()),
+        op_types_to_quantize=op_types_to_quantize,
         extra_options=dict(
             EnableSubgraph=True,
             MatMulConstBOnly=True,
@@ -165,6 +180,7 @@ def quantize_q8(
 def quantize_fp16(
     model: onnx.ModelProto,
     save_path: str,
+    op_block_list: Optional[List[str]]
 ):
     """
     Quantize the weights of the model from float32 to float16
@@ -174,10 +190,15 @@ def quantize_fp16(
     # ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB: 2338583841
     disable_shape_infer = model.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF
 
+    blocked_ops = set(float16.DEFAULT_OP_BLOCK_LIST)
+    if op_block_list is not None:
+        blocked_ops.update(op_block_list)
+
     model_fp16 = float16.convert_float_to_float16(
         model,
         keep_io_types=True,
         disable_shape_infer=disable_shape_infer,
+        op_block_list=blocked_ops,
     )
     graph = gs.import_onnx(model_fp16)
     graph.toposort()
@@ -271,6 +292,7 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                 quantize_fp16(
                     model,
                     save_path,
+                    quantization_args.op_block_list
                 )
 
             elif mode in (QuantMode.Q4, QuantMode.Q4F16):
@@ -287,6 +309,7 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                     quantize_fp16(
                         q4_model,
                         save_path,
+                        quantization_args.op_block_list,
                     )
 
             elif mode == QuantMode.BNB4:
@@ -331,6 +354,7 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                     per_channel=quantization_args.per_channel,
                     reduce_range=quantization_args.reduce_range,
                     weight_type=weight_type,
+                    op_block_list=quantization_args.op_block_list,
                 )
 
 

--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -207,7 +207,6 @@ def quantize_q4(
     block_size: int,
     is_symmetric: bool,
     accuracy_level: int,
-    op_block_list: List[str] = [],
 ):
     """
     Quantize the weights of the model from float32 to 4-bit int
@@ -289,6 +288,7 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                 quantize_fp16(
                     model,
                     save_path,
+                    quantization_args.op_block_list
                 )
 
             elif mode in (QuantMode.Q4, QuantMode.Q4F16):
@@ -300,12 +300,12 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                     block_size=block_size,
                     is_symmetric=quantization_args.is_symmetric,
                     accuracy_level=quantization_args.accuracy_level,
-                    op_block_list=quantization_args.op_block_list,
                 )
                 if mode == QuantMode.Q4F16:
                     quantize_fp16(
                         q4_model,
                         save_path,
+                        quantization_args.op_block_list,
                     )
 
             elif mode == QuantMode.BNB4:
@@ -318,7 +318,6 @@ def quantize(input_folder, output_folder, quantization_args: QuantizationArgumen
                         if quantization_args.quant_type is not None
                         else MatMulBnb4Quantizer.NF4
                     ),
-                    op_block_list=quantization_args.op_block_list,
                 )
 
             elif mode in (QuantMode.Q8, QuantMode.QI8, QuantMode.QU8):


### PR DESCRIPTION
**Background**
Added a new argument to the quantize script called "op_block_list." If op_block_list is provided, do not quantize those ops. Sometimes you have ops that are incompatible with quantization.

**Test Plan**

**Regession Test**
- This test is just making sure there are no regressions in behaviour when you don't provide an `op_block_list`
- `git clone https://huggingface.co/onnx-models/sentence-t5-base-onnx`
- This model has a `/model/model.0/auto_model/encoder/block.0/layer.0/SelfAttention/Range` node so we are checking that it is still excluded because it is part of the default exclude types (https://github.com/microsoft/onnxconverter-common/blob/master/onnxconverter_common/float16.py#L108)
- Test with `main` branch of transformers.js
- `git checkout . && rm -rf ./*_*.onnx || true && PYTHONPATH=../transformers.js ../transformers.js/.venv/bin/python3 -m scripts.quantize --input_folder . --output_folder . --mode fp16`
- Run stat: `stat -f "%z" model_fp16.onnx`
```
220762121
```
- Now test with this PR branch
- `git checkout . && rm -rf ./*_*.onnx || true && PYTHONPATH=../transformers.js ../transformers.js/.venv/bin/python3 -m scripts.quantize --input_folder . --output_folder . --mode fp16`
- Run stat: `stat -f "%z" model_fp16.onnx`
```
220762121
```
- **File size is the same so test passed**


**Qwen2-VL Test**
- Here we actually check that the `op_block_list` works
- Checkout this PR for transformers.js
- Clone this repo https://huggingface.co/pdufour/Qwen2-VL-2B-Instruct-ONNX-Q4-F16
- Delete already quantized models so it doesn't double quant them
- `rm -rf onnx/*_*_*.onnx`
- Quantize the **A** model **without** the op_block_list
- `PYTHONPATH=../transformers.js ../transformers.js/.venv/bin/python3 -m scripts.quantize --input_folder ./onnx --output_folder ./onnx-dest --mode q4f16`
- Run the infer script: `python3 infer.py Qwen/Qwen2-VL-2B-Instruct ./onnx`
  - Expected result: No error.
  - Actual Result: `onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from ./onnx/QwenVL_A_q4f16.onnx failed:Type Error: Type parameter (T) of Optype (Sub) bound to different types (tensor(float) and tensor(float16) in node (/Sub).`
- Now we quantize **with** the op block list
- `rm -rf onnx/*_*_*.onnx`
- `PYTHONPATH=../transformers.js ../transformers.js/.venv/bin/python3 -m scripts.quantize --input_folder ./onnx --output_folder ./onnx --mode q4f16 --op_block_list Conv DynamicQuantizeLinear DequantizeLinear Resize`
- Try infer script again
  - `python3 infer.py Qwen/Qwen2-VL-2B-Instruct ./onnx`
  - ```The image shows a vintage teal-colored...```
  - You see the correct result
