### PR TITLE
docs: Fix formatting for project setup prompts in Next.js tutorial

### DIFF
--- a/docs/source/tutorials/next.md
+++ b/docs/source/tutorials/next.md
@@ -29,13 +29,14 @@ npx create-next-app@latest
 
 On installation, you'll see various prompts. For this demo, we'll be selecting those shown below in bold:
 
-<pre>√ What is your project named? ... next
-√ Would you like to use TypeScript? ... <b>No</b> / Yes
-√ Would you like to use ESLint? ... No / <b>Yes</b>
-√ Would you like to use Tailwind CSS? ... No / <b>Yes</b>
-√ Would you like to use `src/` directory? ... No / <b>Yes</b>
-√ Would you like to use App Router? (recommended) ... No / <b>Yes</b>
-√ Would you like to customize the default import alias? ... <b>No</b> / Yes
+<pre>
+<span>√ What is your project named? ... next</span>
+<span>√ Would you like to use TypeScript? ... <span style="color: green;"><b>No</span></b> / Yes</span>
+<span>√ Would you like to use ESLint? ... No / <span style="color: green;"><b>Yes</b></span>
+<span>√ Would you like to use Tailwind CSS? ... No / <span style="color: green;"><b>Yes</b></span></span>
+<span>√ Would you like to use `src/` directory? ... No / <span style="color: green;"><b>Yes</b></span></span>
+<span>√ Would you like to use App Router? (recommended) ... No / <span style="color: green;"><b>Yes</b></span></span>
+</span>√ Would you like to customize the default import alias? ... <span style="color: green;"><b>No</b></span> / Yes</span>
 </pre>
 
 


### PR DESCRIPTION
#1301 
Updated the installation part and gave green text color to the recommended option.
<img width="595" alt="Screenshot 2025-04-29 at 12 15 44 PM" src="https://github.com/user-attachments/assets/398fc7d7-8cfe-48d3-9dfc-435818df2865" />
