### PR TITLE
Fix ghost dependency onnxruntime-common

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.3.2",
+        "onnxruntime-common": "1.20.1",
         "onnxruntime-node": "1.20.1",
         "onnxruntime-web": "1.21.0-dev.20241205-d27fecd3d3",
         "sharp": "^0.33.5"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/huggingface/transformers.js#readme",
   "dependencies": {
     "@huggingface/jinja": "^0.3.2",
+    "onnxruntime-common": "1.20.1",
     "onnxruntime-node": "1.20.1",
     "onnxruntime-web": "1.21.0-dev.20241205-d27fecd3d3",
     "sharp": "^0.33.5"


### PR DESCRIPTION
Fixes #1087 

A simpler alternative to #1088 that just adds one explicit dependency on onnxruntime-common to package.json.