### PR TITLE
[WIP] Add Gaussian Blur to RawImage

### DIFF
--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -705,24 +705,28 @@ export class RawImage {
         const output = new Uint8ClampedArray(this.data.length);
         const halfSize = Math.floor(kernelSize / 2);
 
-        for (let c = 0; c < this.channels; c++) {
-            for (let y = 0; y < this.height; y++) {
-                for (let x = 0; x < this.width; x++) {
+        const height = this.height;
+        const width = this.width;
+        const channels = this.channels;
+
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                for (let c = 0; c < channels; c++) {
                     let sum = 0;
 
-                    for (let ky = -halfSize; ky < halfSize; ky++) {
-                        for (let kx = -halfSize; kx < halfSize; kx++) {
-                            const pixelX = Math.min(Math.max(x + kx, 0), this.width - 1);
-                            const pixelY = Math.min(Math.max(y + ky, 0), this.height - 1);
+                    for (let ky = -halfSize; ky <= halfSize; ky++) {
+                        for (let kx = -halfSize; kx <= halfSize; kx++) {
+                            const pixelX = Math.min(Math.max(x + kx, 0), width - 1);
+                            const pixelY = Math.min(Math.max(y + ky, 0), height - 1);
 
                             const kernelValue = kernel[ky + halfSize][kx + halfSize];
-                            const dataIndex = (pixelY * this.width + pixelX) * this.channels + c;
+                            const dataIndex = (((pixelY * width) + pixelX) * channels) + c;
 
                             sum += this.data[dataIndex] * kernelValue;
                         }
                     }
 
-                    const outputIndex = (y * this.width + x) * this.channels + c;
+                    const outputIndex = (((y * width) + x) * channels) + c;
                     output[outputIndex] = sum;
                 }
             }


### PR DESCRIPTION
A very slow, first draft of a Gaussian Blur for RawImage.  
The reason for this, is for models like U2Net where the input image size is 320x320, meaning that the resulting output needs to be resized, and can have sharp edges; blurring before resizing can smooth this out.

This is the code that I used to generate the images.
```js
const kernels = [5, 9, 17];
const sigmas = [2, 3, 5];
for (let i = 0; i < kernels.length; i++) {
    const kernel = kernels[i];
    const sigma = sigmas[i];
    image
        .gaussianBlur(kernel, sigma)
        then(image => image.save(`blurred-(${kernel}-${sigma}).png`));
}
```
Sigma should roughly be a third of kernel size (from what I found researching).  
Kernel must be odd, since we want an even square around the pixel.  
For example, if we had a 3x3 kernel grid, then when we place this on our pixel there is an even space all around that pixel (in this case 1 pixel).

Here is a demo of what this implementation currently looks like.

| Image | Kernel | Sigma |       Duration       |
|-------|--------|-------|----------------------|
| <img width="150" src="https://github.com/user-attachments/assets/9d42101f-5561-4cf9-b4eb-01aae1b03c8c" alt="The original image."> |  N/A   |  N/A  |         N/A          |
| <img width="150" src="https://github.com/user-attachments/assets/9bbe4a9c-6f9e-4b2f-8ba1-58686bce3f8f" alt="The image slightly more blurred than the original."> |    5   |   2   |            9 seconds |
| <img width="150" src="https://github.com/user-attachments/assets/f95afe32-cd23-4054-9ae8-4517a349c4c0" alt="The slightly more blurred image, slightly more blurred again."> |    9   |   3   |           31 seconds |
| <img width="150" src="https://github.com/user-attachments/assets/59e80e49-42b6-4bf5-81fe-bb3adf59d32c" alt="The final image that is blurred even more!"> |   17   |   5   | 1 minute, 42 seconds |

As you can see, this is _very_ slow, but I will continue to look into how to improve this significantly!