### PR TITLE
fix: speedup tolist function

### DIFF
--- a/src/utils/tensor.js
+++ b/src/utils/tensor.js
@@ -212,7 +212,7 @@ export class Tensor {
      * @returns {Array}
      */
     tolist() {
-        return reshape(this.data, this.dims)
+        return reshape(this.data, this.dims);
     }
 
     /**
@@ -885,31 +885,54 @@ export class Tensor {
  */
 function reshape(data, dimensions) {
 
+    const ndim = dimensions.length;
+
+    if (ndim === 0) {
+        // Scalar
+        return data[0];
+    }
+
     const totalElements = data.length;
-    const dimensionSize = dimensions.reduce((a, b) => a * b);
+    const dimensionSize = dimensions.reduce((a, b) => a * b, 1);
 
     if (totalElements !== dimensionSize) {
         throw Error(`cannot reshape array of size ${totalElements} into shape (${dimensions})`);
     }
 
-    /** @type {any} */
-    let reshapedArray = data;
-
-    for (let i = dimensions.length - 1; i >= 0; i--) {
-        reshapedArray = reshapedArray.reduce((acc, val) => {
-            let lastArray = acc[acc.length - 1];
-
-            if (lastArray.length < dimensions[i]) {
-                lastArray.push(val);
-            } else {
-                acc.push([val]);
-            }
-
-            return acc;
-        }, [[]]);
+    if (ndim === 1) {
+        return Array.from(data);
     }
 
-    return reshapedArray[0];
+    // Pre-compute strides for each dimension
+    const strides = new Array(ndim);
+    strides[ndim - 1] = 1;
+    for (let i = ndim - 2; i >= 0; i--) {
+        strides[i] = strides[i + 1] * dimensions[i + 1];
+    }
+
+    /**
+     * Recursively construct the nested array.
+     * @param {number} offset - Current offset in `data`.
+     * @param {number} axis - Current axis being processed.
+     * @returns {Array}
+     */
+    function build(offset, axis) {
+        const size = dimensions[axis];
+        const result = new Array(size);
+        if (axis === ndim - 1) {
+            for (let i = 0; i < size; i++) {
+                result[i] = data[offset + i];
+            }
+        } else {
+            const step = strides[axis];
+            for (let i = 0; i < size; i++) {
+                result[i] = build(offset + i * step, axis + 1);
+            }
+        }
+        return result;
+    }
+
+    return build(0, 0);
 }
 
 /**

--- a/tests/utils/tensor.test.js
+++ b/tests/utils/tensor.test.js
@@ -378,6 +378,56 @@ describe("Tensor operations", () => {
         [3, 4],
       ]);
     });
+
+    it("should return nested arrays for a 3D tensor", () => {
+      const t1 = new Tensor(
+        "float32",
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [2, 2, 2],
+      );
+      const arr = t1.tolist();
+      compare(arr, [
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        [
+          [5, 6],
+          [7, 8],
+        ],
+      ]);
+    });
+
+    it("should return nested arrays for a 4D tensor", () => {
+      const t1 = new Tensor(
+        "float32",
+        Array.from({ length: 16 }, (_, i) => i + 1),
+        [2, 2, 2, 2],
+      );
+      const arr = t1.tolist();
+      compare(arr, [
+        [
+          [
+            [1, 2],
+            [3, 4],
+          ],
+          [
+            [5, 6],
+            [7, 8],
+          ],
+        ],
+        [
+          [
+            [9, 10],
+            [11, 12],
+          ],
+          [
+            [13, 14],
+            [15, 16],
+          ],
+        ],
+      ]);
+    });
   });
 
   describe("mul", () => {


### PR DESCRIPTION
## Summary
- implement stride-based `reshape` for faster nested array construction
- add tensor tests for 4D `tolist`

Fixes https://github.com/huggingface/transformers.js/issues/1191 

## The reshape-based approach
The old implementation built the nested structure through a series of reshapes:
- For each dimension, the flat array was chunked into smaller arrays.
- Each chunk was then reshaped again for the next dimension.
- This meant multiple passes over the data: one to create the first level, another for the second, and so on.

Each reshape step:
- Allocates new arrays for every chunk.
- Invokes slice or map operations, producing copies or calling callbacks for every element.
- Re-reads the same data multiple times. For an n‑dimensional tensor, the data might be iterated n separate times.
- Incurs significant JavaScript function‑call overhead, because reduce, map, and friends invoke callbacks for each element.

This results in substantial CPU time (multiple passes and callback dispatches) and memory churn (allocating and discarding intermediate arrays). The complexity effectively grows with both the number of elements and the number of dimensions.

## Recursive construction with precomputed strides
The optimized version precomputes the strides—the number of elements to skip along each dimension—and builds the nested array recursively:
- Starting at dimension 0, allocate the output array for that level.
- For each index at this level, compute the offset into the flat buffer using the stride.
- Recurse into the next dimension until the innermost dimension is reached, where elements are read directly from the typed array.


| Shape              | Current tolist (ms) | Optimized tolist (ms) | Speedup  |
|--------------------|----------------------|-----------------------|----------|
| [16, 768]          | 1.003                | 0.319                 | 3.15×    |
| [32, 768]          | 1.948                | 0.187                 | 10.42×   |
| [8, 16, 64]        | 0.645                | 0.049                 | 13.14×   |
| [8, 32, 64]        | 1.792                | 0.259                 | 6.92×    |
| [4, 8, 16, 32]     | 1.797                | 0.096                 | 18.73×   |
| [2, 4, 8, 16, 32]  | 3.537                | 0.203                 | 17.43×   |
