### PR TITLE
Attempt to slim model if onnx check model fails

### DIFF
--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -220,6 +220,12 @@ def quantize_fp16(
         disable_shape_infer=disable_shape_infer,
         op_block_list=blocked_ops,
     )
+    try:
+        # Check the model
+        onnx.checker.check_model(model_fp16, full_check=True)
+    except Exception as e:
+        import onnxslim
+        model_fp16 = onnxslim.slim(model_fp16)
     check_and_save_model(model_fp16, save_path)
 
 


### PR DESCRIPTION
It seems there is a bug in `onnx.checker.check_model` which throws an error when attempting to perform shape inference on models which run correctly in onnxruntime:
```
InferenceError: [ShapeInferenceError] Inference error(s): (op_type:If, node name: optimum::if): [ShapeInferenceError] Inference error(s): (op_type:Add, node name: /model/decoder/embed_positions/Add): [ShapeInferenceError] Inferred shape and existing shape differ in rank: (1) vs (0)
```

Passing the model through onnxslim seems to resolve the issue.