### PR TITLE
Fix fp16/q4f16 dtype test failures on Node.js 20+

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -128,7 +128,7 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ["./tests/setup.js"],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/src/utils/tensor.js
+++ b/src/utils/tensor.js
@@ -22,9 +22,10 @@ import { TensorOpRegistry } from '../ops/registry.js';
 
 export const DataTypeMap = Object.freeze({
     float32: Float32Array,
-    // @ts-ignore ts(2552) Limited availability of Float16Array across browsers:
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array
-    float16: typeof Float16Array !== "undefined" ? Float16Array: Uint16Array,
+    // NOTE: onnxruntime-node's native binding expects Uint16Array for float16 tensors.
+    // Float16Array is not yet supported by onnxruntime-node (see microsoft/onnxruntime#26742).
+    // Once onnxruntime adds Float16Array support, this can be updated.
+    float16: Uint16Array,
     float64: Float64Array,
     string: Array, // string[]
     int8: Int8Array,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,17 @@
+// WORKAROUND: onnxruntime-node's native binding expects Uint16Array for float16 tensors,
+// but onnxruntime-common uses Float16Array when available (Node 20+).
+// Hide Float16Array before any onnxruntime imports to force Uint16Array usage.
+//
+// This file runs before any test imports, ensuring Float16Array is hidden
+// when onnxruntime-common's checkTypedArray() runs.
+//
+// TODO: Remove this workaround once onnxruntime-node adds Float16Array support.
+// Track the upstream PR: https://github.com/microsoft/onnxruntime/pull/26742
+// When that PR is merged and released, this file can be deleted and the
+// setupFiles entry in jest.config.mjs can be removed.
+
+if (typeof globalThis.Float16Array !== 'undefined') {
+  // Save reference in case other code needs it
+  globalThis._Float16Array = globalThis.Float16Array;
+  delete globalThis.Float16Array;
+}


### PR DESCRIPTION
## Problem

Preparing a different PR I noticed that running tests locally on Node.js 20+ causes the Llama fp16/q4f16 dtype tests to fail:

```
TypeError: Tensor.data must be a typed array (4) for float16 tensors, but got typed array (0).
```

## Cause

`onnxruntime-common` detects `Float16Array` (available in Node 20+) and uses it for float16 tensors. However, `onnxruntime-node`'s native binding was written before `Float16Array` existed and only accepts `Uint16Array`.

## Fix

This PR adds a workaround that hides `Float16Array` before onnxruntime loads, forcing it to use `Uint16Array` instead.

There's an upstream PR to add `Float16Array` support to onnxruntime-node (https://github.com/microsoft/onnxruntime/pull/26742), but it hasn't merged yet (and onnxruntime PRs can take many months to merge).  Once it does, this workaround can be removed.

## Test plan

- [x] `npm test` passes locally on Node.js 20+
- [x] fp16/q4f16 dtype tests now pass