### PR TITLE
refactor: deprecate onnx.env.webgpu.powerPreference

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -152,7 +152,12 @@ export async function createInferenceSession(buffer, session_options, session_co
         // so we wait for it to resolve before creating this new session.
         await wasmInitPromise;
     }
-
+    if (ONNX_ENV?.webgpu) {
+        const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })
+        if (adapter) {
+            ONNX_ENV.webgpu.device = await adapter.requestDevice();
+        }
+    }
     const sessionPromise = InferenceSession.create(buffer, session_options);
     wasmInitPromise ??= sessionPromise;
     const session = await sessionPromise;
@@ -192,10 +197,6 @@ if (ONNX_ENV?.wasm) {
     if (typeof crossOriginIsolated === 'undefined' || !crossOriginIsolated) {
         ONNX_ENV.wasm.numThreads = 1;
     }
-}
-
-if (ONNX_ENV?.webgpu) {
-    ONNX_ENV.webgpu.powerPreference = 'high-performance';
 }
 
 /**


### PR DESCRIPTION
Onnxruntime-web deprecated `powerPreference` in WebGPUFlag.

Instead, they suggested
> Create your own GPUAdapter, use it to create a GPUDevice instance and set [device](https://onnxruntime.ai/docs/api/js/interfaces/Env.WebGpuFlags.html#device) property if you want to use a specific power preference.

Reference:
https://onnxruntime.ai/docs/api/js/interfaces/Env.WebGpuFlags.html#powerPreference:~:text=Create%20your%20own%20GPUAdapter%2C%20use%20it%20to%20create%20a%20GPUDevice%20instance%20and%20set%20device%20property%20if%20you%20want%20to%20use%20a%20specific%20power%20preference.