### PR TITLE
fix: force light theme styles for output tokenids visibility

### DIFF
--- a/examples/tokenizer-playground/src/App.jsx
+++ b/examples/tokenizer-playground/src/App.jsx
@@ -146,7 +146,7 @@ function App() {
         </div>
       </div>
 
-      <div ref={outputRef} className='font-mono text-lg p-2.5 w-full bg-gray-100 rounded-lg border border-gray-200 whitespace-pre-wrap text-left h-[200px] overflow-y-auto'>
+      <div ref={outputRef} className='font-mono text-lg p-2.5 w-full bg-white text-black rounded-lg border border-gray-200 whitespace-pre-wrap text-left h-[200px] overflow-y-auto'>
         {outputOption === 'text' ? (
           decodedTokens.map(
             (token, index) => <Token key={index} text={token} position={index} margin={margins[index]} />


### PR DESCRIPTION
**Description:** This PR addresses the visibility issue reported in the Agents Course (Issue #507).

**Problem:** When the course website is in dark mode, the tokenizer (token_ids) output becomes unreadable due to color inheritance inside the iframe.

**Solution:** Instead of adding dark mode support, I have forced the output container to remain in "light mode" (white background, black text). This ensures the playground remains consistent and readable regardless of the theme used in the environment where it is embedded.

**Changes:**
Updated _className_ of the output div in **App.jsx** to explicitly use _bg-white_ and _text-black._