### PR TITLE
[WIP] Deno browser WASM/WebGPU support

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -142,7 +142,7 @@ export const env = {
     remoteHost: 'https://huggingface.co/',
     remotePathTemplate: '{model}/resolve/{revision}/',
 
-    allowLocalModels: !(IS_BROWSER_ENV || IS_WEBWORKER_ENV),
+    allowLocalModels: !(IS_BROWSER_ENV || IS_WEBWORKER_ENV || IS_DENO_RUNTIME),
     localModelPath: localModelPath,
     useFS: IS_FS_AVAILABLE,
 

--- a/src/models.js
+++ b/src/models.js
@@ -48,6 +48,7 @@ import {
     createInferenceSession,
     isONNXTensor,
     isONNXProxy,
+    runtime,
 } from './backends/onnx.js';
 import {
     DATA_TYPES,
@@ -172,7 +173,7 @@ async function getSession(pretrained_model_name_or_path, fileName, options) {
 
     // If the device is not specified, we use the default (supported) execution providers.
     const selectedDevice = /** @type {import("./utils/devices.js").DeviceType} */(
-        device ?? (apis.IS_NODE_ENV ? 'cpu' : 'wasm')
+        device ?? (runtime === "web" ? 'wasm' : 'cpu')
     );
 
     const executionProviders = deviceToExecutionProviders(selectedDevice);


### PR DESCRIPTION
An experimental branch/PR to test running Transformers.js in Deno's WASM and WebGPU runtimes. This is a bit hacky, but it works... at least for now!

You can test this out by building this PR, and hosting the js files locally.
```js
import { pipeline } from "http://localhost:8080/dist/transformers.js";

const extractor = await pipeline(
    "feature-extraction", "Xenova/all-MiniLM-L6-v2",
    // { device: "webgpu" }, // <-- Enable WebGPU acceleration
);

// Compute sentence embeddings
const sentences = ["Hello world", "This is an example sentence"];
const output = await extractor(sentences, { pooling: "mean", normalize: true });
console.log(output.tolist());
```

**NOTE**: This is different to running with the native EP (#1306), which will enable WebGPU support in Deno, via ONNXRuntime's Native WebGPU EP implementation.

There are some bugs/limitations with the current runtime (based on [wgpu](https://github.com/gfx-rs/wgpu)), e.g.,
```
An uncaught WebGPU validation error was raised: 
Shader 'Gather' parsing error: the `f16` enable-extension is not yet supported
  ┌─ wgsl:1:8
  │
1 │ enable f16;
  │        ^^^ this enable-extension specifies standard functionality which is not yet implemented in Naga
  │
  = note: Let Naga maintainers know that you ran into this at <https://github.com/gfx-rs/wgpu/issues/4384>, so they can prioritize it!

: the `f16` enable-extension is not yet supported
An uncaught WebGPU validation error was raised: ShaderModule with 'Gather' label is invalid
An uncaught WebGPU validation error was raised: ComputePipeline with 'Gather' label is invalid
An uncaught WebGPU validation error was raised: BindGroupLayout with '' label is invalid
An uncaught WebGPU validation error was raised: In a set_pipeline command: ComputePipeline with 'Gather' label is invalid
An uncaught WebGPU validation error was raised: In a set_bind_group command: BindGroup with 'Gather' label is invalid
An uncaught WebGPU validation error was raised: ComputePipeline with 'Gather' label is invalid
An uncaught WebGPU validation error was raised: BindGroupLayout with '' label is invalid
An uncaught WebGPU validation error was raised: In a set_bind_group command: BindGroup with 'Gather' label is invalid
```

but WASM works well 👍 

cc @crowlKats for viz