### PR TITLE
Address deprecation in fromstring to frombuffer

### DIFF
--- a/scripts/float16.py
+++ b/scripts/float16.py
@@ -135,7 +135,7 @@ def convert_tensor_float_to_float16(tensor, min_positive_val=1e-7, max_finite_va
         # convert raw_data (bytes type)
         if tensor.raw_data:
             # convert n.raw_data to float
-            float32_list = np.fromstring(tensor.raw_data, dtype="float32")
+            float32_list = np.frombuffer(tensor.raw_data, dtype="float32")
             # convert float to float16
             float16_list = convert_np_to_float16(
                 float32_list, min_positive_val, max_finite_val


### PR DESCRIPTION
Deprecated since numpy 1.14 according to
https://github.com/numpy/numpy/pull/28254

This should be the correct fix for https://github.com/huggingface/transformers.js/issues/1343

And after this is merged, one can likely just revert this https://github.com/huggingface/transformers.js/pull/1351