### PR TITLE
[audio utils] fix fft_bin_width computation

### DIFF
--- a/src/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.js
+++ b/src/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.js
@@ -10,7 +10,7 @@ export class ASTFeatureExtractor extends FeatureExtractor {
 
         const sampling_rate = this.config.sampling_rate;
         const mel_filters = mel_filter_bank(
-            256, // num_frequency_bins
+            257, // num_frequency_bins
             this.config.num_mel_bins, // num_mel_filters
             20, // min_frequency
             Math.floor(sampling_rate / 2), // max_frequency
@@ -19,11 +19,6 @@ export class ASTFeatureExtractor extends FeatureExtractor {
             "kaldi", // mel_scale
             true, // triangularize_in_mel_space
         );
-
-        // Do padding:
-        for (let i = 0; i < mel_filters.length; ++i) {
-            mel_filters[i].push(0);
-        }
         this.mel_filters = mel_filters;
 
         this.window = window_function(400, 'hann', {

--- a/src/models/seamless_m4t/feature_extraction_seamless_m4t.js
+++ b/src/models/seamless_m4t/feature_extraction_seamless_m4t.js
@@ -9,7 +9,7 @@ export class SeamlessM4TFeatureExtractor extends FeatureExtractor {
 
         const sampling_rate = this.config.sampling_rate;
         const mel_filters = mel_filter_bank(
-            256, // num_frequency_bins
+            257, // num_frequency_bins
             this.config.num_mel_bins, // num_mel_filters
             20, // min_frequency
             Math.floor(sampling_rate / 2), // max_frequency
@@ -18,11 +18,6 @@ export class SeamlessM4TFeatureExtractor extends FeatureExtractor {
             "kaldi", // mel_scale
             true, // triangularize_in_mel_space
         );
-
-        // Do padding:
-        for (let i = 0; i < mel_filters.length; ++i) {
-            mel_filters[i].push(0);
-        }
         this.mel_filters = mel_filters;
 
         this.window = window_function(400, 'povey', {

--- a/src/models/wespeaker/feature_extraction_wespeaker.js
+++ b/src/models/wespeaker/feature_extraction_wespeaker.js
@@ -10,7 +10,7 @@ export class WeSpeakerFeatureExtractor extends FeatureExtractor {
 
         const sampling_rate = this.config.sampling_rate;
         const mel_filters = mel_filter_bank(
-            256, // num_frequency_bins
+            257, // num_frequency_bins
             this.config.num_mel_bins, // num_mel_filters
             20, // min_frequency
             Math.floor(sampling_rate / 2), // max_frequency
@@ -19,11 +19,6 @@ export class WeSpeakerFeatureExtractor extends FeatureExtractor {
             "kaldi", // mel_scale
             true, // triangularize_in_mel_space
         );
-
-        // Do padding:
-        for (let i = 0; i < mel_filters.length; ++i) {
-            mel_filters[i].push(0);
-        }
         this.mel_filters = mel_filters;
 
         this.window = window_function(400, 'hamming', {


### PR DESCRIPTION
Copied from https://github.com/huggingface/transformers/pull/36603:

> When computing triangular mel filter matrices and when we triangularize in mel space, if we have e.g. `num_frequency_bins` being 257, meaning real-valued fft as been computed on 512 points (`257 = n_fft // 2 + 1`), then the `fft_bin_width` should be `(sampling rate / 2) / number_of_bins` with `number_of_bins = num_frequency_bins - 1`.
> 
> This was very likely introduced and not seen by tests for the reason that `mel_filter_bank` was called with, following the above example, `num_frequency_bins = 256` when using `triangularize_in_mel_space=True` then padded with 0s to retrieve the correct expected shape (257), **which is a bad practice and misleading for the user as we do not respect the method API!**
> 
> I also updated the expected outputs with the one I got from running torchaudio kaldi implementation, confirming our implem was incorrect.

Thanks @eustlb for the original fix!