### PR TITLE
fix: tps not initialized with 0, skip_special_tokens not exists in TextStreamer options

### DIFF
--- a/examples/webgpu-whisper/src/worker.js
+++ b/examples/webgpu-whisper/src/worker.js
@@ -58,7 +58,7 @@ async function generate({ audio, language }) {
     const callback_function = (output) => {
         startTime ??= performance.now();
 
-        let tps;
+        let tps = 0;
         if (numTokens++ > 0) {
             tps = numTokens / (performance.now() - startTime) * 1000;
         }
@@ -70,7 +70,9 @@ async function generate({ audio, language }) {
 
     const streamer = new TextStreamer(tokenizer, {
         skip_prompt: true,
-        skip_special_tokens: true,
+        decode_kwargs: {
+            skip_special_tokens: true,
+        },
         callback_function,
     });
 
@@ -100,6 +102,7 @@ async function load() {
     });
 
     // Load the pipeline and save it for future use.
+    // eslint-disable-next-line no-unused-vars
     const [tokenizer, processor, model] = await AutomaticSpeechRecognitionPipeline.getInstance(x => {
         // We also add a progress callback to the pipeline so that we can
         // track model loading.


### PR DESCRIPTION
## Summary

I realized several issues when trying to replicate the Whisper WebGPU example in my development environment:

- The event of `update` may contain `undefined` value for `tps`, and with the semantic of the code, tps is used to calculate the speed of outputting tokens, where it should be consistant as number since it works like metrics.
- According to [Transformers.js documentation](https://huggingface.co/docs/transformers.js/main/en/api/generation/streamers#new-textstreamertokenizer-options), instead, `skip_special_tokens` should be [`PreTrainedTokenizer.decode(...)`](https://huggingface.co/docs/transformers.js/main/en/api/tokenizers#pretrainedtokenizerdecodetokenids-decodeargs--code-string-code)'s option.

## Changes

- Initialize `tps` with `0`.
- Move `skip_special_tokens` into `decode_kwargs` as one of the property.
- Added `// eslint-disable-next-line no-unused-vars` comment to disable lint check for line `const [tokenizer, processor, model] = await AutomaticSpeechRecognitionPipeline.getInstance(x => {` or lint will fail.