### PR TITLE
Fix ghost dependency onnxruntime-common with versions for node and web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.3.2",
+        "onnxruntime-common-for-node": "npm:onnxruntime-common@1.20.1",
+        "onnxruntime-common-for-web": "npm:onnxruntime-common@1.21.0-dev.20241205-6ed77cc374",
         "onnxruntime-node": "1.20.1",
         "onnxruntime-web": "1.21.0-dev.20241205-d27fecd3d3",
         "sharp": "^0.33.5"
@@ -8763,6 +8765,20 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.20.1.tgz",
       "integrity": "sha512-YiU0s0IzYYC+gWvqD1HzLc46Du1sXpSiwzKb63PACIJr6LfL27VsXSXQvt68EzD3V0D5Bc0vyJTjmMxp0ylQiw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-common-for-node": {
+      "name": "onnxruntime-common",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.20.1.tgz",
+      "integrity": "sha512-YiU0s0IzYYC+gWvqD1HzLc46Du1sXpSiwzKb63PACIJr6LfL27VsXSXQvt68EzD3V0D5Bc0vyJTjmMxp0ylQiw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-common-for-web": {
+      "name": "onnxruntime-common",
+      "version": "1.21.0-dev.20241205-6ed77cc374",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0-dev.20241205-6ed77cc374.tgz",
+      "integrity": "sha512-U4DGq/dZiboIEK0Zv1KUuWJesJ/txUALpWSXwI8kqOCSxe8GrI65xfRFeMbqYFhPVGAWZPsBpT1zo1s4ksrlrg==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
   "homepage": "https://github.com/huggingface/transformers.js#readme",
   "dependencies": {
     "@huggingface/jinja": "^0.3.2",
+    "onnxruntime-common-for-node": "npm:onnxruntime-common@1.20.0",
+    "onnxruntime-common-for-web": "npm:onnxruntime-common@1.21.0-dev.20241205-6ed77cc374",
     "onnxruntime-node": "1.20.1",
     "onnxruntime-web": "1.21.0-dev.20241205-d27fecd3d3",
     "sharp": "^0.33.5"
@@ -75,6 +77,14 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.1.0"
   },
+  "overrides": {
+    "onnxruntime-node": {
+      "onnxruntime-common": "$onnxruntime-common-for-node"
+    },
+    "onnxruntime-web": {
+      "onnxruntime-common": "$onnxruntime-common-for-web"
+    }
+  },
   "files": [
     "src",
     "dist",
@@ -87,7 +97,8 @@
     "path": false,
     "url": false,
     "sharp": false,
-    "onnxruntime-node": false
+    "onnxruntime-node": false,
+    "onnxruntime-common-for-node": false
   },
   "publishConfig": {
     "access": "public"

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -23,7 +23,10 @@ import { env, apis } from '../env.js';
 import * as ONNX_NODE from 'onnxruntime-node';
 import * as ONNX_WEB from 'onnxruntime-web';
 
-export { Tensor } from 'onnxruntime-common';
+import { Tensor as Tensor_NODE } from "onnxruntime-common-for-node";
+import { Tensor as Tensor_WEB } from "onnxruntime-common-for-web";
+let Tensor = apis.IS_NODE_ENV ? Tensor_NODE : Tensor_WEB;
+export { Tensor };
 
 /**
  * @typedef {import('onnxruntime-common').InferenceSession.ExecutionProviderConfig} ONNXExecutionProviders

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,13 +94,14 @@ function buildConfig({
 
 // Do not bundle onnxruntime-web when packaging for Node.js.
 // Instead, we use the native library (onnxruntime-node).
-const NODE_IGNORE_MODULES = ["onnxruntime-web"];
+const NODE_IGNORE_MODULES = ["onnxruntime-web", "onnxruntime-common-for-web"];
 
 // Do not bundle the following modules with webpack (mark as external)
 // NOTE: This is necessary for both type="module" and type="commonjs",
 // and will be ignored when building for web (only used for node/deno)
 const NODE_EXTERNAL_MODULES = [
   "onnxruntime-node",
+  "onnxruntime-common-for-node",
   "sharp",
   "fs",
   "path",


### PR DESCRIPTION
Fixes #1087 

The correct version of Tensor from onnxruntime-common is also exported depending on environment (node, web).

Please note that the new overrides in package.json don't currently do anything in npm (it's bugged), but one day npm might actually use them.