### PR TITLE
Add the ONNX TensorRT execution provider and respective device.

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -38,6 +38,7 @@ const DEVICE_TO_EXECUTION_PROVIDER_MAPPING = Object.freeze({
     webgpu: 'webgpu', // WebGPU
     cuda: 'cuda', // CUDA
     dml: 'dml', // DirectML
+    tensorrt: 'tensorrt', // TensorRT
 
     webnn: { name: 'webnn', deviceType: 'cpu' }, // WebNN (default)
     'webnn-npu': { name: 'webnn', deviceType: 'npu' }, // WebNN NPU

--- a/src/utils/devices.js
+++ b/src/utils/devices.js
@@ -10,6 +10,7 @@ export const DEVICE_TYPES = Object.freeze({
     webgpu: 'webgpu', // WebGPU
     cuda: 'cuda', // CUDA
     dml: 'dml', // DirectML
+    tensorrt: 'tensorrt', // TensorRT
 
     webnn: 'webnn', // WebNN (default)
     'webnn-npu': 'webnn-npu', // WebNN NPU


### PR DESCRIPTION
ONNX has a TensorRT EP that is available for NodeJS along with the CUDA EP (under linux x64) when installing onnxruntime-node.
This commit makes it possible to use it by specifying 'tensorrt' as the device.