### PR TITLE
Hot-fix default fetch assignment

### DIFF
--- a/packages/transformers/src/env.js
+++ b/packages/transformers/src/env.js
@@ -134,6 +134,11 @@ const DEFAULT_CACHE_DIR = RUNNING_LOCALLY ? path.join(dirname__, '/.cache/') : n
 const DEFAULT_LOCAL_MODEL_PATH = '/models/';
 const localModelPath = RUNNING_LOCALLY ? path.join(dirname__, DEFAULT_LOCAL_MODEL_PATH) : DEFAULT_LOCAL_MODEL_PATH;
 
+// Ensure default fetch is called with the correct receiver in browser environments.
+const DEFAULT_FETCH = typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : undefined;
+
 /**
  * Log levels for controlling output verbosity.
  *
@@ -230,7 +235,7 @@ export const env = {
     cacheKey: 'transformers-cache',
 
     /////////////////// Custom fetch /////////////////////
-    fetch: fetch,
+    fetch: DEFAULT_FETCH,
 
     //////////////////////////////////////////////////////
 };


### PR DESCRIPTION
Follow-up to https://github.com/huggingface/transformers.js/pull/1538, specific to in-browser use.

Without binding to globalThis, we get this error:
```
Uncaught TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
```
