### PR TITLE
Remove unused imports from tokenizers.js

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -47,10 +47,8 @@ import {
 import { Template } from '@huggingface/jinja';
 
 import {
-    WHISPER_LANGUAGE_MAPPING,
-    whisper_language_to_code,
+    WHISPER_LANGUAGE_MAPPING
 } from './models/whisper/common_whisper.js';
-import { GITHUB_ISSUE_URL } from './utils/constants.js';
 
 /**
  * @typedef {Object} TokenizerProperties Additional tokenizer-specific properties.


### PR DESCRIPTION
Use of these imports was removed in 77ebe0d, this PR removes the unused imports. cc @xenova 