### PR TITLE
fix: resolve webpack import.meta warning in browser extension

### DIFF
--- a/examples/extension/webpack.config.js
+++ b/examples/extension/webpack.config.js
@@ -22,6 +22,26 @@ const config = {
         path: path.resolve(__dirname, 'build'),
         filename: '[name].js',
     },
+    resolve: {
+        fallback: {
+            "fs": false,
+            "path": false,
+            "url": false,
+        }
+    },
+    module: {
+        parser: {
+            javascript: {
+                importMeta: false,
+            },
+        },
+    },
+    ignoreWarnings: [
+        {
+            module: /node_modules\/@huggingface\/transformers/,
+            message: /Critical dependency: Accessing import\.meta directly is unsupported/,
+        },
+    ],
     plugins: [
         new HtmlWebpackPlugin({
             template: './src/popup.html',


### PR DESCRIPTION
- Add parser configuration to disable import.meta parsing in webpack
- Suppress critical dependency warnings from @huggingface/transformers
- Add Node.js fallbacks for browser compatibility (fs, path, url)
- Ensures clean build without warnings while maintaining ML functionality
- Extension now builds successfully for both development and production

Resolves webpack 5 compatibility issue with Transformers.js library when bundling for browser extension environment.