### PR TITLE
fixing text color to display token ids correctly

### DIFF
--- a/examples/tokenizer-playground/src/App.jsx
+++ b/examples/tokenizer-playground/src/App.jsx
@@ -146,7 +146,7 @@ function App() {
         </div>
       </div>
 
-      <div ref={outputRef} className='font-mono text-lg p-2.5 w-full bg-gray-100 rounded-lg border border-gray-200 whitespace-pre-wrap text-left h-[200px] overflow-y-auto'>
+      <div ref={outputRef} className='font-mono text-black text-lg p-2.5 w-full bg-gray-100 rounded-lg border border-gray-200 whitespace-pre-wrap text-left h-[200px] overflow-y-auto'>
         {outputOption === 'text' ? (
           decodedTokens.map(
             (token, index) => <Token key={index} text={token} position={index} margin={margins[index]} />


### PR DESCRIPTION
Current tokenizer example displays white text over white background while displaying the token-ids which is difficult to see. (need to highlight the text inside textbox)

<img width="1146" height="912" alt="Screenshot 2026-01-07 220705" src="https://github.com/user-attachments/assets/a0497548-96f5-42f1-ab67-2539b596a324" />

Proposed fix is to change text color to black to see it better.

<img width="1128" height="916" alt="Screenshot 2026-01-07 220407" src="https://github.com/user-attachments/assets/e3385115-2ea7-46f3-a11a-de13b5060443" />
