### PR TITLE
[deno] Support both wgpu and dawn webgpu backends

### DIFF
--- a/packages/transformers/scripts/build/plugins/ignoreModulesPlugin.mjs
+++ b/packages/transformers/scripts/build/plugins/ignoreModulesPlugin.mjs
@@ -16,18 +16,34 @@ export const ignoreModulesPlugin = (modules = []) => ({
     build.onResolve({ filter }, (args) => {
       return { path: args.path, namespace: "ignore-modules" };
     });
-    build.onLoad({ filter: /.*/, namespace: "ignore-modules" }, () => {
-      return {
-        contents: `
-          const noop = () => {};
-          const emptyObj = {};
-          export default emptyObj;
-          export const Readable = { fromWeb: noop };
-          export const pipeline = noop;
-          export const createWriteStream = noop;
-          export const createReadStream = noop;
-        `,
-      };
+    build.onLoad({ filter: /.*/, namespace: "ignore-modules" }, (args) => {
+      switch (args.path) {
+        case "node:stream":
+          return {
+            contents: `
+              const noop = () => {};
+              export default {};
+              export const Readable = { fromWeb: noop };
+            `,
+          };
+        case "node:stream/promises":
+          return {
+            contents: `
+              const noop = () => {};
+              export default {};
+              export const pipeline = noop;
+            `,
+          };
+        case "node:fs":
+        case "node:path":
+        case "node:url":
+        case "sharp":
+        case "onnxruntime-node":
+        default:
+          return {
+            contents: `export default {};`,
+          };
+      }
     });
   },
 });

--- a/packages/transformers/src/backends/utils/cacheWasm.js
+++ b/packages/transformers/src/backends/utils/cacheWasm.js
@@ -77,7 +77,8 @@ export async function loadWasmFactory(libURL) {
         let code = await response.text();
         // Fix relative paths when loading factory from blob, overwrite import.meta.url with actual baseURL
         const baseUrl = libURL.split('/').slice(0, -1).join('/');
-        code = code.replace(/import\.meta\.url/g, `"${baseUrl}"`);
+        code = code.replaceAll('import.meta.url', `"${baseUrl}"`);
+        code = code.replaceAll('globalThis.process?.versions?.node', 'false');
         const blob = new Blob([code], { type: 'text/javascript' });
         return URL.createObjectURL(blob);
     } catch (error) {

--- a/packages/transformers/src/env.js
+++ b/packages/transformers/src/env.js
@@ -28,14 +28,18 @@ import url from 'node:url';
 
 const VERSION = '4.0.0-next.4';
 
-const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
-const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
 const IS_FS_AVAILABLE = !isEmpty(fs);
 const IS_PATH_AVAILABLE = !isEmpty(path);
+const IS_WEB_CACHE_AVAILABLE = typeof self !== 'undefined' && 'caches' in self;
 
 // Runtime detection
 const IS_DENO_RUNTIME = typeof globalThis.Deno !== 'undefined';
 const IS_BUN_RUNTIME = typeof globalThis.Bun !== 'undefined';
+
+const IS_DENO_WEB_RUNTIME = IS_DENO_RUNTIME && IS_WEB_CACHE_AVAILABLE && !IS_FS_AVAILABLE;
+
+const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
+const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node' && !IS_DENO_WEB_RUNTIME;
 
 // Check if various APIs are available (depends on environment)
 const IS_BROWSER_ENV = typeof window !== 'undefined' && typeof window.document !== 'undefined';
@@ -44,7 +48,6 @@ const IS_WEBWORKER_ENV =
     ['DedicatedWorkerGlobalScope', 'ServiceWorkerGlobalScope', 'SharedWorkerGlobalScope'].includes(
         self.constructor?.name,
     );
-const IS_WEB_CACHE_AVAILABLE = typeof self !== 'undefined' && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = IS_NODE_ENV || (typeof navigator !== 'undefined' && 'gpu' in navigator);
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;
 const IS_CRYPTO_AVAILABLE = typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function';
@@ -139,9 +142,7 @@ const DEFAULT_LOCAL_MODEL_PATH = '/models/';
 const localModelPath = RUNNING_LOCALLY ? path.join(dirname__, DEFAULT_LOCAL_MODEL_PATH) : DEFAULT_LOCAL_MODEL_PATH;
 
 // Ensure default fetch is called with the correct receiver in browser environments.
-const DEFAULT_FETCH = typeof globalThis.fetch === 'function'
-    ? globalThis.fetch.bind(globalThis)
-    : undefined;
+const DEFAULT_FETCH = typeof globalThis.fetch === 'function' ? globalThis.fetch.bind(globalThis) : undefined;
 
 /**
  * Log levels for controlling output verbosity.
@@ -222,12 +223,12 @@ export const env = {
     remoteHost: 'https://huggingface.co/',
     remotePathTemplate: '{model}/resolve/{revision}/',
 
-    allowLocalModels: !(IS_BROWSER_ENV || IS_WEBWORKER_ENV),
+    allowLocalModels: !(IS_BROWSER_ENV || IS_WEBWORKER_ENV || IS_DENO_WEB_RUNTIME), // Default to true for non-web environments, false for web environments
     localModelPath: localModelPath,
     useFS: IS_FS_AVAILABLE,
 
     /////////////////// Cache settings ///////////////////
-    useBrowserCache: IS_WEB_CACHE_AVAILABLE && !IS_DENO_RUNTIME,
+    useBrowserCache: IS_WEB_CACHE_AVAILABLE,
 
     useFSCache: IS_FS_AVAILABLE,
     cacheDir: DEFAULT_CACHE_DIR,


### PR DESCRIPTION
This PR allows users to decide which backend they want to use for running webgpu applications in deno: [dawn](https://dawn.googlesource.com/dawn) or [wgpu](https://github.com/gfx-rs/wgpu/).

For example, if you run
```js
import { pipeline } from "npm:@huggingface/transformers@next";
```

you will use the dawn backend (via onnxruntime-node)

and if you do
```js
import { pipeline } from 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.0.0-next.5'; // unreleased; you can test out by building locally and pointing to ./dist/transformers.js
```

it will use the wgpu backend (via onnxruntime-web)

---

### HOWEVER

@crowlKats suggests that deno should default to use the wgpu backend, meaning that `npm:@huggingface/transformers@next` would use the wgpu backend, and users would need to explicitly request the dawn version. Open to suggestions here!

I ran a few tests, which show that the dawn backend is significantly faster in most cases. For example, a simple text embedding model produces these results:
```
═══════════════════════════════════════════════════════════════════
  BENCHMARK RESULTS  (mean ms, lower is better)
═══════════════════════════════════════════════════════════════════
Batch  Seq   Dawn (ms)   WGPU (ms)     Speedup
──────────────────────────────────────────────────
1      1     3.0         19.1          0.15x
1      8     3.4         17.8          0.19x
1      16    2.9         18.9          0.16x
1      32    3.1         18.7          0.17x
1      64    3.5         19.0          0.18x
1      128   4.5         19.6          0.23x
1      256   8.6         20.6          0.42x
1      512   16.7        25.8          0.65x
2      1     2.2         18.8          0.12x
2      8     2.4         19.1          0.12x
2      16    3.0         19.6          0.15x
2      32    3.4         19.6          0.17x
2      64    3.7         18.8          0.20x
2      128   5.7         20.5          0.28x
2      256   10.8        23.6          0.46x
2      512   24.1        34.7          0.70x
4      1     2.2         18.9          0.12x
4      8     2.5         18.6          0.13x
4      16    3.0         18.9          0.16x
4      32    3.5         19.1          0.18x
4      64    4.8         20.4          0.24x
4      128   7.1         22.1          0.32x
4      256   15.0        31.1          0.48x
4      512   54.4        53.4          1.02x
8      1     2.3         19.8          0.12x
8      8     2.8         19.7          0.14x
8      16    3.4         20.0          0.17x
8      32    4.0         20.2          0.20x
8      64    5.5         21.9          0.25x
8      128   10.6        28.2          0.38x
8      256   32.5        46.2          0.70x
8      512   110.4       85.6          1.29x
16     1     2.7         20.1          0.14x
16     8     3.7         19.7          0.19x
16     16    5.2         20.6          0.25x
16     32    5.4         21.4          0.25x
16     64    8.7         27.2          0.32x
16     128   22.4        40.4          0.55x
16     256   64.8        73.3          0.88x
16     512   227.8       167.1         1.36x
32     1     2.9         20.3          0.14x
32     8     5.9         19.6          0.30x
32     16    6.7         25.4          0.26x
32     32    9.0         27.4          0.33x
32     64    16.7        39.8          0.42x
32     128   42.0        65.2          0.64x
32     256   128.2       130.1         0.99x
32     512   453.8       312.1         1.45x
═══════════════════════════════════════════════════════════════════
```

