### PR TITLE
fix: correct type definitions for AutoTokenizer and AutoModelForCausalLM

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -7866,7 +7866,21 @@ export class PretrainedMixin {
     static BASE_IF_FAIL = false;
 
 
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * Instantiate one of the model classes of the library from a pretrained model.
+     *
+     * The model class to instantiate is selected based on the `model_type` property of the config object
+     * (either passed as an argument or loaded from `pretrained_model_name_or_path` if possible)
+     *
+     * @param {string} pretrained_model_name_or_path The name or path of the pretrained model. Can be either:
+     * - A string, the *model id* of a pretrained model hosted inside a model repo on huggingface.co.
+     *   Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
+     *   user or organization name, like `dbmdz/bert-base-german-cased`.
+     * - A path to a *directory* containing model weights, e.g., `./my_model_directory/`.
+     * @param {import('./utils/hub.js').PretrainedModelOptions} [options] Additional options for loading the model.
+     *
+     * @returns {Promise<PreTrainedModel>} A new instance of the `PreTrainedModel` class.
+     */
     static async from_pretrained(pretrained_model_name_or_path, {
         progress_callback = null,
         config = null,
@@ -8595,6 +8609,17 @@ export class AutoModelForTextToWaveform extends PretrainedMixin {
  */
 export class AutoModelForCausalLM extends PretrainedMixin {
     static MODEL_CLASS_MAPPINGS = [MODEL_FOR_CAUSAL_LM_MAPPING_NAMES];
+
+    /**
+     * Instantiate a pretrained causal language model from a pretrained model.
+     *
+     * @param {string} pretrained_model_name_or_path The name or path of the pretrained model.
+     * @param {import('./utils/hub.js').PretrainedModelOptions} [options] Additional options for loading the model.
+     * @returns {Promise<PreTrainedModel>} A new instance of a causal language model.
+     */
+    static async from_pretrained(pretrained_model_name_or_path, options = {}) {
+        return /** @type {Promise<PreTrainedModel>} */ (super.from_pretrained(pretrained_model_name_or_path, options));
+    }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR fixes incorrect TypeScript type definitions for `AutoTokenizer` and `AutoModelForCausalLM`.

Fixes #1495

## Changes

### `src/models.js`
- **PretrainedMixin.from_pretrained**: Replaced `@type {typeof PreTrainedModel.from_pretrained}` with full JSDoc documentation including proper parameter and return type annotations
- **AutoModelForCausalLM**: Added explicit `from_pretrained` override with proper JSDoc to ensure TypeScript correctly types the return value

### `src/tokenizers.js`
- **PreTrainedTokenizer.from_pretrained**: Changed `@param {PretrainedTokenizerOptions} options` to `@param {PretrainedTokenizerOptions} [options]` to correctly mark as optional
- **AutoTokenizer.from_pretrained**: Same fix - marked options parameter as optional

## Type Generation

After running `npm run typegen`, the generated `.d.ts` files now correctly show:
- `from_pretrained` methods with optional options parameter (`?`)
- Proper return types (`Promise<PreTrainedTokenizer>` and `Promise<PreTrainedModel>`)

## Testing

Created a TypeScript test file to validate the fixes - compilation succeeded with no errors.