### PR TITLE
Support device-level configuration across all devices

### DIFF
--- a/src/configs.js
+++ b/src/configs.js
@@ -1,4 +1,3 @@
-
 /**
  * @file Helper module for using model configs. For more information, see the corresponding
  * [Python documentation](https://huggingface.co/docs/transformers/main/en/model_doc/auto#transformers.AutoConfig).
@@ -405,10 +404,10 @@ export class AutoConfig {
  * Transformers.js-specific configuration, possibly present in config.json under the key `transformers.js_config`.
  * @typedef {Object} TransformersJSConfig
  * @property {import('./utils/tensor.js').DataType|Record<import('./utils/dtypes.js').DataType, import('./utils/tensor.js').DataType>} [kv_cache_dtype] The data type of the key-value cache.
- * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
- * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
- * for more information.
  * @property {import('./utils/devices.js').DeviceType} [device] The default device to use for the model.
  * @property {import('./utils/dtypes.js').DataType|Record<string, import('./utils/dtypes.js').DataType>} [dtype] The default data type to use for the model.
  * @property {import('./utils/hub.js').ExternalData|Record<string, import('./utils/hub.js').ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).
+ * @property {{ free_dimension_overrides?: Record<string, number> }} [webnn] WebNN-specific configuration, override the free dimensions of the model.
+ * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
+ * for more information.
  */

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,3 +1,4 @@
+
 /**
  * @file Helper module for using model configs. For more information, see the corresponding
  * [Python documentation](https://huggingface.co/docs/transformers/main/en/model_doc/auto#transformers.AutoConfig).

--- a/src/configs.js
+++ b/src/configs.js
@@ -415,11 +415,5 @@ export class AutoConfig {
 
 /**
  * Device-specific configuration options.
- * @typedef {Object} DeviceConfig
- * @property {import('./utils/tensor.js').DataType|Record<import('./utils/dtypes.js').DataType, import('./utils/tensor.js').DataType>} [kv_cache_dtype] The data type of the key-value cache.
- * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
- * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
- * for more information.
- * @property {import('./utils/dtypes.js').DataType|Record<string, import('./utils/dtypes.js').DataType>} [dtype] The default data type to use for the model.
- * @property {import('./utils/hub.js').ExternalData|Record<string, import('./utils/hub.js').ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).
+ * @typedef {Omit<TransformersJSConfig, "device" | "device_config">} DeviceConfig
  */

--- a/src/configs.js
+++ b/src/configs.js
@@ -403,11 +403,23 @@ export class AutoConfig {
 /**
  * Transformers.js-specific configuration, possibly present in config.json under the key `transformers.js_config`.
  * @typedef {Object} TransformersJSConfig
+ * @property {Record<import('./utils/devices.js').DeviceType, DeviceConfig>} [device_config] Device-specific configurations.
  * @property {import('./utils/tensor.js').DataType|Record<import('./utils/dtypes.js').DataType, import('./utils/tensor.js').DataType>} [kv_cache_dtype] The data type of the key-value cache.
+ * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
+ * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
+ * for more information.
  * @property {import('./utils/devices.js').DeviceType} [device] The default device to use for the model.
  * @property {import('./utils/dtypes.js').DataType|Record<string, import('./utils/dtypes.js').DataType>} [dtype] The default data type to use for the model.
  * @property {import('./utils/hub.js').ExternalData|Record<string, import('./utils/hub.js').ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).
- * @property {{ free_dimension_overrides?: Record<string, number> }} [webnn] WebNN-specific configuration, override the free dimensions of the model.
+ */
+
+/**
+ * Device-specific configuration options.
+ * @typedef {Object} DeviceConfig
+ * @property {import('./utils/tensor.js').DataType|Record<import('./utils/dtypes.js').DataType, import('./utils/tensor.js').DataType>} [kv_cache_dtype] The data type of the key-value cache.
+ * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
  * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
  * for more information.
+ * @property {import('./utils/dtypes.js').DataType|Record<string, import('./utils/dtypes.js').DataType>} [dtype] The default data type to use for the model.
+ * @property {import('./utils/hub.js').ExternalData|Record<string, import('./utils/hub.js').ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).
  */

--- a/src/models.js
+++ b/src/models.js
@@ -238,14 +238,16 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
     session_options.executionProviders ??= executionProviders;
 
     // Overwrite `freeDimensionOverrides` if specified in config and not set in session options
-    const free_dimension_overrides = custom_config.free_dimension_overrides;
-    if (free_dimension_overrides) {
-        session_options.freeDimensionOverrides ??= free_dimension_overrides;
-    } else if (selectedDevice.startsWith('webnn') && !session_options.freeDimensionOverrides) {
-        console.warn(
-            'WebNN does not currently support dynamic shapes and requires `free_dimension_overrides` to be set in config.json as a field within "transformers.js_config". ' +
-            'When `free_dimension_overrides` is not set, you may experience significant performance degradation.'
-        );
+    if (selectedDevice.startsWith('webnn')) {
+        const free_dimension_overrides = custom_config.webnn?.['free_dimension_overrides'] ?? {};
+        if (free_dimension_overrides) {
+            session_options.freeDimensionOverrides ??= free_dimension_overrides;
+        } else if (!session_options.freeDimensionOverrides) {
+            console.warn(
+                'WebNN does not currently support dynamic shapes and requires `free_dimension_overrides` to be set in config.json as a field within "transformers.js_config.webnn". ' +
+                'When `free_dimension_overrides` is not set, you may experience significant performance degradation.'
+            );
+        }
     }
 
     const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, apis.IS_NODE_ENV);

--- a/src/models.js
+++ b/src/models.js
@@ -249,6 +249,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
     // Overwrite `executionProviders` if not specified
     session_options.executionProviders ??= executionProviders;
 
+    // Overwrite `freeDimensionOverrides` if specified in config and not set in session options
     const free_dimension_overrides = custom_config.free_dimension_overrides;
     if (free_dimension_overrides) {
         session_options.freeDimensionOverrides ??= free_dimension_overrides;

--- a/src/models.js
+++ b/src/models.js
@@ -199,7 +199,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
     }
 
     if (dtype === DATA_TYPES.auto) {
-        // Try to choose the auto dtype based on the device-specific config first, then fall back to transformers.js_config
+        // Try to choose the auto dtype based on the custom config
         let config_dtype = custom_config.dtype;
         if (typeof config_dtype !== 'string') {
             config_dtype = config_dtype?.[fileName];
@@ -250,7 +250,6 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
     session_options.executionProviders ??= executionProviders;
 
     const free_dimension_overrides = custom_config.free_dimension_overrides;
-
     if (free_dimension_overrides) {
         session_options.freeDimensionOverrides ??= free_dimension_overrides;
     } else if (selectedDevice.startsWith('webnn') && !session_options.freeDimensionOverrides) {
@@ -264,7 +263,6 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
 
     // Handle onnx external data files
     const use_external_data_format = options.use_external_data_format ?? custom_config.use_external_data_format;
-
     /** @type {Promise<string|{path: string, data: Uint8Array}>[]} */
     let externalDataPromises = [];
     if (use_external_data_format) {

--- a/src/models.js
+++ b/src/models.js
@@ -158,8 +158,7 @@ const MODEL_CLASS_TO_NAME_MAPPING = new Map();
  * @private
  */
 async function getSession(pretrained_model_name_or_path, fileName, options) {
-    const custom_config = options.config?.['transformers.js_config'] ?? {};
-    const device_config = custom_config.device_config ?? {};
+    let custom_config = options.config?.['transformers.js_config'] ?? {};
 
     let device = options.device ?? custom_config.device;
     if (device && typeof device !== 'string') {
@@ -176,14 +175,20 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         device ?? (apis.IS_NODE_ENV ? 'cpu' : 'wasm')
     );
 
-    // Get device-specific config if available
-    const deviceSpecificConfig = device_config[selectedDevice] ?? {};
-
     const executionProviders = deviceToExecutionProviders(selectedDevice);
 
+    // Update custom config with the selected device's config, if it exists
+    const device_config = custom_config.device_config ?? {};
+    if (device_config.hasOwnProperty(selectedDevice)) {
+        custom_config = {
+            ...custom_config,
+            ...device_config[selectedDevice],
+        };
+    }
+
     // If options.dtype is specified, we use it to choose the suffix for the model file.
-    // Otherwise, try device-specific config, then fall back to transformers.js_config
-    let dtype = options.dtype ?? deviceSpecificConfig.dtype ?? custom_config.dtype;
+    // Otherwise, we use the default dtype for the device.
+    let dtype = options.dtype ?? custom_config.dtype;
     if (typeof dtype !== 'string') {
         if (dtype && dtype.hasOwnProperty(fileName)) {
             dtype = dtype[fileName];
@@ -195,7 +200,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
 
     if (dtype === DATA_TYPES.auto) {
         // Try to choose the auto dtype based on the device-specific config first, then fall back to transformers.js_config
-        let config_dtype = deviceSpecificConfig.dtype ?? custom_config.dtype;
+        let config_dtype = custom_config.dtype;
         if (typeof config_dtype !== 'string') {
             config_dtype = config_dtype?.[fileName];
         }
@@ -217,10 +222,8 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         throw new Error(`The device (${selectedDevice}) does not support fp16.`);
     }
 
-    // Check device-specific kv_cache_dtype first, then fall back to transformers.js_config
-    const kv_cache_dtype_config = deviceSpecificConfig.kv_cache_dtype ?? custom_config.kv_cache_dtype;
-
     // Only valid for models with a decoder
+    const kv_cache_dtype_config = custom_config.kv_cache_dtype;
     const kv_cache_dtype = kv_cache_dtype_config
         ? (typeof kv_cache_dtype_config === 'string'
             ? kv_cache_dtype_config
@@ -246,24 +249,21 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
     // Overwrite `executionProviders` if not specified
     session_options.executionProviders ??= executionProviders;
 
-    // First check device-specific free_dimension_overrides, then fall back to transformers.js_config
-    const free_dimension_overrides = deviceSpecificConfig.free_dimension_overrides ?? custom_config.free_dimension_overrides;
+    const free_dimension_overrides = custom_config.free_dimension_overrides;
 
     if (free_dimension_overrides) {
         session_options.freeDimensionOverrides ??= free_dimension_overrides;
     } else if (selectedDevice.startsWith('webnn') && !session_options.freeDimensionOverrides) {
         console.warn(
-            'WebNN does not currently support dynamic shapes and requires `free_dimension_overrides` to be set in config.json as a field within "device_config[selectedDevice]" or "transformers.js_config"' +
-            'When `free_dimension_overrides` is not set, you may experience significant performance degradation.'
+            `WebNN does not currently support dynamic shapes and requires 'free_dimension_overrides' to be set in config.json, preferably as a field within config["transformers.js_config"]["device_config"]["${selectedDevice}"]. ` +
+            `When 'free_dimension_overrides' is not set, you may experience significant performance degradation.`
         );
     }
 
     const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, apis.IS_NODE_ENV);
 
-    // handle onnx external data files - check device-specific config first, then fall back to transformers.js_config
-    const use_external_data_format = options.use_external_data_format ??
-        deviceSpecificConfig.use_external_data_format ??
-        custom_config.use_external_data_format;
+    // Handle onnx external data files
+    const use_external_data_format = options.use_external_data_format ?? custom_config.use_external_data_format;
 
     /** @type {Promise<string|{path: string, data: Uint8Array}>[]} */
     let externalDataPromises = [];


### PR DESCRIPTION
Currently setting free_dimension_override at a model level would restrict the models which can handle dynamic shapes, which impacts cpu, webgpu and node.js...

This PR changed the logic a little bit that only allow free_dimension_override on a device level, and work under `webnn` key only of `transformers.js_config` in config.json.

<table>
<tr><th>Current</th><th>This PR</th></tr>
<tr>
<td><pre>
{
  "transformers.js_config": {
    "free_dimension_overrides": {
      "batch_size": 1,
      "num_channels": 3,
      "height": 30,
      "width": 30
    }
  }
}</pre></td>
<td><pre>
{
  "transformers.js_config": {
    "webnn": {
      "free_dimension_overrides": {
        "batch_size": 1,
        "num_channels": 3,
        "height": 30,
        "width": 30
      }
    }
  }
}</pre></td>
</tr>
<tr>
<td><pre>
{
  "transformers.js_config": {
    "device": "webnn-gpu",
    "dtype": "fp16",
    "free_dimension_overrides": {
      "batch_size": 1,
      "num_channels": 3,
      "height": 30,
      "width": 30
    }
  }
}</pre></td>
<td><pre>{
  "transformers.js_config": {
    "device": "webnn-gpu",
    "dtype": "fp16",
    "webnn": {
      "free_dimension_overrides": {
        "batch_size": 1,
        "num_channels": 3,
        "height": 30,
        "width": 30
      }
    }
  }
}</pre></td>
</tr>
</table>

Tested pass by using `xenova/resnet-50` with updated local `config.js` file and didn't set `free_dimension_overrides` in app JavaScript code.

@xenova PTAL

CC @honry @huningxin