### PR TITLE
feat: add fast boolean `is_cached` / `is_pipeline_cached`, closes #1554

### DIFF
--- a/packages/transformers/src/utils/model_registry/ModelRegistry.js
+++ b/packages/transformers/src/utils/model_registry/ModelRegistry.js
@@ -49,8 +49,12 @@
  * const modelId = "onnx-community/Qwen3-0.6B-ONNX";
  * const options = { dtype: "q4" };
  *
- * // Check if the model is cached (probably false)
- * let cacheStatus = await ModelRegistry.is_cached(modelId, options);
+ * // Quickly check if the model is cached (probably false)
+ * let cached = await ModelRegistry.is_cached(modelId, options);
+ * console.log(cached); // false
+ *
+ * // Get per-file cache detail
+ * let cacheStatus = await ModelRegistry.is_cached_files(modelId, options);
  * console.log(cacheStatus);
  * // {
  * //   allCached: false,
@@ -66,12 +70,8 @@
  * console.log(output[0].generated_text.at(-1).content); // <think>...</think>\n\nThe capital of France is **Paris**.
  *
  * // Check if the model is cached (should be true now)
- * cacheStatus = await ModelRegistry.is_cached(modelId, options);
- * console.log(cacheStatus);
- * // {
- * //   allCached: true,
- * //   files: [ { file: 'config.json', cached: true }, { file: 'onnx/model_q4.onnx', cached: true }, { file: 'generation_config.json', cached: true }, { file: 'tokenizer.json', cached: true }, { file: 'tokenizer_config.json', cached: true } ]
- * // }
+ * cached = await ModelRegistry.is_cached(modelId, options);
+ * console.log(cached); // true
  *
  * // Clear the cache
  * const clearResult = await ModelRegistry.clear_cache(modelId, options);
@@ -83,12 +83,8 @@
  * // }
  *
  * // Check if the model is cached (should be false again)
- * cacheStatus = await ModelRegistry.is_cached(modelId, options);
- * console.log(cacheStatus);
- * // {
- * //   allCached: false,
- * //   files: [ { file: 'config.json', cached: true }, { file: 'onnx/model_q4.onnx', cached: false }, { file: 'generation_config.json', cached: false }, { file: 'tokenizer.json', cached: false }, { file: 'tokenizer_config.json', cached: false } ]
- * // }
+ * cached = await ModelRegistry.is_cached(modelId, options);
+ * console.log(cached); // false
  * ```
  *
  * @module utils/model_registry
@@ -99,7 +95,7 @@ import { get_pipeline_files } from './get_pipeline_files.js';
 import { get_model_files } from './get_model_files.js';
 import { get_tokenizer_files } from './get_tokenizer_files.js';
 import { get_processor_files } from './get_processor_files.js';
-import { is_cached, is_pipeline_cached } from './is_cached.js';
+import { is_cached, is_cached_files, is_pipeline_cached, is_pipeline_cached_files } from './is_cached.js';
 import { get_file_metadata } from './get_file_metadata.js';
 import { clear_cache, clear_pipeline_cache } from './clear_cache.js';
 
@@ -198,24 +194,74 @@ export class ModelRegistry {
     }
 
     /**
-     * Check if a model and all its required files are cached.
+     * Quickly checks if a model is fully cached by verifying `config.json` is present,
+     * then confirming all required files are cached.
+     * Returns a plain boolean — use `is_cached_files` if you need per-file detail.
      *
      * @param {string} modelId - The model id
      * @param {Object} [options] - Optional parameters
+     * @param {string} [options.cache_dir] - Custom cache directory
+     * @param {string} [options.revision] - Model revision (default: 'main')
+     * @param {import('../../configs.js').PretrainedConfig} [options.config] - Pre-loaded config
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
-     * @returns {Promise<import('./is_cached.js').CacheCheckResult>} Object with allCached boolean and files array with cache status
+     * @returns {Promise<boolean>} Whether all required files are cached
      *
      * @example
-     * const status = await ModelRegistry.is_cached('onnx-community/bert-base-uncased-ONNX');
-     * console.log(status.allCached); // true or false
+     * const cached = await ModelRegistry.is_cached('onnx-community/bert-base-uncased-ONNX');
+     * console.log(cached); // true or false
      */
     static async is_cached(modelId, options = {}) {
         return is_cached(modelId, options);
     }
 
     /**
-     * Check if all files for a specific pipeline task are cached.
+     * Checks if all files for a given model are already cached, with per-file detail.
+     * Automatically determines which files are needed using get_files().
+     *
+     * @param {string} modelId - The model id
+     * @param {Object} [options] - Optional parameters
+     * @param {string} [options.cache_dir] - Custom cache directory
+     * @param {string} [options.revision] - Model revision (default: 'main')
+     * @param {import('../../configs.js').PretrainedConfig} [options.config] - Pre-loaded config
+     * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
+     * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
+     * @returns {Promise<import('./is_cached.js').CacheCheckResult>} Object with allCached boolean and files array with cache status
+     *
+     * @example
+     * const status = await ModelRegistry.is_cached_files('onnx-community/bert-base-uncased-ONNX');
+     * console.log(status.allCached); // true or false
+     * console.log(status.files); // [{ file: 'config.json', cached: true }, ...]
+     */
+    static async is_cached_files(modelId, options = {}) {
+        return is_cached_files(modelId, options);
+    }
+
+    /**
+     * Quickly checks if all files for a specific pipeline task are cached by verifying
+     * `config.json` is present, then confirming all required files are cached.
+     * Returns a plain boolean — use `is_pipeline_cached_files` if you need per-file detail.
+     *
+     * @param {string} task - The pipeline task (e.g., "text-generation", "background-removal")
+     * @param {string} modelId - The model id
+     * @param {Object} [options] - Optional parameters
+     * @param {string} [options.cache_dir] - Custom cache directory
+     * @param {string} [options.revision] - Model revision (default: 'main')
+     * @param {import('../../configs.js').PretrainedConfig} [options.config] - Pre-loaded config
+     * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
+     * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
+     * @returns {Promise<boolean>} Whether all required files are cached
+     *
+     * @example
+     * const cached = await ModelRegistry.is_pipeline_cached('text-generation', 'onnx-community/gpt2-ONNX');
+     * console.log(cached); // true or false
+     */
+    static async is_pipeline_cached(task, modelId, options = {}) {
+        return is_pipeline_cached(task, modelId, options);
+    }
+
+    /**
+     * Checks if all files for a specific pipeline task are already cached, with per-file detail.
      * Automatically determines which components are needed based on the task.
      *
      * @param {string} task - The pipeline task (e.g., "text-generation", "background-removal")
@@ -229,11 +275,12 @@ export class ModelRegistry {
      * @returns {Promise<import('./is_cached.js').CacheCheckResult>} Object with allCached boolean and files array with cache status
      *
      * @example
-     * const status = await ModelRegistry.is_pipeline_cached('text-generation', 'onnx-community/gpt2-ONNX');
+     * const status = await ModelRegistry.is_pipeline_cached_files('text-generation', 'onnx-community/gpt2-ONNX');
      * console.log(status.allCached); // true or false
+     * console.log(status.files); // [{ file: 'config.json', cached: true }, ...]
      */
-    static async is_pipeline_cached(task, modelId, options = {}) {
-        return is_pipeline_cached(task, modelId, options);
+    static async is_pipeline_cached_files(task, modelId, options = {}) {
+        return is_pipeline_cached_files(task, modelId, options);
     }
 
     /**

--- a/packages/transformers/src/utils/model_registry/is_cached.js
+++ b/packages/transformers/src/utils/model_registry/is_cached.js
@@ -44,7 +44,51 @@ async function check_files_cache(modelId, files, options = {}) {
 }
 
 /**
- * Checks if all files for a given model are already cached.
+ * Internal helper to check whether a single file is cached.
+ * @private
+ * @param {string} modelId - The model id
+ * @param {string} filename - The file path to check
+ * @param {Object} options - Options including cache_dir
+ * @returns {Promise<boolean>}
+ */
+async function is_file_cached(modelId, filename, options = {}) {
+    const cache = await getCache(options?.cache_dir);
+    if (!cache) return false;
+    const { localPath, proposedCacheKey } = buildResourcePaths(modelId, filename, options, cache);
+    return !!(await checkCachedResource(cache, localPath, proposedCacheKey));
+}
+
+/**
+ * Quickly checks if a model is cached by verifying that `config.json` is present,
+ * then confirming all required files are cached.
+ * Returns a plain boolean — use `is_cached_files` if you need per-file detail.
+ *
+ * @param {string} modelId The model id (e.g., "Xenova/gpt2")
+ * @param {Object} [options] Optional parameters
+ * @param {string} [options.cache_dir] Custom cache directory
+ * @param {string} [options.revision] Model revision (default: 'main')
+ * @param {import('../../configs.js').PretrainedConfig} [options.config] Pre-loaded config
+ * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype] Override dtype
+ * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device] Override device
+ * @returns {Promise<boolean>} Whether all required files are cached
+ */
+export async function is_cached(modelId, options = {}) {
+    if (!modelId) {
+        throw new Error('modelId is required');
+    }
+
+    // Fast early-exit: if config.json is missing we can expect the rest not to be cached too.
+    if (!(await is_file_cached(modelId, 'config.json', options))) {
+        return false;
+    }
+
+    const files = await get_files(modelId, options);
+    const result = await check_files_cache(modelId, files, options);
+    return result.allCached;
+}
+
+/**
+ * Checks if all files for a given model are already cached, with per-file detail.
  * Automatically determines which files are needed using get_files().
  *
  * @param {string} modelId The model id (e.g., "Xenova/gpt2")
@@ -56,7 +100,7 @@ async function check_files_cache(modelId, files, options = {}) {
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device] Override device
  * @returns {Promise<CacheCheckResult>} Object with allCached boolean and files array with cache status
  */
-export async function is_cached(modelId, options = {}) {
+export async function is_cached_files(modelId, options = {}) {
     if (!modelId) {
         throw new Error('modelId is required');
     }
@@ -66,7 +110,40 @@ export async function is_cached(modelId, options = {}) {
 }
 
 /**
- * Checks if all files for a specific pipeline task are already cached.
+ * Quickly checks if all files for a specific pipeline task are cached by verifying
+ * that `config.json` is present, then confirming all required files are cached.
+ * Returns a plain boolean — use `is_pipeline_cached_files` if you need per-file detail.
+ *
+ * @param {string} task - The pipeline task (e.g., "text-generation", "image-classification")
+ * @param {string} modelId - The model id (e.g., "Xenova/gpt2")
+ * @param {Object} [options] - Optional parameters
+ * @param {string} [options.cache_dir] - Custom cache directory
+ * @param {string} [options.revision] - Model revision (default: 'main')
+ * @param {import('../../configs.js').PretrainedConfig} [options.config] - Pre-loaded config
+ * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype] - Override dtype
+ * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device] - Override device
+ * @returns {Promise<boolean>} Whether all required files are cached
+ */
+export async function is_pipeline_cached(task, modelId, options = {}) {
+    if (!task) {
+        throw new Error('task is required');
+    }
+    if (!modelId) {
+        throw new Error('modelId is required');
+    }
+
+    // Fast early-exit: if config.json is missing we can expect the rest not to be cached too.
+    if (!(await is_file_cached(modelId, 'config.json', options))) {
+        return false;
+    }
+
+    const files = await get_pipeline_files(task, modelId, options);
+    const result = await check_files_cache(modelId, files, options);
+    return result.allCached;
+}
+
+/**
+ * Checks if all files for a specific pipeline task are already cached, with per-file detail.
  * Automatically determines which components are needed based on the task.
  *
  * @param {string} task - The pipeline task (e.g., "text-generation", "image-classification")
@@ -79,7 +156,7 @@ export async function is_cached(modelId, options = {}) {
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device] - Override device
  * @returns {Promise<CacheCheckResult>} Object with allCached boolean and files array with cache status
  */
-export async function is_pipeline_cached(task, modelId, options = {}) {
+export async function is_pipeline_cached_files(task, modelId, options = {}) {
     if (!task) {
         throw new Error('task is required');
     }

--- a/packages/transformers/tests/utils/cache.test.js
+++ b/packages/transformers/tests/utils/cache.test.js
@@ -205,9 +205,20 @@ describe("Cache", () => {
 
     describe("is_cached", () => {
       it(
+        "should return a boolean",
+        async () => {
+          const cached = await ModelRegistry.is_cached(BERT_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          expect(typeof cached).toBe("boolean");
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+    });
+
+    describe("is_cached_files", () => {
+      it(
         "should return cache status with correct shape",
         async () => {
-          const status = await ModelRegistry.is_cached(BERT_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          const status = await ModelRegistry.is_cached_files(BERT_MODEL_ID, DEFAULT_MODEL_OPTIONS);
           expect(status).toHaveProperty("allCached");
           expect(typeof status.allCached).toBe("boolean");
           expect(status).toHaveProperty("files");
@@ -222,13 +233,34 @@ describe("Cache", () => {
         },
         MAX_TEST_EXECUTION_TIME,
       );
+
+      it(
+        "should agree with is_cached on allCached",
+        async () => {
+          const cached = await ModelRegistry.is_cached(BERT_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          const status = await ModelRegistry.is_cached_files(BERT_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          expect(cached).toBe(status.allCached);
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
     });
 
     describe("is_pipeline_cached", () => {
       it(
+        "should return a boolean for text-generation pipeline",
+        async () => {
+          const cached = await ModelRegistry.is_pipeline_cached("text-generation", LLAMA_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          expect(typeof cached).toBe("boolean");
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+    });
+
+    describe("is_pipeline_cached_files", () => {
+      it(
         "should return cache status for text-generation pipeline",
         async () => {
-          const status = await ModelRegistry.is_pipeline_cached("text-generation", LLAMA_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          const status = await ModelRegistry.is_pipeline_cached_files("text-generation", LLAMA_MODEL_ID, DEFAULT_MODEL_OPTIONS);
           expect(status).toHaveProperty("allCached");
           expect(typeof status.allCached).toBe("boolean");
           expect(status).toHaveProperty("files");
@@ -238,6 +270,16 @@ describe("Cache", () => {
             expect(entry).toHaveProperty("file");
             expect(entry).toHaveProperty("cached");
           }
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+
+      it(
+        "should agree with is_pipeline_cached on allCached",
+        async () => {
+          const cached = await ModelRegistry.is_pipeline_cached("text-generation", LLAMA_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          const status = await ModelRegistry.is_pipeline_cached_files("text-generation", LLAMA_MODEL_ID, DEFAULT_MODEL_OPTIONS);
+          expect(cached).toBe(status.allCached);
         },
         MAX_TEST_EXECUTION_TIME,
       );
@@ -358,6 +400,14 @@ describe("Cache", () => {
       );
 
       it(
+        "should throw for empty modelId in is_cached_files",
+        async () => {
+          await expect(ModelRegistry.is_cached_files("")).rejects.toThrow("modelId is required");
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+
+      it(
         "should throw for empty modelId in clear_cache",
         async () => {
           await expect(ModelRegistry.clear_cache("")).rejects.toThrow("modelId is required");
@@ -369,6 +419,14 @@ describe("Cache", () => {
         "should throw for empty task in is_pipeline_cached",
         async () => {
           await expect(ModelRegistry.is_pipeline_cached("", BERT_MODEL_ID)).rejects.toThrow("task is required");
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+
+      it(
+        "should throw for empty task in is_pipeline_cached_files",
+        async () => {
+          await expect(ModelRegistry.is_pipeline_cached_files("", BERT_MODEL_ID)).rejects.toThrow("task is required");
         },
         MAX_TEST_EXECUTION_TIME,
       );


### PR DESCRIPTION
Splits `is_cached` and `is_pipeline_cached` into two function pairs:

| Function | Returns |
|---|---|
| `is_cached(modelId, options)` | `Promise<boolean>` |
| `is_cached_files(modelId, options)` | `Promise<CacheCheckResult>` |
| `is_pipeline_cached(task, modelId, options)` | `Promise<boolean>` |
| `is_pipeline_cached_files(task, modelId, options)` | `Promise<CacheCheckResult>` |

The boolean variants short-circuit on `config.json`: if that file is not cached, `false` is returned immediately without enumerating all model files.

## Why two functions instead of an option flag

The alternative (`is_cached(modelId, { detail: true })`) was rejected because I dont like the idea of a function changing its return type based on a parameter value.
I know we do this at some places and yes, this can also be reflected in typesctipt types, but I still think having separate functions is a cleaner approach. This way its clear that `_files` returns the details for each file while the other just returns the boolean.
Separate functions keep types simple and make intent explicit at the call site.