### PR TITLE
added ProgressCallback and ProgressInfo as type exports

### DIFF
--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -59,4 +59,6 @@ export { softmax, log_softmax, dot, cos_sim } from './utils/maths.js';
  * @typedef {import('./tokenization_utils.js').PretrainedTokenizerOptions} PretrainedTokenizerOptions
  * @typedef {import('./utils/dtypes.js').DataType} DataType
  * @typedef {import('./utils/devices.js').DeviceType} DeviceType
+ * @typedef {import('./utils/core.js').ProgressCallback} ProgressCallback
+ * @typedef {import('./utils/core.js').ProgressInfo} ProgressInfo
  */


### PR DESCRIPTION
Due to some refactorings, types for ProgressCallback and ProgressInfo are not longer exported. This PR readds those exports

Closes https://github.com/huggingface/transformers.js/issues/1522