### PR TITLE
style: incorrect background color for LanguageSelector in dark mode

### DIFF
--- a/examples/webgpu-whisper/src/components/LanguageSelector.jsx
+++ b/examples/webgpu-whisper/src/components/LanguageSelector.jsx
@@ -121,7 +121,7 @@ export function LanguageSelector({ language, setLanguage }) {
 
     return (
         <select
-            className="border rounded-lg p-2 max-w-[100px]"
+            className="border rounded-lg p-2 max-w-[100px] bg-transparent"
             value={language} onChange={handleLanguageChange}>
             {Object.keys(LANGUAGES).map((key, i) => (
                 <option key={key} value={key}>


### PR DESCRIPTION
## Summary

- The default background color of `<select>`will cause the `<select>` to be bad to see the texts in it which violates the best practice of minimum color contrast of texts in accessibilities guidelines.

## Changes

- Added `bg-transparent` to omit out the background for `<select>`.
- Auto format and added a space line for better EOF handling.

## Side by side screenshots of changes

| Color Mode | Before | After |
| --- | --- | --- |
| Day (white) | ![](https://github.com/user-attachments/assets/82e77774-088f-455e-8811-fd7bdcbda9d6) | ![](https://github.com/user-attachments/assets/c165d9b5-004a-409d-b8f6-085caa0972c1) | 
| Night (dark) | ![](https://github.com/user-attachments/assets/30ee0e50-ea4d-4b52-a21c-827d6373007b) | ![](https://github.com/user-attachments/assets/b4d9b6b2-c84e-4d68-8c61-e9513c8eb1b4) | 