### PR TITLE
fix extension example with 3.4.0

### DIFF
--- a/examples/extension/package.json
+++ b/examples/extension/package.json
@@ -15,6 +15,6 @@
     "webpack": "^5.79.0"
   },
   "dependencies": {
-    "@xenova/transformers": "^2.0.0"
+    "@huggingface/transformers": "^3.4.0"
   }
 }

--- a/examples/extension/src/background.js
+++ b/examples/extension/src/background.js
@@ -1,6 +1,6 @@
 // background.js - Handles requests from the UI, runs the model, then sends back a response
 
-import { pipeline, env } from '@xenova/transformers';
+import { pipeline, env } from '@huggingface/transformers';
 
 // Skip initial check for local models, since we are not loading any local models.
 env.allowLocalModels = false;

--- a/examples/extension/src/background.js
+++ b/examples/extension/src/background.js
@@ -1,6 +1,6 @@
 // background.js - Handles requests from the UI, runs the model, then sends back a response
 
-import { pipeline, env } from '@huggingface/transformers';
+import { pipeline } from '@huggingface/transformers';
 
 class PipelineSingleton {
     static task = 'text-classification';

--- a/examples/extension/src/background.js
+++ b/examples/extension/src/background.js
@@ -2,23 +2,13 @@
 
 import { pipeline, env } from '@huggingface/transformers';
 
-// Skip initial check for local models, since we are not loading any local models.
-env.allowLocalModels = false;
-
-// Due to a bug in onnxruntime-web, we must disable multithreading for now.
-// See https://github.com/microsoft/onnxruntime/issues/14445 for more information.
-env.backends.onnx.wasm.numThreads = 1;
-
-
 class PipelineSingleton {
     static task = 'text-classification';
     static model = 'Xenova/distilbert-base-uncased-finetuned-sst-2-english';
     static instance = null;
 
     static async getInstance(progress_callback = null) {
-        if (this.instance === null) {
-            this.instance = pipeline(this.task, this.model, { progress_callback });
-        }
+        this.instance ??= pipeline(this.task, this.model, { progress_callback });
 
         return this.instance;
     }

--- a/examples/extension/webpack.config.js
+++ b/examples/extension/webpack.config.js
@@ -11,7 +11,10 @@ const config = {
     mode: 'development',
     devtool: 'inline-source-map',
     entry: {
-        background: './src/background.js',
+        background: {
+            import: './src/background.js',
+            chunkLoading: `import-scripts`,
+        },
         popup: './src/popup.js',
         content: './src/content.js',
     },


### PR DESCRIPTION
This fixes the extension example.

The code does not work yet, because it depends on transformerjs v3.4.0, which is not released yet. It needs #1161 to work.