### PR TITLE
Return buffer instead of file_path if cache unavailable for model loading

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -118,7 +118,8 @@ const localModelPath = RUNNING_LOCALLY
  * @property {string} cacheDir The directory to use for caching files with the file system. By default, it is `./.cache`.
  * @property {boolean} useCustomCache Whether to use a custom cache system (defined by `customCache`), defaults to `false`.
  * @property {Object} customCache The custom cache to use. Defaults to `null`. Note: this must be an object which
- * implements the `match` and `put` functions of the Web Cache API. For more information, see https://developer.mozilla.org/en-US/docs/Web/API/Cache
+ * implements the `match` and `put` functions of the Web Cache API. For more information, see https://developer.mozilla.org/en-US/docs/Web/API/Cache.
+ * If you wish, you may also return a `Promise<string>` from the `match` function if you'd like to use a file path instead of `Promise<Response>`.
  */
 
 /** @type {TransformersEnvironment} */

--- a/src/models.js
+++ b/src/models.js
@@ -248,7 +248,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         );
     }
 
-    const return_path = apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache);
+    const return_path = apis.IS_NODE_ENV && env.useFSCache;
     const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, return_path);
 
     // handle onnx external data files

--- a/src/models.js
+++ b/src/models.js
@@ -116,7 +116,7 @@ import { RawImage } from './utils/image.js';
 import { dynamic_time_warping, max, medianFilter } from './utils/maths.js';
 import { EosTokenCriteria, MaxLengthCriteria, StoppingCriteriaList } from './generation/stopping_criteria.js';
 import { LogitsSampler } from './generation/logits_sampler.js';
-import { apis } from './env.js';
+import { apis, env } from './env.js';
 
 import { WhisperGenerationConfig } from './models/whisper/generation_whisper.js';
 import { whisper_language_to_code } from './models/whisper/common_whisper.js';
@@ -248,7 +248,8 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         );
     }
 
-    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, apis.IS_NODE_ENV);
+    const return_path = apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache);
+    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, return_path);
 
     // handle onnx external data files
     const use_external_data_format = options.use_external_data_format ?? custom_config.use_external_data_format;
@@ -276,7 +277,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
             const path = `${baseName}_data${i === 0 ? '' : '_' + i}`;
             const fullPath = `${options.subfolder ?? ''}/${path}`;
             externalDataPromises.push(new Promise(async (resolve, reject) => {
-                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
+                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, return_path);
                 resolve(data instanceof Uint8Array ? { path, data } : path);
             }));
         }

--- a/src/models.js
+++ b/src/models.js
@@ -116,7 +116,7 @@ import { RawImage } from './utils/image.js';
 import { dynamic_time_warping, max, medianFilter } from './utils/maths.js';
 import { EosTokenCriteria, MaxLengthCriteria, StoppingCriteriaList } from './generation/stopping_criteria.js';
 import { LogitsSampler } from './generation/logits_sampler.js';
-import { apis, env } from './env.js';
+import { apis } from './env.js';
 
 import { WhisperGenerationConfig } from './models/whisper/generation_whisper.js';
 import { whisper_language_to_code } from './models/whisper/common_whisper.js';
@@ -248,7 +248,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         );
     }
 
-    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, (apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache)));
+    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, apis.IS_NODE_ENV);
 
     // handle onnx external data files
     const use_external_data_format = options.use_external_data_format ?? custom_config.use_external_data_format;
@@ -276,7 +276,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
             const path = `${baseName}_data${i === 0 ? '' : '_' + i}`;
             const fullPath = `${options.subfolder ?? ''}/${path}`;
             externalDataPromises.push(new Promise(async (resolve, reject) => {
-                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, (apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache)));
+                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
                 resolve(data instanceof Uint8Array ? { path, data } : path);
             }));
         }

--- a/src/models.js
+++ b/src/models.js
@@ -116,7 +116,7 @@ import { RawImage } from './utils/image.js';
 import { dynamic_time_warping, max, medianFilter } from './utils/maths.js';
 import { EosTokenCriteria, MaxLengthCriteria, StoppingCriteriaList } from './generation/stopping_criteria.js';
 import { LogitsSampler } from './generation/logits_sampler.js';
-import { apis } from './env.js';
+import { apis, env } from './env.js';
 
 import { WhisperGenerationConfig } from './models/whisper/generation_whisper.js';
 import { whisper_language_to_code } from './models/whisper/common_whisper.js';
@@ -248,7 +248,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
         );
     }
 
-    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, apis.IS_NODE_ENV);
+    const bufferOrPathPromise = getModelFile(pretrained_model_name_or_path, modelFileName, true, options, (apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache)));
 
     // handle onnx external data files
     const use_external_data_format = options.use_external_data_format ?? custom_config.use_external_data_format;
@@ -276,7 +276,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
             const path = `${baseName}_data${i === 0 ? '' : '_' + i}`;
             const fullPath = `${options.subfolder ?? ''}/${path}`;
             externalDataPromises.push(new Promise(async (resolve, reject) => {
-                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
+                const data = await getModelFile(pretrained_model_name_or_path, fullPath, true, options, (apis.IS_NODE_ENV && (env.useFSCache || env.useCustomCache)));
                 resolve(data instanceof Uint8Array ? { path, data } : path);
             }));
         }

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -407,7 +407,6 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             throw Error("Invalid configuration detected: both local and remote models are disabled. Fix by setting `env.allowLocalModels` or `env.allowRemoteModels` to `true`.")
         }
     }
-    return_path &&= env.useFSCache || env.useCustomCache;
 
     // Initiate file retrieval
     dispatchCallback(options.progress_callback, {

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -407,6 +407,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             throw Error("Invalid configuration detected: both local and remote models are disabled. Fix by setting `env.allowLocalModels` or `env.allowRemoteModels` to `true`.")
         }
     }
+    return_path &&= env.useFSCache || env.useCustomCache;
 
     // Initiate file retrieval
     dispatchCallback(options.progress_callback, {

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -638,7 +638,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     });
 
     if (result) {
-        if (return_path) {
+        if (!apis.IS_NODE_ENV && return_path) {
             throw new Error("Cannot return path in a browser environment.")
         }
         return result;
@@ -647,7 +647,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         return response.filePath;
     }
 
-    const path = await cache.match(cacheKey);
+    const path = await cache?.match(cacheKey);
     if (path instanceof FileResponse) {
         return path.filePath;
     }

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -647,12 +647,18 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         return response.filePath;
     }
 
-    const path = await cache?.match(cacheKey);
-    if (path instanceof FileResponse) {
-        return path.filePath;
+    // Otherwise, return the cached response (most likely a `FileResponse`).
+    // NOTE: A custom cache may return a Response, or a string (file path)
+    const cachedResponse = await cache?.match(cacheKey);
+    if (cachedResponse instanceof FileResponse) {
+        return cachedResponse.filePath;
+    } else if (cachedResponse instanceof Response) {
+        return new Uint8Array(await cachedResponse.arrayBuffer());
+    } else if (typeof cachedResponse === 'string') {
+        return cachedResponse;
     }
-    throw new Error("Unable to return path for response.");
 
+    throw new Error("Unable to get model file path or buffer.");
 }
 
 /**


### PR DESCRIPTION
This PR resolves #1249 and #1279 . When running in a Node.js environment, there's an edge case where the unavailability of a caching system causes an error when loading model files. [The problematic code is here.](https://github.com/huggingface/transformers.js/blob/10c09fb561857abf817d651a02898f590f5b7954/src/utils/hub.js#L650). Can be verified by simply setting both `env.useFSCache` and `env.useCustomCache` to false.

Specifically, in a Node.js environment, `getModelFile()` attempts to download the respective model.onnx (or equivalent) file, store it in a cache and return the path to it. In cases where caching is disabled or unavailable and a remote model is to be loaded, `cache` stays undefined and the `cache.match()` call throws an error. Can be verified by simply setting both `env.useFSCache` and `env.useCustomCache` to false.

This PR makes it so that the file_path is only requested if the environment is Node.js AND either of the two caching options are available. Otherwise, the buffer containing the model file is returned as is.