### PR TITLE
customize the wasm paths

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -180,9 +180,16 @@ if (ONNX_ENV?.wasm) {
     if (
         // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
         !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
+        && !env.backends.onnx.versions?.web
         && !ONNX_ENV.wasm.wasmPaths
     ) {
-        ONNX_ENV.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/@huggingface/transformers@${env.version}/dist/`;
+        const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${env.backends.onnx.versions.web}/dist/`;
+
+        ONNX_ENV.wasm.wasmPaths = environmentIsSafari ? {
+            "mjs": `${wasmPathPrefix}/ort-wasm-simd-threaded.mjs`,
+            "wasm": `${wasmPathPrefix}/ort-wasm-simd-threaded.wasm`,
+        }
+            : wasmPathPrefix;
     }
 
     // TODO: Add support for loading WASM files from cached buffer when we upgrade to onnxruntime-web@1.19.0

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -180,12 +180,12 @@ if (ONNX_ENV?.wasm) {
     if (
         // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
         !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope)
-        && !env.backends.onnx.versions?.web
+        && env.backends.onnx.versions?.web
         && !ONNX_ENV.wasm.wasmPaths
     ) {
         const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${env.backends.onnx.versions.web}/dist/`;
 
-        ONNX_ENV.wasm.wasmPaths = environmentIsSafari ? {
+        ONNX_ENV.wasm.wasmPaths = apis.IS_SAFARI ? {
             "mjs": `${wasmPathPrefix}/ort-wasm-simd-threaded.mjs`,
             "wasm": `${wasmPathPrefix}/ort-wasm-simd-threaded.wasm`,
         }

--- a/src/env.js
+++ b/src/env.js
@@ -30,10 +30,38 @@ const VERSION = '3.4.0';
 
 // Check if various APIs are available (depends on environment)
 const IS_BROWSER_ENV = typeof window !== "undefined" && typeof window.document !== "undefined";
-const IS_WEBWORKER_ENV = typeof self !== "undefined"  && self.constructor?.name === 'DedicatedWorkerGlobalScope';
+const IS_WEBWORKER_ENV = typeof self !== "undefined" && self.constructor?.name === 'DedicatedWorkerGlobalScope';
 const IS_WEB_CACHE_AVAILABLE = typeof self !== "undefined" && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;
+
+/**
+ * Check if the current environment is Safari browser.
+ * Works in both browser and web worker contexts.
+ * @returns {boolean} Whether the current environment is Safari.
+ */
+const isSafari = () => {
+    // Check if we're in a browser environment
+    if (typeof navigator === 'undefined') {
+        return false;
+    }
+
+    const userAgent = navigator.userAgent;
+    const vendor = navigator.vendor || '';
+
+    // Safari has "Apple" in vendor string
+    const isAppleVendor = vendor.indexOf('Apple') > -1;
+
+    // Exclude Chrome on iOS (CriOS), Firefox on iOS (FxiOS), 
+    // Edge on iOS (EdgiOS), and other browsers
+    const notOtherBrowser =
+        !userAgent.match(/CriOS|FxiOS|EdgiOS|OPiOS|mercury|brave/i) &&
+        !userAgent.includes('Chrome') &&
+        !userAgent.includes('Android');
+
+    return isAppleVendor && notOtherBrowser;
+};
+const IS_SAFARI = isSafari();
 
 const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
 const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
@@ -58,6 +86,9 @@ export const apis = Object.freeze({
 
     /** Whether the WebNN API is available */
     IS_WEBNN_AVAILABLE,
+
+    /** Whether we are running in a Safari browser */
+    IS_SAFARI,
 
     /** Whether the Node.js process API is available */
     IS_PROCESS_AVAILABLE,


### PR DESCRIPTION
This PR updates the logics to have a better customized `wasmPaths` setting. Specifically, the following changes were made:

- (Safari) Fallback to non ASYNCIFY build of webassembly, because of an OOM issue: #1242 
  - This fallback does not affect any existing feature, because WebGPU is not available on Safari yet anyway

- Because of the fallback feature, we need to access file ort-wasm-simd-threaded.mjs and ort-wasm-simd-threaded.wasm, which is not in package `@huggingface/transformers`. point to `onnxruntime-web`.

- only apply override to `wasmPaths` when `env.backends.onnx.versions.web` exists. The only situation that it does not exist is the nodejs build.

The feature need to be well tested.