### PR TITLE
Improve webworker detection to support ServiceWorker and SharedWorker

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -30,7 +30,7 @@ const VERSION = '3.5.2';
 
 // Check if various APIs are available (depends on environment)
 const IS_BROWSER_ENV = typeof window !== "undefined" && typeof window.document !== "undefined";
-const IS_WEBWORKER_ENV = typeof self !== "undefined" && (self.constructor?.name === 'DedicatedWorkerGlobalScope' || self.constructor?.name === 'ServiceWorkerGlobalScope' || self.constructor?.name === 'SharedWorkerGlobalScope');
+const IS_WEBWORKER_ENV = typeof self !== "undefined" && (['DedicatedWorkerGlobalScope', 'ServiceWorkerGlobalScope', 'SharedWorkerGlobalScope'].includes(self.constructor?.name));
 const IS_WEB_CACHE_AVAILABLE = typeof self !== "undefined" && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;

--- a/src/env.js
+++ b/src/env.js
@@ -30,7 +30,7 @@ const VERSION = '3.5.2';
 
 // Check if various APIs are available (depends on environment)
 const IS_BROWSER_ENV = typeof window !== "undefined" && typeof window.document !== "undefined";
-const IS_WEBWORKER_ENV = typeof self !== "undefined"  && self.constructor?.name === 'DedicatedWorkerGlobalScope';
+const IS_WEBWORKER_ENV = typeof self !== "undefined" && (self.constructor?.name === 'DedicatedWorkerGlobalScope' || self.constructor?.name === 'ServiceWorkerGlobalScope' || self.constructor?.name === 'SharedWorkerGlobalScope');
 const IS_WEB_CACHE_AVAILABLE = typeof self !== "undefined" && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;


### PR DESCRIPTION
Closes #1259 

I got the same error as [#1259](https://github.com/huggingface/transformers.js/issues/1259) when I tried to implement an image classification pipeline in the Chrome extension's background script. When I looked into it, it was because the of `IS_WEBWORKER_ENV` value being false. Current web worker detection checks only one of the three WorkerGlobalScope types. I've extended the check to also include reminding two types: `ServiceWorkerGlobalScope` and `SharedWorkerGlobalScope`.