### PR TITLE
Improve detection & usage of deno/bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 node_modules
 .cache
 .DS_STORE
+deno.lock
 
 # Do not track build artifacts/generated files
 /dist

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
         "default": "./dist/transformers.node.cjs"
       }
     },
+    "worker": {
+      "types": "./types/transformers.d.ts",
+      "default": "./dist/transformers.js"
+    },
     "default": {
       "types": "./types/transformers.d.ts",
       "default": "./dist/transformers.web.js"

--- a/package.json
+++ b/package.json
@@ -82,13 +82,6 @@
     "README.md",
     "LICENSE"
   ],
-  "browser": {
-    "fs": false,
-    "path": false,
-    "url": false,
-    "sharp": false,
-    "onnxruntime-node": false
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
         "default": "./dist/transformers.node.cjs"
       }
     },
-    "worker": {
-      "types": "./types/transformers.d.ts",
-      "default": "./dist/transformers.js"
-    },
     "default": {
       "types": "./types/transformers.d.ts",
       "default": "./dist/transformers.web.js"

--- a/src/env.js
+++ b/src/env.js
@@ -22,9 +22,9 @@
  * @module env
  */
 
-import fs from 'fs';
-import path from 'path';
-import url from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
 
 const VERSION = '3.5.2';
 
@@ -39,6 +39,10 @@ const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
 const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
 const IS_FS_AVAILABLE = !isEmpty(fs);
 const IS_PATH_AVAILABLE = !isEmpty(path);
+
+// Runtime detection
+const IS_DENO_RUNTIME = typeof globalThis.Deno !== 'undefined';
+const IS_BUN_RUNTIME = typeof globalThis.Bun !== 'undefined';
 
 /**
  * A read-only object containing information about the APIs available in the current environment.
@@ -62,7 +66,7 @@ export const apis = Object.freeze({
     /** Whether the Node.js process API is available */
     IS_PROCESS_AVAILABLE,
 
-    /** Whether we are running in a Node.js environment */
+    /** Whether we are running in a Node.js-like environment (node, deno, bun) */
     IS_NODE_ENV,
 
     /** Whether the filesystem API is available */
@@ -143,7 +147,7 @@ export const env = {
     useFS: IS_FS_AVAILABLE,
 
     /////////////////// Cache settings ///////////////////
-    useBrowserCache: IS_WEB_CACHE_AVAILABLE,
+    useBrowserCache: IS_WEB_CACHE_AVAILABLE && !IS_DENO_RUNTIME,
 
     useFSCache: IS_FS_AVAILABLE,
     cacheDir: DEFAULT_CACHE_DIR,

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -15,9 +15,8 @@ import {
     calculateReflectOffset, saveBlob,
 } from './core.js';
 import { apis } from '../env.js';
-import fs from 'fs';
 import { Tensor, matmul } from './tensor.js';
-
+import fs from 'node:fs';
 
 /**
  * Helper function to read audio from a path/URL.

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -5,8 +5,8 @@
  * @module utils/hub
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { apis, env } from '../env.js';
 import { dispatchCallback } from './core.js';

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export async function loadAudio(url) {
   // NOTE: Since the Web Audio API is not available in Node.js, we will need to use the `wavefile` library to obtain the raw audio data.

--- a/tests/utils/hub.test.js
+++ b/tests/utils/hub.test.js
@@ -1,7 +1,7 @@
 import { AutoModel, PreTrainedModel } from "../../src/models.js";
 
 import { MAX_TEST_EXECUTION_TIME, DEFAULT_MODEL_OPTIONS } from "../init.js";
-import fs from "fs";
+import fs from "node:fs";
 
 // TODO: Set cache folder to a temp directory
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -166,7 +166,7 @@ const NODE_EXTERNAL_MODULES = [
   "node:url",
 ];
 
-// Do not bundle onnxruntime-node or sharp when packaging for the web.
+// Do not bundle node-only packages when bundling for the web.
 const WEB_IGNORE_MODULES = ["onnxruntime-node", "sharp", "fs", "path", "url"];
 
 // Do not bundle the following modules with webpack (mark as external)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-import TerserPlugin from "terser-webpack-plugin";
-import { fileURLToPath } from "url";
-import path from "path";
-import fs from "fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
 import webpack from "webpack";
+import TerserPlugin from "terser-webpack-plugin";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -167,6 +167,8 @@ const NODE_EXTERNAL_MODULES = [
 ];
 
 // Do not bundle node-only packages when bundling for the web.
+// NOTE: We can exclude the "node:" prefix for built-in modules here,
+// since we apply the `StripNodePrefixPlugin` to strip it.
 const WEB_IGNORE_MODULES = ["onnxruntime-node", "sharp", "fs", "path", "url"];
 
 // Do not bundle the following modules with webpack (mark as external)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,9 +100,6 @@ function buildConfig({
       },
       assetModuleFilename: "[name][ext]",
       chunkFormat: false,
-
-      // https://github.com/huggingface/transformers.js/issues/926
-      publicPath: "",
     },
     optimization: {
       minimize: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,9 +137,9 @@ const NODE_EXTERNAL_MODULES = [
   "onnxruntime-common",
   "onnxruntime-node",
   "sharp",
-  "fs",
-  "path",
-  "url",
+  "node:fs",
+  "node:path",
+  "node:url",
 ];
 
 // Do not bundle onnxruntime-node when packaging for the web.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ import TerserPlugin from "terser-webpack-plugin";
 import { fileURLToPath } from "url";
 import path from "path";
 import fs from "fs";
+import webpack from "webpack";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -142,8 +143,8 @@ const NODE_EXTERNAL_MODULES = [
   "node:url",
 ];
 
-// Do not bundle onnxruntime-node when packaging for the web.
-const WEB_IGNORE_MODULES = ["onnxruntime-node"];
+// Do not bundle onnxruntime-node or sharp when packaging for the web.
+const WEB_IGNORE_MODULES = ["onnxruntime-node", "sharp"];
 
 // Do not bundle the following modules with webpack (mark as external)
 const WEB_EXTERNAL_MODULES = [
@@ -157,12 +158,23 @@ const WEB_BUILD = buildConfig({
   type: "module",
   ignoreModules: WEB_IGNORE_MODULES,
   externalModules: WEB_EXTERNAL_MODULES,
+  plugins: [
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^node:/,
+    }),
+  ]
 });
 
 // Web-only build, bundled with onnxruntime-web
 const BUNDLE_BUILD = buildConfig({
   type: "module",
-  plugins: [new PostBuildPlugin()],
+  ignoreModules: WEB_IGNORE_MODULES,
+  plugins: [
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^node:/,
+    }),
+    new PostBuildPlugin(),
+  ],
 });
 
 // Node-compatible builds


### PR DESCRIPTION
Closes https://github.com/huggingface/transformers.js/issues/1332

- Uses `node:` prefixes for built-in libraries, ensuring standardization across node, bun, and deno runtimes
- Disable browser cache by default in Deno runtime (because the web cache API is available, but our URLs are not valid because we are using relative file paths due to the filesystem access we have)