### PR TITLE
[deno via CDN] Fix simultaneous multi-session loading (e.g., VLMs) and d support usage for image loading

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -176,8 +176,6 @@ export function deviceToExecutionProviders(device = null) {
     throw new Error(`Unsupported device: "${device}". Should be one of: ${supportedDevices.join(', ')}.`);
 }
 
-const IS_WEB_ENV = apis.IS_BROWSER_ENV || apis.IS_WEBWORKER_ENV;
-
 /**
  * Currently, Transformers.js doesn't support simultaneous loading of sessions in WASM/WebGPU.
  * For this reason, we need to chain the loading calls.
@@ -274,7 +272,7 @@ export async function createInferenceSession(buffer_or_path, session_options, se
             logSeverityLevel,
             ...session_options,
         });
-    const session = await (IS_WEB_ENV ? (webInitChain = webInitChain.then(load)) : load());
+    const session = await (apis.IS_WEB_ENV ? (webInitChain = webInitChain.then(load)) : load());
     session.config = session_config;
     return session;
 }
@@ -294,7 +292,7 @@ let webInferenceChain = Promise.resolve();
  */
 export async function runInferenceSession(session, ortFeed) {
     const run = () => session.run(ortFeed);
-    const output = await (IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run());
+    const output = await (apis.IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run());
     return output;
 }
 
@@ -306,41 +304,8 @@ export async function runInferenceSession(session, ortFeed) {
 export function isONNXTensor(x) {
     return x instanceof ONNX.Tensor;
 }
-
 /** @type {import('onnxruntime-common').Env} */
 const ONNX_ENV = ONNX?.env;
-if (ONNX_ENV?.wasm) {
-    // Initialize wasm backend with suitable default settings.
-
-    // (Optional) Set path to wasm files. This will override the default path search behavior of onnxruntime-web.
-    // By default, we only do this if we are not in a service worker and the wasmPaths are not already set.
-    if (
-        // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
-        !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope) &&
-        ONNX_ENV.versions?.web &&
-        !ONNX_ENV.wasm.wasmPaths
-    ) {
-        const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX_ENV.versions.web}/dist/`;
-
-        ONNX_ENV.wasm.wasmPaths = apis.IS_SAFARI
-            ? {
-                  mjs: `${wasmPathPrefix}ort-wasm-simd-threaded.mjs`,
-                  wasm: `${wasmPathPrefix}ort-wasm-simd-threaded.wasm`,
-              }
-            : {
-                  mjs: `${wasmPathPrefix}ort-wasm-simd-threaded.asyncify.mjs`,
-                  wasm: `${wasmPathPrefix}ort-wasm-simd-threaded.asyncify.wasm`,
-              };
-    }
-
-    // Users may wish to proxy the WASM backend to prevent the UI from freezing,
-    // However, this is not necessary when using WebGPU, so we default to false.
-    ONNX_ENV.wasm.proxy = false;
-}
-
-if (ONNX_ENV?.webgpu) {
-    ONNX_ENV.webgpu.powerPreference = 'high-performance';
-}
 
 /**
  * Check if ONNX's WASM backend is being proxied.
@@ -351,21 +316,56 @@ export function isONNXProxy() {
     return ONNX_ENV?.wasm?.proxy;
 }
 
-/**
- * A function to map Transformers.js log levels to ONNX Runtime log severity
- * levels, and set the log level environment variable in ONNX Runtime.
- * @param {number} logLevel The log level to set.
- */
-function setLogLevel(logLevel) {
-    const severityLevel = getOnnxLogSeverityLevel(logLevel);
-    ONNX_ENV.logLevel = ONNX_LOG_LEVEL_NAMES[severityLevel];
+if (ONNX_ENV) {
+    if (ONNX_ENV.wasm) {
+        // Initialize wasm backend with suitable default settings.
+
+        // (Optional) Set path to wasm files. This will override the default path search behavior of onnxruntime-web.
+        // By default, we only do this if we are not in a service worker and the wasmPaths are not already set.
+        if (
+            // @ts-ignore Cannot find name 'ServiceWorkerGlobalScope'.ts(2304)
+            !(typeof ServiceWorkerGlobalScope !== 'undefined' && self instanceof ServiceWorkerGlobalScope) &&
+            ONNX_ENV.versions?.web &&
+            !ONNX_ENV.wasm.wasmPaths
+        ) {
+            const wasmPathPrefix = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ONNX_ENV.versions.web}/dist/`;
+
+            ONNX_ENV.wasm.wasmPaths = apis.IS_SAFARI
+                ? {
+                      mjs: `${wasmPathPrefix}ort-wasm-simd-threaded.mjs`,
+                      wasm: `${wasmPathPrefix}ort-wasm-simd-threaded.wasm`,
+                  }
+                : {
+                      mjs: `${wasmPathPrefix}ort-wasm-simd-threaded.asyncify.mjs`,
+                      wasm: `${wasmPathPrefix}ort-wasm-simd-threaded.asyncify.wasm`,
+                  };
+        }
+
+        // Users may wish to proxy the WASM backend to prevent the UI from freezing,
+        // However, this is not necessary when using WebGPU, so we default to false.
+        ONNX_ENV.wasm.proxy = false;
+    }
+
+    if (ONNX_ENV.webgpu) {
+        ONNX_ENV.webgpu.powerPreference = 'high-performance';
+    }
+
+    /**
+     * A function to map Transformers.js log levels to ONNX Runtime log severity
+     * levels, and set the log level environment variable in ONNX Runtime.
+     * @param {number} logLevel The log level to set.
+     */
+    function setLogLevel(logLevel) {
+        const severityLevel = getOnnxLogSeverityLevel(logLevel);
+        ONNX_ENV.logLevel = ONNX_LOG_LEVEL_NAMES[severityLevel];
+    }
+
+    // Set the initial log level to be the default Transformers.js log level.
+    setLogLevel(env.logLevel ?? LogLevel.WARNING);
+
+    // Expose ONNX environment variables to `env.backends.onnx`
+    env.backends.onnx = {
+        ...ONNX_ENV,
+        setLogLevel,
+    };
 }
-
-// Set the initial log level to be the default Transformers.js log level.
-setLogLevel(env.logLevel ?? LogLevel.WARNING);
-
-// Expose ONNX environment variables to `env.backends.onnx`
-env.backends.onnx = {
-    ...ONNX_ENV,
-    setLogLevel,
-};

--- a/packages/transformers/src/env.js
+++ b/packages/transformers/src/env.js
@@ -48,6 +48,8 @@ const IS_WEBWORKER_ENV =
     ['DedicatedWorkerGlobalScope', 'ServiceWorkerGlobalScope', 'SharedWorkerGlobalScope'].includes(
         self.constructor?.name,
     );
+const IS_WEB_ENV = IS_BROWSER_ENV || IS_WEBWORKER_ENV || IS_DENO_WEB_RUNTIME;
+
 const IS_WEBGPU_AVAILABLE = IS_NODE_ENV || (typeof navigator !== 'undefined' && 'gpu' in navigator);
 const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;
 const IS_CRYPTO_AVAILABLE = typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function';
@@ -89,6 +91,9 @@ export const apis = Object.freeze({
 
     /** Whether we are running in a web worker environment */
     IS_WEBWORKER_ENV,
+
+    /** Whether we are running in a web-like environment (browser, web worker, or Deno web runtime) */
+    IS_WEB_ENV,
 
     /** Whether the Cache API is available */
     IS_WEB_CACHE_AVAILABLE,

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -39,7 +39,7 @@ export { MAX_EXTERNAL_DATA_CHUNKS } from './hub/constants.js';
  * @typedef {Object} ModelSpecificPretrainedOptions Options for loading a pretrained model.
  * @property {string} [subfolder='onnx'] In case the relevant files are located inside a subfolder of the model repo on huggingface.co,
  * you can specify the folder name here.
- * @property {string} [model_file_name=null] If specified, load the model with this name (excluding the .onnx suffix). Currently only valid for encoder- or decoder-only models.
+ * @property {string} [model_file_name=null] If specified, load the model with this name (excluding the dtype and .onnx suffixes). Currently only valid for encoder- or decoder-only models.
  * @property {import("./devices.js").DeviceType|Record<string, import("./devices.js").DeviceType>} [device=null] The device to run the model on. If not specified, the device will be chosen from the environment settings.
  * @property {import("./dtypes.js").DataType|Record<string, import("./dtypes.js").DataType>} [dtype=null] The data type to use for the model. If not specified, the data type will be chosen from the environment settings.
  * @property {ExternalData|Record<string, ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).

--- a/packages/transformers/src/utils/image.js
+++ b/packages/transformers/src/utils/image.js
@@ -20,12 +20,11 @@ import { logger } from './logger.js';
 let createCanvasFunction;
 let ImageDataClass;
 let loadImageFunction;
-const IS_BROWSER_OR_WEBWORKER = apis.IS_BROWSER_ENV || apis.IS_WEBWORKER_ENV;
-if (IS_BROWSER_OR_WEBWORKER) {
+if (apis.IS_WEB_ENV) {
     // Running in browser or web-worker
     createCanvasFunction = (/** @type {number} */ width, /** @type {number} */ height) => {
         if (!self.OffscreenCanvas) {
-            throw new Error('OffscreenCanvas not supported by this browser.');
+            throw new Error('OffscreenCanvas not supported by this environment.');
         }
         return new self.OffscreenCanvas(width, height);
     };
@@ -134,7 +133,7 @@ export class RawImage {
      * @returns {RawImage} The image object.
      */
     static fromCanvas(canvas) {
-        if (!IS_BROWSER_OR_WEBWORKER) {
+        if (!apis.IS_WEB_ENV) {
             throw new Error('fromCanvas() is only supported in browser environments.');
         }
 
@@ -165,7 +164,7 @@ export class RawImage {
      * @returns {Promise<RawImage>} The image object.
      */
     static async fromBlob(blob) {
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             // Running in environment with canvas
             const img = await loadImageFunction(blob);
 
@@ -379,7 +378,7 @@ export class RawImage {
             height = (width / this.width) * this.height;
         }
 
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             // TODO use `resample` in browser environment
 
             // Store number of channels before resizing
@@ -453,7 +452,7 @@ export class RawImage {
             return this;
         }
 
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             // Store number of channels before padding
             const numChannels = this.channels;
 
@@ -495,7 +494,7 @@ export class RawImage {
         const crop_width = x_max - x_min + 1;
         const crop_height = y_max - y_min + 1;
 
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             // Store number of channels before resizing
             const numChannels = this.channels;
 
@@ -542,7 +541,7 @@ export class RawImage {
         const width_offset = (this.width - crop_width) / 2;
         const height_offset = (this.height - crop_height) / 2;
 
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             // Store number of channels before resizing
             const numChannels = this.channels;
 
@@ -650,7 +649,7 @@ export class RawImage {
     }
 
     async toBlob(type = 'image/png', quality = 1) {
-        if (!IS_BROWSER_OR_WEBWORKER) {
+        if (!apis.IS_WEB_ENV) {
             throw new Error('toBlob() is only supported in browser environments.');
         }
 
@@ -673,7 +672,7 @@ export class RawImage {
     }
 
     toCanvas() {
-        if (!IS_BROWSER_OR_WEBWORKER) {
+        if (!apis.IS_WEB_ENV) {
             throw new Error('toCanvas() is only supported in browser environments.');
         }
 
@@ -774,7 +773,7 @@ export class RawImage {
      * @returns {Promise<void>}
      */
     async save(path) {
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             if (apis.IS_WEBWORKER_ENV) {
                 throw new Error('Unable to save an image from a Web Worker.');
             }
@@ -799,7 +798,7 @@ export class RawImage {
      * @returns {import('sharp').Sharp} The Sharp instance.
      */
     toSharp() {
-        if (IS_BROWSER_OR_WEBWORKER) {
+        if (apis.IS_WEB_ENV) {
             throw new Error('toSharp() is only supported in server-side environments.');
         }
 


### PR DESCRIPTION
Encountered these issue when loading Qwen3.5 and LFM2-VL in Deno:

1. `Error: another WebGPU EP inference session is being created.`
2. Image loading (which will work when OffscrenCanvas is supported in Deno). Opening PR early in anticipation for https://github.com/denoland/deno/pull/29357.

Note: This does not effect usage via node environment (default). Neither issue occurs there.