### PR TITLE
fixed backend loading path

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -193,11 +193,13 @@ if (ONNX_ENV?.wasm) {
     // By default, we only do this if we are not in a service worker and the wasmPaths are not already set.
     if (
         // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
-        !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope) &&
-        env.backends.onnx.versions?.web &&
-        !ONNX_ENV.wasm.wasmPaths
+        (
+            !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope) &&
+            ONNX_ENV.versions?.web &&
+            !ONNX_ENV.wasm.wasmPaths
+        )
     ) {
-        const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${env.backends.onnx.versions.web}/dist/`;
+        const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX_ENV.versions.web}/dist/`;
 
         ONNX_ENV.wasm.wasmPaths = apis.IS_SAFARI
             ? {


### PR DESCRIPTION
The env.backends.onnx is set at the end of the file while env.backends.onnx.versions?.web is requested already on line 197.
That means the check wether the jsdelivr file should be requested is always `false`.

This PR ensures that https://cdn.jsdelivr.net is used if not in service worker.