### PR TITLE
Fix model fetching from workers.dev domains

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -245,7 +245,7 @@ export async function getFile(urlOrPath) {
         // Running in a browser-environment, so we use default headers
         // NOTE: We do not allow passing authorization headers in the browser,
         // since this would require exposing the token to the client.
-        return fetch(urlOrPath);
+        return fetch(urlOrPath, { referrerPolicy: 'no-referrer' });
     }
 }
 


### PR DESCRIPTION
Add referrerPolicy: 'no-referrer' to browser fetch calls to prevent Hugging Face infrastructure from blocking requests based on referrer.

To test: `curl https://huggingface.co/Xenova/bert-base-uncased/resolve/main/config.json`
And also: `curl -s https://huggingface.co/Xenova/bert-base-uncased/resolve/main/config.json -H "Referer: https://workers.dev/"`
And also: `curl -s https://huggingface.co/Xenova/bert-base-uncased/resolve/main/config.json -H "Referer: https://example.com/"`

Weird stuff happens when adding a referer from a workers.dev subdomain.

See live example at `https://transformers-js-demo.cloudflare-huddle586.workers.dev/` where the model errors. However, see example at `https://transformers-js-demo-2.cloudflare-huddle586.workers.dev/` using my fork of transformers.js where it actually works with my changes.