### PR TITLE
fix: update WebGPU embedding benchmark to prefer `GPUAdapter.info` over `requestAdapterInfo`

### DIFF
--- a/examples/webgpu-embedding-benchmark/main.js
+++ b/examples/webgpu-embedding-benchmark/main.js
@@ -107,7 +107,7 @@ let gpuHasFp16 = false;
 try {
   // Shouldn't fail since the WebGPU model has loaded successfully
   const adapter = await navigator.gpu.requestAdapter();
-  adapterInfo = adapter.info;
+  adapterInfo = adapter.info || await adapter.requestAdapterInfo();
   gpuHasFp16 = adapter.features.has('shader-f16')
 } catch (err) {
   adapterInfo = {};


### PR DESCRIPTION
Migrates to use the new spec.-compliant way of getting adapter info in WebGPU (see also <https://github.com/microsoft/onnxruntime/pull/21065>).

This has been removed by both Chrome and Firefox, so there might be enough reason to simply stop using `requestAdapterInfo`, but I wasn't sure.