### PR TITLE
enhancement: add a flag to force remote download models

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -116,6 +116,7 @@ const localModelPath = RUNNING_LOCALLY
  * @property {boolean} allowLocalModels Whether to allow loading of local files, defaults to `false` if running in-browser, and `true` otherwise.
  * If set to `false`, it will skip the local file check and try to load the model from the remote host.
  * @property {string} localModelPath Path to load local models from. Defaults to `/models/`.
+ * @property {boolean} forceRemoteDownload Flag to force downloading from remote(HuggingFace). Defaults to `false`.
  * @property {boolean} useFS Whether to use the file system to load files. By default, it is `true` if available.
  * @property {boolean} useBrowserCache Whether to use Cache API to cache models. By default, it is `true` if available.
  * @property {boolean} useFSCache Whether to use the file system to cache files. By default, it is `true` if available.
@@ -154,6 +155,9 @@ export const env = {
 
     useCustomCache: false,
     customCache: null,
+
+    // Add a flag to force remote downloading
+    forceRemoteDownload: false,
     //////////////////////////////////////////////////////
 }
 


### PR DESCRIPTION
add a flag to force remote download models as typescript has issues with env.js while pipeline creation