### PR TITLE
fix package export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@huggingface/jinja": "^0.3.2",
         "onnxruntime-node": "1.20.1",
-        "onnxruntime-web": "1.21.0-dev.20250114-228dd16893",
+        "onnxruntime-web": "1.21.0-dev.20250129-80bc1d25f0",
         "sharp": "^0.33.5"
       },
       "devDependencies": {
@@ -8782,9 +8782,9 @@
       }
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.21.0-dev.20250114-228dd16893",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.0-dev.20250114-228dd16893.tgz",
-      "integrity": "sha512-fUnedxS63NYwNkQJlvdD55jVcOtyM+Qzw1SGt9Pj3jZVaIwR4mltx/5C0yvwdue44BTSV7M5Q0qnhL6/30ewqA==",
+      "version": "1.21.0-dev.20250129-80bc1d25f0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.0-dev.20250129-80bc1d25f0.tgz",
+      "integrity": "sha512-+xw53OJARUpqxoDDEVyGqrx3kFudSdveGLObSG4S4I7EarpmdlOwYUei3KW3MUjm4gOPJGAlI6KS8+NpIDPMPA==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@huggingface/transformers",
-  "version": "3.4.0",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@huggingface/transformers",
-      "version": "3.4.0",
+      "version": "3.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@huggingface/transformers",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@huggingface/transformers",
-      "version": "3.3.3",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/jinja": "^0.3.3",
         "onnxruntime-node": "1.20.1",
-        "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3",
+        "onnxruntime-web": "1.22.0-dev.20250306-aafa8d170a",
         "sharp": "^0.33.5"
       },
       "devDependencies": {
@@ -8783,23 +8783,23 @@
       }
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.21.0-dev.20250206-d981b153d3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.0-dev.20250206-d981b153d3.tgz",
-      "integrity": "sha512-esDVQdRic6J44VBMFLumYvcGfioMh80ceLmzF1yheJyuLKq/Th8VT2aj42XWQst+2bcWnAhw4IKmRQaqzU8ugg==",
+      "version": "1.22.0-dev.20250306-aafa8d170a",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250306-aafa8d170a.tgz",
+      "integrity": "sha512-g72WvR1IZFVZQe3fp7K4lk5Ka6zEnMkAVc1jpLK5TIzTc2anOIEYzGTjG2t0cM+BRKN2wxSS20zWtYOL+h5C6Q==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.21.0-dev.20250206-d981b153d3",
+        "onnxruntime-common": "1.22.0-dev.20250306-aafa8d170a",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }
     },
     "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.21.0-dev.20250206-d981b153d3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0-dev.20250206-d981b153d3.tgz",
-      "integrity": "sha512-TwaE51xV9q2y8pM61q73rbywJnusw9ivTEHAJ39GVWNZqxCoDBpe/tQkh/w9S+o/g+zS7YeeL0I/2mEWd+dgyA==",
+      "version": "1.22.0-dev.20250306-aafa8d170a",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250306-aafa8d170a.tgz",
+      "integrity": "sha512-NfIQnW4lIk/8LnhnYqknYPeet0U0+AADgKQRlKex36QrNoVSCY+aNaX6wyy2VzQ4CNWxsYh0E203ajRD/zxn0g==",
       "license": "MIT"
     },
     "node_modules/open": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "node": {
       "import": {
         "types": "./types/transformers.d.ts",
-        "default": "./dist/transformers.mjs"
+        "default": "./dist/transformers.node.mjs"
       },
       "require": {
         "types": "./types/transformers.d.ts",
-        "default": "./dist/transformers.cjs"
+        "default": "./dist/transformers.node.cjs"
       }
     },
     "default": {
       "types": "./types/transformers.d.ts",
-      "default": "./dist/transformers.js"
+      "default": "./dist/transformers.web.js"
     }
   },
   "scripts": {
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/jinja": "^0.3.2",
     "onnxruntime-node": "1.20.1",
-    "onnxruntime-web": "1.21.0-dev.20250114-228dd16893",
+    "onnxruntime-web": "1.21.0-dev.20250129-80bc1d25f0",
     "sharp": "^0.33.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huggingface/transformers",
-  "version": "3.4.0",
+  "version": "3.3.3",
   "description": "State-of-the-art Machine Learning for the web. Run 🤗 Transformers directly in your browser, with no need for a server!",
   "main": "./src/transformers.js",
   "types": "./types/transformers.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huggingface/transformers",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "State-of-the-art Machine Learning for the web. Run 🤗 Transformers directly in your browser, with no need for a server!",
   "main": "./src/transformers.js",
   "types": "./types/transformers.d.ts",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/jinja": "^0.3.3",
     "onnxruntime-node": "1.20.1",
-    "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3",
+    "onnxruntime-web": "1.22.0-dev.20250306-aafa8d170a",
     "sharp": "^0.33.5"
   },
   "devDependencies": {

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -57,8 +57,8 @@ let ONNX;
 const ORT_SYMBOL = Symbol.for('onnxruntime');
 
 if (ORT_SYMBOL in globalThis) {
-  // If the JS runtime exposes their own ONNX runtime, use it
-  ONNX = globalThis[ORT_SYMBOL];
+    // If the JS runtime exposes their own ONNX runtime, use it
+    ONNX = globalThis[ORT_SYMBOL];
 
 } else if (apis.IS_NODE_ENV) {
     ONNX = ONNX_NODE.default ?? ONNX_NODE;
@@ -175,11 +175,20 @@ const ONNX_ENV = ONNX?.env;
 if (ONNX_ENV?.wasm) {
     // Initialize wasm backend with suitable default settings.
 
-    // (Optional) Set path to wasm files. This is needed when running in a web worker.
-    // https://onnxruntime.ai/docs/api/js/interfaces/Env.WebAssemblyFlags.html#wasmPaths
-    // We use remote wasm files by default to make it easier for newer users.
-    // In practice, users should probably self-host the necessary .wasm files.
-    ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/@huggingface/transformers@${env.version}/dist/`;
+    // (Optional) Set path to wasm files. This will override the default path search behavior of onnxruntime-web.
+    // Currently, this behavior is disabled. To enable it, uncomment the following code.
+
+    // // Override the wasm search path if:
+    // // 1. We are not in a service worker.
+    // // 2. ONNX Runtime Web version is defined.
+    // // 3. The wasmPaths are not already set.
+    // //
+    // // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
+    // if (!(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
+    //     && typeof ONNX?.versions?.web === 'string'
+    //     && !ONNX_ENV.wasm.wasmPaths) {
+    //     ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX.versions.web}/dist/`;
+    // }
 
     // TODO: Add support for loading WASM files from cached buffer when we upgrade to onnxruntime-web@1.19.0
     // https://github.com/microsoft/onnxruntime/pull/21534
@@ -187,11 +196,6 @@ if (ONNX_ENV?.wasm) {
     // Users may wish to proxy the WASM backend to prevent the UI from freezing,
     // However, this is not necessary when using WebGPU, so we default to false.
     ONNX_ENV.wasm.proxy = false;
-
-    // https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated
-    if (typeof crossOriginIsolated === 'undefined' || !crossOriginIsolated) {
-        ONNX_ENV.wasm.numThreads = 1;
-    }
 }
 
 if (ONNX_ENV?.webgpu) {

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -176,19 +176,18 @@ if (ONNX_ENV?.wasm) {
     // Initialize wasm backend with suitable default settings.
 
     // (Optional) Set path to wasm files. This will override the default path search behavior of onnxruntime-web.
-    // Currently, this behavior is disabled. To enable it, uncomment the following code.
 
-    // // Override the wasm search path if:
-    // // 1. We are not in a service worker.
-    // // 2. ONNX Runtime Web version is defined.
-    // // 3. The wasmPaths are not already set.
-    // //
-    // // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
-    // if (!(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
-    //     && typeof ONNX?.versions?.web === 'string'
-    //     && !ONNX_ENV.wasm.wasmPaths) {
-    //     ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX.versions.web}/dist/`;
-    // }
+    // Override the wasm search path if:
+    // 1. We are not in a service worker.
+    // 2. ONNX Runtime Web version is defined.
+    // 3. The wasmPaths are not already set.
+    //
+    // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
+    if (!(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
+        && typeof ONNX?.versions?.web === 'string'
+        && !ONNX_ENV.wasm.wasmPaths) {
+        ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX.versions.web}/dist/`;
+    }
 
     // TODO: Add support for loading WASM files from cached buffer when we upgrade to onnxruntime-web@1.19.0
     // https://github.com/microsoft/onnxruntime/pull/21534

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -176,17 +176,13 @@ if (ONNX_ENV?.wasm) {
     // Initialize wasm backend with suitable default settings.
 
     // (Optional) Set path to wasm files. This will override the default path search behavior of onnxruntime-web.
-
-    // Override the wasm search path if:
-    // 1. We are not in a service worker.
-    // 2. ONNX Runtime Web version is defined.
-    // 3. The wasmPaths are not already set.
-    //
-    // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
-    if (!(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
-        && typeof ONNX?.versions?.web === 'string'
-        && !ONNX_ENV.wasm.wasmPaths) {
-        ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX.versions.web}/dist/`;
+    // By default, we only do this if we are not in a service worker and the wasmPaths are not already set.
+    if (
+        // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
+        !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
+        && !ONNX_ENV.wasm.wasmPaths
+    ) {
+        ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/@huggingface/transformers@${env.version}/dist/`;
     }
 
     // TODO: Add support for loading WASM files from cached buffer when we upgrade to onnxruntime-web@1.19.0


### PR DESCRIPTION
### Summary

This PR includes a few changes that helps to fix the package export. Now transformers.js has the following exports:

| usage | file | description |
|------|------|-------------|
|   CDN <br/> `import {...} from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@{version}"`  |    `dist/transformers[.min].js`  | This is a JavaScript file that bundled with all its JS dependencies. |
|   Node.js/Deno (ESM/CJS) <br/> `import {...} from "@huggingface/transformers"` <br/> `const {...} = require("@huggingface/transformers")` |    `dist/transformers.node[.min].mjs` <br/> `dist/transformers.node[.min].cjs` |  Treat `onnxruntime-common` and `onnxruntime-node` as external; Ignore `onnxruntime-web`     |
| Web (ESM) <br/> `import {...} from "@huggingface/transformers"` | `dist/transformers.web[.min].js` | Treat `onnxruntime-common` and `onnxruntime-web` as external; Ignore `onnxruntime-node` |


### Problem

There are complains about different kinds of failures when users try to import transformers.js and/or onnxruntime-web in their web applications.

It took me quite a while to fix most of the problems in onnxruntime-web. The latest dev version of onnxruntime-web should have worked for all known major use cases.

When things come to transformers.js, the situation become more complicated. After some investigation, I found that some import/export problems that resolved in onnxruntime-web occurred in transformers.js again. This is because when building transformers.js, webpack generated some code that will not work for using as input for bundler again.

### Solution

There are 2 major changes in this PR:
- remove the override of `env.wasm.wasmPaths`
- make `onnxruntime-web` as external dependency of transformers.js

#### Why treat `onnxruntime-web` as external dependency

ONNX Runtime Web has a few workarounds for webpack to ensure out-of-the-box user experience. Those workarounds requires the code as-is when webpack starts to process it. The workarounds cannot keep in the bundled JS file.

To make sure of backward compatibility, this change still keeps the file `dist/transformers[.min].js` unchanged. Instead, a new file `dist/transformers.web[.min].js` is added and replaced in the "exports" property of the package.json.

### Tests

The following tests are passed when applying this PR:

- [x] CDN
      https://github.com/huggingface/transformers.js-examples/tree/migrate-examples/segment-anything-webgpu
- [x] Next.js (Server, onnxruntime-node)
      https://github.com/huggingface/transformers.js-examples/tree/migrate-examples/next-server
      * some issue with the "standalone" mode but not related to package export.
      * need workaround for Nextjs. See [1] below
- [x] Next.js (Client, onnxruntime-web)
      * need workaround for Nextjs. See [1] below
- [x] Vite
      https://github.com/huggingface/transformers.js-examples/tree/migrate-examples/remove-background-webgpu
      * need workaround for Vite. See [2] below
- [x] Vite + worker
      https://github.com/huggingface/transformers.js-examples/tree/migrate-examples/phi-3.5-webgpu
      * need workaround for Vite. See [2] below
- [x] Service worker
      https://github.com/microsoft/onnxruntime/pull/20991

** [1] - For Next.js based app, a [workaround](https://github.com/huggingface/transformers.js-examples/blob/a48196ab77182b4c0e221eb0eb4fd4f19e545111/next-server/next.config.mjs#L3-L4) is needed if any code statically imports `@huggingface/transformers`. This is because Next.js tries to bundle the code for server even if those code starts with `"use client";`. This happens to both dev mode and prod mode, and to both default and turbopack bundler.
** [2] - For Vite 5.x based app, a [workaround](https://github.com/microsoft/onnxruntime/blob/41a49617523b2d5cd40552fc2fde507c111c9a66/js/web/test/e2e/exports/testcases/vite-default/vite.config.js#L6-L11) is needed according to https://github.com/vitejs/vite/issues/8427. This is a known issue affecting all Vite app depending on WebAssembly based packages, and may be fixed in Vite 6.x