### PR TITLE
Use custom cache over FSCache if specified

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -451,7 +451,9 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     }
 
     if (!cache && env.useFSCache) {
-        // TODO throw error if not available
+        if (!apis.IS_FS_AVAILABLE) {
+            throw Error('File System Cache is not available in this environment.');
+        }
 
         // If `cache_dir` is not specified, use the default cache directory
         cache = new FileCache(options.cache_dir ?? env.cacheDir);

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -434,13 +434,6 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         }
     }
 
-    if (!cache && env.useFSCache) {
-        // TODO throw error if not available
-
-        // If `cache_dir` is not specified, use the default cache directory
-        cache = new FileCache(options.cache_dir ?? env.cacheDir);
-    }
-
     if (!cache && env.useCustomCache) {
         // Allow the user to specify a custom cache system.
         if (!env.customCache) {
@@ -455,6 +448,13 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             )
         }
         cache = env.customCache;
+    }
+
+    if (!cache && env.useFSCache) {
+        // TODO throw error if not available
+
+        // If `cache_dir` is not specified, use the default cache directory
+        cache = new FileCache(options.cache_dir ?? env.cacheDir);
     }
 
     const revision = options.revision ?? 'main';

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -418,22 +418,6 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     // First, check if the a caching backend is available
     // If no caching mechanism available, will download the file every time
     let cache;
-    if (!cache && env.useBrowserCache) {
-        if (typeof caches === 'undefined') {
-            throw Error('Browser cache is not available in this environment.')
-        }
-        try {
-            // In some cases, the browser cache may be visible, but not accessible due to security restrictions.
-            // For example, when running an application in an iframe, if a user attempts to load the page in
-            // incognito mode, the following error is thrown: `DOMException: Failed to execute 'open' on 'CacheStorage':
-            // An attempt was made to break through the security policy of the user agent.`
-            // So, instead of crashing, we just ignore the error and continue without using the cache.
-            cache = await caches.open('transformers-cache');
-        } catch (e) {
-            console.warn('An error occurred while opening the browser cache:', e);
-        }
-    }
-
     if (!cache && env.useCustomCache) {
         // Allow the user to specify a custom cache system.
         if (!env.customCache) {
@@ -448,6 +432,22 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             )
         }
         cache = env.customCache;
+    }
+
+    if (!cache && env.useBrowserCache) {
+        if (typeof caches === 'undefined') {
+            throw Error('Browser cache is not available in this environment.')
+        }
+        try {
+            // In some cases, the browser cache may be visible, but not accessible due to security restrictions.
+            // For example, when running an application in an iframe, if a user attempts to load the page in
+            // incognito mode, the following error is thrown: `DOMException: Failed to execute 'open' on 'CacheStorage':
+            // An attempt was made to break through the security policy of the user agent.`
+            // So, instead of crashing, we just ignore the error and continue without using the cache.
+            cache = await caches.open('transformers-cache');
+        } catch (e) {
+            console.warn('An error occurred while opening the browser cache:', e);
+        }
     }
 
     if (!cache && env.useFSCache) {


### PR DESCRIPTION
Currently, if both `useFSCache` and `useCustomCache` env options are set to true (perhaps because `useFSCache` is true by default and the user forgot to unset it), the code defaults to instantiating a FileCache instead of using the custom cache instance passed in by the user when getting model files. This commit changes the default to be the custom cache if specified.