### PR TITLE
added no-store to range request #1561

### DIFF
--- a/packages/transformers/src/utils/model_registry/get_file_metadata.js
+++ b/packages/transformers/src/utils/model_registry/get_file_metadata.js
@@ -34,7 +34,7 @@ async function fetch_file_head(urlOrPath) {
 
     const headers = getFetchHeaders(urlOrPath);
     headers.set('Range', 'bytes=0-0');
-    return env.fetch(urlOrPath, { method: 'GET', headers });
+    return env.fetch(urlOrPath, { method: 'GET', headers, cache: 'no-store' });
 }
 
 /**


### PR DESCRIPTION
closes https://github.com/huggingface/transformers.js/issues/1561

[Due to a bug](https://issues.chromium.org/issues/490137346), Chrome stores range-requests in its browser cache which means the main request fails afterward. This adds `cache: no-store` to the range-requests:

```
The no-store response directive indicates that any caches of any kind (private or shared) should not store this response.
```
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control