### PR TITLE
Auto-detect wordpiece tokenizer when model.type is missing

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -364,13 +364,15 @@ export class TokenizerModel extends Callable {
                 return new BPE(config);
 
             default:
-                // Some tokenizers, like for google-t5/t5-small, do not have a `type` field.
-                // In this case, we can infer the tokenizer type based on the structure of the `vocab` field.
+                // Some older tokenizers, like `google-t5/t5-small` and `distilbert/distilbert-base-uncased`, do not have a `type` field.
+                // In this case, we can infer the tokenizer type based on the structure of the `vocab` field and other properties.
                 if (config.vocab) {
                     if (Array.isArray(config.vocab)) {
                         // config.vocab is of type `[string, number][]`
                         // @ts-ignore
                         return new Unigram(config, ...args);
+                    } else if (typeof config.vocab === 'object' && config.continuing_subword_prefix && config.unk_token) {
+                        return new WordPieceTokenizer(config);
                     } else {
                         // @ts-ignore
                         return new LegacyTokenizerModel(config, ...args);

--- a/tests/models/bert/test_tokenization_bert.js
+++ b/tests/models/bert/test_tokenization_bert.js
@@ -1332,4 +1332,13 @@ export const TEST_CONFIG = {
       decoded: "[CLS] test $ 1 r2 # 3 [UNK] [UNK] [UNK] [UNK] [UNK] [UNK] test [SEP]",
     },
   },
+  // `model.type` field missing in tokenizer.json
+  "google-bert/bert-base-cased": {
+    CURRENCY: {
+      text: BERT_TEST_STRINGS.CHINESE_LATIN_MIXED,
+      tokens: ["ah", "[UNK]", "[UNK]", "z", "##z"],
+      ids: [101, 18257, 100, 100, 195, 1584, 102],
+      decoded: "[CLS] ah [UNK] [UNK] zz [SEP]",
+    },
+  },
 };

--- a/tests/models/bert/test_tokenization_bert.js
+++ b/tests/models/bert/test_tokenization_bert.js
@@ -1334,7 +1334,7 @@ export const TEST_CONFIG = {
   },
   // `model.type` field missing in tokenizer.json
   "google-bert/bert-base-cased": {
-    CURRENCY: {
+    CHINESE_LATIN_MIXED: {
       text: BERT_TEST_STRINGS.CHINESE_LATIN_MIXED,
       tokens: ["ah", "[UNK]", "[UNK]", "z", "##z"],
       ids: [101, 18257, 100, 100, 195, 1584, 102],

--- a/tests/models/distilbert/test_tokenization_distilbert.js
+++ b/tests/models/distilbert/test_tokenization_distilbert.js
@@ -305,7 +305,7 @@ export const TEST_CONFIG = {
   },
   // `model.type` field missing in tokenizer.json
   "distilbert/distilbert-base-multilingual-cased": {
-    CURRENCY: {
+    CHINESE_LATIN_MIXED: {
       text: BERT_TEST_STRINGS.CHINESE_LATIN_MIXED,
       tokens: ["ah", "\u535a", "\u63a8", "z", "##z"],
       ids: [101, 69863, 2684, 4163, 194, 10305, 102],

--- a/tests/models/distilbert/test_tokenization_distilbert.js
+++ b/tests/models/distilbert/test_tokenization_distilbert.js
@@ -1,5 +1,5 @@
 import { DistilBertTokenizer } from "../../../src/tokenizers.js";
-import { BASE_TEST_STRINGS } from "../test_strings.js";
+import { BASE_TEST_STRINGS, BERT_TEST_STRINGS } from "../test_strings.js";
 
 export const TOKENIZER_CLASS = DistilBertTokenizer;
 export const TEST_CONFIG = {
@@ -301,6 +301,15 @@ export const TEST_CONFIG = {
       tokens: ["wei", "##rd", "\uff5e", "edge", "\uff5e", "case"],
       ids: [101, 86981, 12023, 10096, 30599, 10096, 13474, 102],
       decoded: "[CLS] weird \uff5e edge \uff5e case [SEP]",
+    },
+  },
+  // `model.type` field missing in tokenizer.json
+  "distilbert/distilbert-base-multilingual-cased": {
+    CURRENCY: {
+      text: BERT_TEST_STRINGS.CHINESE_LATIN_MIXED,
+      tokens: ["ah", "\u535a", "\u63a8", "z", "##z"],
+      ids: [101, 69863, 2684, 4163, 194, 10305, 102],
+      decoded: "[CLS] ah \u535a \u63a8 zz [SEP]",
     },
   },
 };


### PR DESCRIPTION
Some old wordpiece tokenizers do not have `model.type` saved inside tokenizer.json. This PR adds logic to auto-detect when this is the case. Thanks to @pcuenca for finding this! 🤗