### PR TITLE
Minimal fixes for type declarations to resolve errors when importing transformers.js via typescript (partially resolves #1093)

### DIFF
--- a/src/base/feature_extraction_utils.js
+++ b/src/base/feature_extraction_utils.js
@@ -17,23 +17,23 @@ export class FeatureExtractor extends Callable {
     }
 
     /**
-     * Instantiate one of the processor classes of the library from a pretrained model.
+     * Instantiate one of the feature extractor classes of the library from a pretrained model.
      * 
-     * The processor class to instantiate is selected based on the `image_processor_type` (or `feature_extractor_type`; legacy)
-     * property of the config object (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
+     * The feature extractor class to instantiate is selected based on the `feature_extractor_type` property of
+     * the config object (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
      * 
      * @param {string} pretrained_model_name_or_path The name or path of the pretrained model. Can be either:
-     * - A string, the *model id* of a pretrained processor hosted inside a model repo on huggingface.co.
+     * - A string, the *model id* of a pretrained feature_extractor hosted inside a model repo on huggingface.co.
      *   Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
      *   user or organization name, like `dbmdz/bert-base-german-cased`.
-     * - A path to a *directory* containing processor files, e.g., `./my_model_directory/`.
-     * @param {import('../utils/hub.js').PretrainedOptions} options Additional options for loading the processor.
+     * - A path to a *directory* containing feature_extractor files, e.g., `./my_model_directory/`.
+     * @param {import('../utils/hub.js').PretrainedOptions} options Additional options for loading the feature_extractor.
      * 
-     * @returns {Promise<FeatureExtractor>} A new instance of the Processor class.
+     * @returns {Promise<FeatureExtractor>} A new instance of the Feature Extractor class.
      */
     static async from_pretrained(pretrained_model_name_or_path, options) {
-        const preprocessorConfig = await getModelJSON(pretrained_model_name_or_path, FEATURE_EXTRACTOR_NAME, true, options);
-        return new this(preprocessorConfig);
+        const config = await getModelJSON(pretrained_model_name_or_path, FEATURE_EXTRACTOR_NAME, true, options);
+        return new this(config);
     }
 }
 

--- a/src/base/processing_utils.js
+++ b/src/base/processing_utils.js
@@ -121,8 +121,8 @@ export class Processor extends Callable {
     /**
      * Instantiate one of the processor classes of the library from a pretrained model.
      * 
-     * The processor class to instantiate is selected based on the `feature_extractor_type` property of the config object
-     * (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
+     * The processor class to instantiate is selected based on the `image_processor_type` (or `feature_extractor_type`; legacy)
+     * property of the config object (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
      * 
      * @param {string} pretrained_model_name_or_path The name or path of the pretrained model. Can be either:
      * - A string, the *model id* of a pretrained processor hosted inside a model repo on huggingface.co.

--- a/src/base/processing_utils.js
+++ b/src/base/processing_utils.js
@@ -84,6 +84,11 @@ export class Processor extends Callable {
         });
     }
 
+    /**
+     * Calls the processor with the given input.
+     * @param {...any} args Additional arguments.
+     * @returns {any} The processed input.
+     */
     batch_decode(...args) {
         if (!this.tokenizer) {
             throw new Error('Unable to decode without a tokenizer.');

--- a/src/models/auto/feature_extraction_auto.js
+++ b/src/models/auto/feature_extraction_auto.js
@@ -6,22 +6,6 @@ import * as AllFeatureExtractors from '../feature_extractors.js';
 
 export class AutoFeatureExtractor {
 
-    /**
-     * Instantiate one of the feature extractor classes of the library from a pretrained model.
-     * 
-     * The processor class to instantiate is selected based on the `feature_extractor_type` property of
-     * the config object (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
-     * 
-     * @param {string} pretrained_model_name_or_path The name or path of the pretrained model. Can be either:
-     * - A string, the *model id* of a pretrained processor hosted inside a model repo on huggingface.co.
-     *   Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
-     *   user or organization name, like `dbmdz/bert-base-german-cased`.
-     * - A path to a *directory* containing processor files, e.g., `./my_model_directory/`.
-     * @param {import('../../utils/hub.js').PretrainedOptions} options Additional options for loading the processor.
-     * 
-     * @returns {Promise<AllFeatureExtractors.ImageProcessor>} A new instance of the Processor class.
-     */
-
     /** @type {typeof FeatureExtractor.from_pretrained} */
     static async from_pretrained(pretrained_model_name_or_path, options={}) {
 

--- a/src/models/auto/processing_auto.js
+++ b/src/models/auto/processing_auto.js
@@ -51,12 +51,11 @@ export class AutoProcessor {
      *   Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
      *   user or organization name, like `dbmdz/bert-base-german-cased`.
      * - A path to a *directory* containing processor files, e.g., `./my_model_directory/`.
-     * @param {import('../../utils/hub.js').PretrainedOptions} options Additional options for loading the processor.
+     * @param {import('../../base/processing_utils.js').PretrainedProcessorOptions} options Additional options for loading the processor.
      * 
      * @returns {Promise<Processor>} A new instance of the Processor class.
      */
 
-    /** @type {typeof Processor.from_pretrained} */
     static async from_pretrained(pretrained_model_name_or_path, options={}) {
 
         // TODO: first check for processor.json 

--- a/src/models/auto/processing_auto.js
+++ b/src/models/auto/processing_auto.js
@@ -40,22 +40,7 @@ import * as AllFeatureExtractors from '../feature_extractors.js';
  */
 export class AutoProcessor {
 
-    /**
-     * Instantiate one of the processor classes of the library from a pretrained model.
-     * 
-     * The processor class to instantiate is selected based on the `image_processor_type` (or `feature_extractor_type`; legacy)
-     * property of the config object (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
-     * 
-     * @param {string} pretrained_model_name_or_path The name or path of the pretrained model. Can be either:
-     * - A string, the *model id* of a pretrained processor hosted inside a model repo on huggingface.co.
-     *   Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
-     *   user or organization name, like `dbmdz/bert-base-german-cased`.
-     * - A path to a *directory* containing processor files, e.g., `./my_model_directory/`.
-     * @param {import('../../base/processing_utils.js').PretrainedProcessorOptions} options Additional options for loading the processor.
-     * 
-     * @returns {Promise<Processor>} A new instance of the Processor class.
-     */
-
+    /** @type {typeof Processor.from_pretrained} */
     static async from_pretrained(pretrained_model_name_or_path, options={}) {
 
         // TODO: first check for processor.json 

--- a/src/models/phi3_v/processing_phi3_v.js
+++ b/src/models/phi3_v/processing_phi3_v.js
@@ -14,7 +14,7 @@ export class Phi3VProcessor extends Processor {
      * 
      * @param {string|string[]} text 
      * @param {RawImage|RawImage[]} images 
-     * @param  {...any} args 
+     * @param  { { padding?: boolean, truncation?: boolean, num_crops?: number } | undefined } options
      * @returns {Promise<any>}
      */
     async _call(text, images = null, {

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1916,7 +1916,7 @@ export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (options
             const max_new_tokens = Math.floor(aud.length / sampling_rate) * 6;
             const outputs = await this.model.generate({ max_new_tokens, ...kwargs, ...inputs });
 
-            const text = this.processor.batch_decode(outputs, { skip_special_tokens: true })[0];
+            const text = this.processor.batch_decode(/** @type {Tensor} */(outputs), { skip_special_tokens: true })[0];
             toReturn.push({ text });
         }
         return single ? toReturn[0] : toReturn;


### PR DESCRIPTION
Hey; I hope the holiday season is treating you well.

As of 3.1.0, `transformers.js` will result in errors when importing it via typescript (see #1093). Some of these errors are due to limitations in how typescript interprets jsdoc type declarations, and some are architectural design issues with how subclasses extending from a parent class can have methods with differing call/return signatures. (See attached error log below).

I notice #1081 is still open - that PR would make errors like this more visible, but it's still yet to be merged, and that's fine (there's a lot of changes in there to review, so I understand the wait).

In the mean time, I've applied the minimum possible fix without resorting to `@ts-ignore` and without any changes to architecture/design to at least get transformers.js usable via typescript.

This only partially resolves #1093, because the other errors they report with HTML elements not being found are partially issues with their own typescript config - they should add "DOM" to "lib" in their tsconfig (or transfomers.js should provide duck typed shims for HTMLCanvasElement, etc. but this is out of scope of this minimal fix PR).

Thanks!

```
node_modules/@huggingface/transformers/types/models/auto/processing_auto.d.ts:32:76 - error TS2304: Cannot find name 'PretrainedProcessorOptions'.

32     static from_pretrained(pretrained_model_name_or_path: string, options: PretrainedProcessorOptions): Promise<Processor>;
                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@huggingface/transformers/types/models/mgp_str/processing_mgp_str.d.ts:52:5 - error TS2416: Property 'batch_decode' in type 'MgpstrProcessor' is not assignable to the same property in base type 'Processor'.
  Type '([char_logits, bpe_logits, wp_logits]: Tensor[]) => { generated_text: string[]; scores: number[]; char_preds: string[]; bpe_preds: string[]; wp_preds: string[]; }' is not assignable to type '(...args: any[]) => string[]'.
    Type '{ generated_text: string[]; scores: number[]; char_preds: string[]; bpe_preds: string[]; wp_preds: string[]; }' is missing the following properties from type 'string[]': length, pop, push, concat, and 35 more.

52     batch_decode([char_logits, bpe_logits, wp_logits]: import("../../utils/tensor.js").Tensor[]): {  
       ~~~~~~~~~~~~

node_modules/@huggingface/transformers/types/models/phi3_v/processing_phi3_v.d.ts:11:70 - error TS2339: 
Property 'padding' does not exist on type 'any[]'.

11     _call(text: string | string[], images?: RawImage | RawImage[], { padding, truncation, num_crops, 
}?: any[]): Promise<any>;
                                                                        ~~~~~~~

node_modules/@huggingface/transformers/types/models/phi3_v/processing_phi3_v.d.ts:11:79 - error TS2339: 
Property 'truncation' does not exist on type 'any[]'.

11     _call(text: string | string[], images?: RawImage | RawImage[], { padding, truncation, num_crops, 
}?: any[]): Promise<any>;
                                                                                 ~~~~~~~~~~

node_modules/@huggingface/transformers/types/models/phi3_v/processing_phi3_v.d.ts:11:91 - error TS2339: 
Property 'num_crops' does not exist on type 'any[]'.

11     _call(text: string | string[], images?: RawImage | RawImage[], { padding, truncation, num_crops, 
}?: any[]): Promise<any>;
                                                                                             ~~~~~~~~~  

[11:34:32 am] Found 5 errors. Watching for file changes.
```