### PR TITLE
Add Voxtral Realtime 4B speech-to-text model support

### DIFF
--- a/packages/transformers/src/configs.js
+++ b/packages/transformers/src/configs.js
@@ -70,6 +70,7 @@ function getNormalizedConfig(config) {
         case 'idefics3':
         case 'ultravox':
         case 'voxtral':
+        case 'voxtral_realtime':
         case 'smolvlm':
         case 'gemma3n':
         case 'chatterbox':
@@ -131,6 +132,7 @@ function getNormalizedConfig(config) {
         case 'cohere':
         case 'cohere2':
         case 'mistral':
+        case 'voxtral_realtime_text':
         case 'starcoder2':
         case 'qwen2':
         case 'qwen2_moe':

--- a/packages/transformers/src/generation/logits_process.js
+++ b/packages/transformers/src/generation/logits_process.js
@@ -198,6 +198,34 @@ export class ForcedEOSTokenLogitsProcessor extends LogitsProcessor {
 }
 
 /**
+ * A LogitsProcessor that suppresses a list of tokens at every generation step.
+ */
+export class SuppressTokensLogitsProcessor extends LogitsProcessor {
+    /**
+     * @param {number[]} suppress_tokens The IDs of the tokens to suppress.
+     */
+    constructor(suppress_tokens) {
+        super();
+        this.suppress_tokens = suppress_tokens;
+    }
+
+    /**
+     * @param {bigint[][]} input_ids
+     * @param {Tensor} logits
+     * @returns {Tensor}
+     */
+    _call(input_ids, logits) {
+        for (let i = 0; i < input_ids.length; ++i) {
+            const batch_logits_data = /** @type {Float32Array} */ (logits[i].data);
+            for (const token_id of this.suppress_tokens) {
+                batch_logits_data[token_id] = -Infinity;
+            }
+        }
+        return logits;
+    }
+}
+
+/**
  * A LogitsProcessor that suppresses a list of tokens as soon as the `generate` function starts
  * generating using `begin_index` tokens. This should ensure that the tokens defined by
  * `begin_suppress_tokens` at not sampled at the begining of the generation.

--- a/packages/transformers/src/models/feature_extractors.js
+++ b/packages/transformers/src/models/feature_extractors.js
@@ -12,6 +12,7 @@ export * from './snac/feature_extraction_snac.js';
 export * from './speecht5/feature_extraction_speecht5.js';
 export * from './wav2vec2/feature_extraction_wav2vec2.js';
 export * from './wespeaker/feature_extraction_wespeaker.js';
+export * from './voxtral_realtime/feature_extraction_voxtral_realtime.js';
 export * from './whisper/feature_extraction_whisper.js';
 
 export { FeatureExtractor } from '../feature_extraction_utils.js';

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -21,6 +21,7 @@ import {
     LogitsProcessorList,
     ForcedBOSTokenLogitsProcessor,
     ForcedEOSTokenLogitsProcessor,
+    SuppressTokensLogitsProcessor,
     SuppressTokensAtBeginLogitsProcessor,
     NoRepeatNGramLogitsProcessor,
     RepetitionPenaltyLogitsProcessor,
@@ -669,9 +670,9 @@ export class PreTrainedModel extends Callable {
         //     ));
         // }
 
-        // if (generation_config.suppress_tokens !== null) {
-        //     processors.push(new SuppressTokensLogitsProcessor(generation_config.suppress_tokens));
-        // }
+        if (generation_config.suppress_tokens !== null) {
+            processors.push(new SuppressTokensLogitsProcessor(generation_config.suppress_tokens));
+        }
 
         if (generation_config.begin_suppress_tokens !== null) {
             const begin_index =

--- a/packages/transformers/src/models/models.js
+++ b/packages/transformers/src/models/models.js
@@ -158,6 +158,7 @@ export * from './t5/modeling_t5.js';
 export * from './table_transformer/modeling_table_transformer.js';
 export * from './trocr/modeling_trocr.js';
 export * from './ultravox/modeling_ultravox.js';
+export * from './voxtral_realtime/modeling_voxtral_realtime.js';
 export * from './unispeech/modeling_unispeech.js';
 export * from './unispeech_sat/modeling_unispeech_sat.js';
 export * from './vaultgemma/modeling_vaultgemma.js';

--- a/packages/transformers/src/models/processors.js
+++ b/packages/transformers/src/models/processors.js
@@ -22,6 +22,7 @@ export * from './smolvlm/processing_smolvlm.js';
 export * from './speecht5/processing_speecht5.js';
 export * from './ultravox/processing_ultravox.js';
 export * from './voxtral/processing_voxtral.js';
+export * from './voxtral_realtime/processing_voxtral_realtime.js';
 export * from './wav2vec2/processing_wav2vec2.js';
 export * from './wav2vec2_with_lm/processing_wav2vec2_with_lm.js';
 export * from './whisper/processing_whisper.js';

--- a/packages/transformers/src/models/registry.js
+++ b/packages/transformers/src/models/registry.js
@@ -375,6 +375,7 @@ const MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES = new Map([
 const MODEL_FOR_AUDIO_TEXT_TO_TEXT_MAPPING_NAMES = new Map([
     ['ultravox', 'UltravoxModel'],
     ['voxtral', 'VoxtralForConditionalGeneration'],
+    ['voxtral_realtime', 'VoxtralRealtimeForConditionalGeneration'],
 ]);
 
 const MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES = new Map([

--- a/packages/transformers/src/models/voxtral_realtime/feature_extraction_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/feature_extraction_voxtral_realtime.js
@@ -1,0 +1,87 @@
+import { FeatureExtractor, validate_audio_inputs } from '../../feature_extraction_utils.js';
+import { Tensor } from '../../utils/tensor.js';
+import { mel_filter_bank, spectrogram, window_function } from '../../utils/audio.js';
+
+export class VoxtralRealtimeFeatureExtractor extends FeatureExtractor {
+    constructor(config) {
+        super(config);
+
+        const num_frequency_bins = Math.floor(1 + this.config.n_fft / 2);
+        this.config.mel_filters ??= mel_filter_bank(
+            num_frequency_bins,
+            this.config.feature_size, // 128
+            0.0,
+            8000.0, // max_frequency
+            this.config.sampling_rate, // 16000
+            'slaney',
+            'slaney',
+        );
+
+        this.window = window_function(this.config.n_fft, 'hann');
+    }
+
+    /**
+     * Computes log-Mel spectrogram features for VoxtralRealtime.
+     * Uses log10 with global_log_mel_max normalization (same as Whisper but with fixed max).
+     * @param {Float32Array|Float64Array} waveform
+     * @returns {Promise<Tensor>}
+     */
+    async _extract_fbank_features(waveform) {
+        const features = await spectrogram(
+            waveform,
+            this.window,
+            this.config.n_fft, // 400
+            this.config.hop_length, // 160
+            {
+                power: 2.0,
+                mel_filters: this.config.mel_filters,
+                log_mel: 'log10',
+                max_num_frames: null,
+            },
+        );
+
+        // Remove the last time frame to match Python's stft[..., :-1]
+        let result = features.slice(null, [0, -1]);
+
+        // Apply normalization
+        const maxValue = this.config.global_log_mel_max ?? 1.5;
+        const data = /** @type {Float32Array} */ (result.data);
+        for (let i = 0; i < data.length; ++i) {
+            data[i] = (Math.max(data[i], maxValue - 8.0) + 4.0) / 4.0;
+        }
+
+        // Pad to a multiple of 8 frames so the encoder's conv2 (stride=2) output
+        // is divisible by downsample_factor=4: floor(8k / 2) = 4k
+        const mel_frames = result.dims[1];
+        const padded_frames = Math.ceil(mel_frames / 8) * 8;
+        if (padded_frames !== mel_frames) {
+            const [mel_bins] = result.dims;
+            const silence = (Math.max(Math.log10(1e-10), maxValue - 8.0) + 4.0) / 4.0;
+            const padded_data = new Float32Array(mel_bins * padded_frames).fill(silence);
+            // Copy normalized data into the padded buffer
+            for (let m = 0; m < mel_bins; m++) {
+                padded_data.set(
+                    data.subarray(m * mel_frames, (m + 1) * mel_frames),
+                    m * padded_frames,
+                );
+            }
+            result = new Tensor('float32', padded_data, [mel_bins, padded_frames]);
+        }
+
+        return result;
+    }
+
+    /**
+     * @param {Float32Array|Float64Array} audio
+     * @returns {Promise<{ input_features: Tensor }>}
+     */
+    async _call(audio) {
+        validate_audio_inputs(audio, 'VoxtralRealtimeFeatureExtractor');
+
+        const features = await this._extract_fbank_features(audio);
+
+        return {
+            input_features: features.unsqueeze_(0),
+        };
+    }
+}

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -1,0 +1,157 @@
+import { PreTrainedModel, getPastLength, decoder_forward } from '../modeling_utils.js';
+import { sessionRun } from '../session.js';
+import { Tensor } from '../../utils/tensor.js';
+
+const ENCODER_NUM_LAYERS = 32;
+const ENCODER_NUM_HEADS = 32;
+const ENCODER_HEAD_DIM = 64;
+const PADDING_CACHE_DIM = 1408; // conv1.in_channels (128) + conv1.out_channels (1280)
+const EOS_TOKEN_ID = 2;
+
+export class VoxtralRealtimePreTrainedModel extends PreTrainedModel {
+    forward_params = ['input_ids', 'attention_mask', 'position_ids', 'audio_values', 'past_key_values'];
+}
+
+export class VoxtralRealtimeForConditionalGeneration extends VoxtralRealtimePreTrainedModel {
+    /** @type {Tensor|null} Full audio embeddings [1, n_audio, 3072] */
+    _audio_embeds = null;
+
+    /**
+     * Encode audio through the ONNX merged encoder (conv + transformer + projector).
+     * Returns audio embeddings of shape [batch, n_audio, 3072].
+     */
+    async encode_audio({ audio_values }) {
+        const batch_size = audio_values.dims[0];
+        const mel_frames = audio_values.dims[2];
+        const seq_len = Math.floor(mel_frames / 2);
+
+        const attention_mask = new Tensor(
+            'int64',
+            new BigInt64Array(batch_size * seq_len).fill(1n),
+            [batch_size, seq_len],
+        );
+        const position_ids_data = new BigInt64Array(batch_size * seq_len);
+        for (let b = 0; b < batch_size; b++) {
+            for (let i = 0; i < seq_len; i++) {
+                position_ids_data[b * seq_len + i] = BigInt(i);
+            }
+        }
+        const position_ids = new Tensor('int64', position_ids_data, [batch_size, seq_len]);
+
+        const past_padding_cache = new Tensor(
+            'float32',
+            new Float32Array(batch_size * PADDING_CACHE_DIM * 2),
+            [batch_size, PADDING_CACHE_DIM, 2],
+        );
+
+        const feeds = { input_features: audio_values, attention_mask, position_ids, past_padding_cache };
+        for (let i = 0; i < ENCODER_NUM_LAYERS; i++) {
+            const empty = new Tensor(
+                'float32',
+                new Float32Array(0),
+                [batch_size, ENCODER_NUM_HEADS, 0, ENCODER_HEAD_DIM],
+            );
+            feeds[`past_key_values.${i}.key`] = empty;
+            feeds[`past_key_values.${i}.value`] = empty;
+        }
+
+        const result = await sessionRun(this.sessions['audio_encoder'], feeds);
+        return result.audio_embeds;
+    }
+
+    /**
+     * Custom forward that adds audio embeddings at EVERY generation step.
+     *
+     * VoxtralRealtime architecture requires:
+     *   embed = audio_embed[pos] + text_embed(token)
+     * at every position — not just during prefill like standard multimodal models.
+     *
+     * Flow:
+     *   1. Prefill: audio_embeds[:, :L, :] + embed_tokens(prefix_ids)
+     *   2. Each generation step at position pos: audio_embeds[:, pos, :] + embed_tokens(prev_token)
+     *   3. Force EOS when pos >= n_audio (all audio consumed)
+     */
+    async forward(params) {
+        const {
+            input_ids = null,
+            attention_mask = null,
+            position_ids = null,
+            inputs_embeds = null,
+            past_key_values = null,
+            generation_config = null,
+            logits_processor = null,
+            audio_values = null,
+            ...kwargs
+        } = params;
+
+        let currentEmbeds = inputs_embeds;
+        let currentAttentionMask = attention_mask;
+
+        if (!currentEmbeds) {
+            currentEmbeds = await this.encode_text({ input_ids, ...kwargs });
+
+            if (audio_values && input_ids.dims[1] !== 1) {
+                // ── Prefill ──
+                const audioEmbeds = await this.encode_audio({ audio_values });
+                this._audio_embeds = audioEmbeds;
+
+                const textData = /** @type {Float32Array} */ (currentEmbeds.data);
+                const audioData = /** @type {Float32Array} */ (audioEmbeds.data);
+                const hiddenSize = currentEmbeds.dims[2];
+                const prefixLen = input_ids.dims[1];
+                const count = prefixLen * hiddenSize;
+
+                for (let i = 0; i < count; i++) {
+                    textData[i] += audioData[i];
+                }
+            } else if (past_key_values && this._audio_embeds) {
+                // ── Generation step ──
+                const pastLength = getPastLength(past_key_values);
+                const n_audio = this._audio_embeds.dims[1];
+
+                if (pastLength < n_audio) {
+                    const textData = /** @type {Float32Array} */ (currentEmbeds.data);
+                    const audioData = /** @type {Float32Array} */ (this._audio_embeds.data);
+                    const hiddenSize = currentEmbeds.dims[2];
+                    const audioOffset = pastLength * hiddenSize;
+
+                    for (let k = 0; k < hiddenSize; k++) {
+                        textData[k] += audioData[audioOffset + k];
+                    }
+                }
+            }
+        }
+
+        const outputs = await decoder_forward(
+            this,
+            {
+                inputs_embeds: currentEmbeds,
+                past_key_values,
+                attention_mask: currentAttentionMask,
+                position_ids,
+                generation_config,
+                logits_processor,
+            },
+            true,
+        );
+
+        // Force EOS when all audio positions are consumed
+        if (this._audio_embeds && past_key_values) {
+            const pastLength = getPastLength(past_key_values);
+            const n_audio = this._audio_embeds.dims[1];
+            if (pastLength >= n_audio) {
+                const logits = outputs.logits;
+                const logitsData = /** @type {Float32Array} */ (logits.data);
+                const vocabSize = logits.dims[logits.dims.length - 1];
+                const offset = logits.dims.length === 3
+                    ? (logits.dims[1] - 1) * vocabSize
+                    : 0;
+                for (let i = 0; i < vocabSize; i++) {
+                    logitsData[offset + i] = (i === EOS_TOKEN_ID) ? 0 : -Infinity;
+                }
+            }
+        }
+
+        return outputs;
+    }
+}

--- a/packages/transformers/src/models/voxtral_realtime/processing_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/processing_voxtral_realtime.js
@@ -1,0 +1,83 @@
+import { AutoFeatureExtractor } from '../auto/feature_extraction_auto.js';
+import { AutoTokenizer } from '../auto/tokenization_auto.js';
+import { Processor } from '../../processing_utils.js';
+import { Tensor } from '../../utils/tensor.js';
+
+// Streaming constants (from mistral_common AudioConfig + AudioEncoder)
+const TOKEN_BOS = 1;
+const TOKEN_STREAMING_PAD = 32;
+const N_LEFT_PAD_TOKENS = 32;
+const N_DELAY_TOKENS = 6;
+const RAW_AUDIO_LENGTH_PER_TOK = 1280; // sample_rate (16000) / frame_rate (12.5)
+const N_RIGHT_PAD_TOKENS = (N_DELAY_TOKENS + 1) + 10; // 17
+
+export class VoxtralRealtimeProcessor extends Processor {
+    static tokenizer_class = AutoTokenizer;
+    static feature_extractor_class = AutoFeatureExtractor;
+    static uses_processor_config = false;
+
+    /**
+     * Process audio for VoxtralRealtime offline transcription.
+     *
+     * Builds the streaming-format prefix tokens and applies audio padding
+     * matching the mistral_common offline streaming format.
+     *
+     * @param {string|null} _text Unused (kept for API compatibility).
+     * @param {Float32Array|Float32Array[]} audio Raw audio samples at 16kHz.
+     * @returns {Promise<{input_ids: Tensor, attention_mask: Tensor, audio_values: Tensor}>}
+     */
+    async _call(_text, audio = null, kwargs = {}) {
+        if (!audio) {
+            throw new Error('VoxtralRealtimeProcessor requires audio input.');
+        }
+        if (Array.isArray(audio)) {
+            if (audio.length > 1) {
+                throw new Error('Batched audio inputs are not supported yet.');
+            }
+            audio = audio[0];
+        }
+
+        // Apply streaming padding (offline mode: left pad + right pad + alignment)
+        const paddedAudio = this._pad_audio_streaming(audio);
+
+        // Extract mel spectrogram features
+        const features = await this.feature_extractor(paddedAudio);
+        const audio_values = features.input_features;
+
+        // Build prefix tokens: [BOS] + [STREAMING_PAD] * (N_LEFT_PAD_TOKENS + N_DELAY_TOKENS)
+        const prefixLength = 1 + N_LEFT_PAD_TOKENS + N_DELAY_TOKENS; // 39
+        const input_ids_data = new BigInt64Array(prefixLength);
+        const attention_mask_data = new BigInt64Array(prefixLength);
+        input_ids_data[0] = BigInt(TOKEN_BOS);
+        attention_mask_data[0] = 1n;
+        for (let i = 1; i < prefixLength; i++) {
+            input_ids_data[i] = BigInt(TOKEN_STREAMING_PAD);
+            attention_mask_data[i] = 1n;
+        }
+
+        return {
+            input_ids: new Tensor('int64', input_ids_data, [1, prefixLength]),
+            attention_mask: new Tensor('int64', attention_mask_data, [1, prefixLength]),
+            audio_values,
+        };
+    }
+
+    /**
+     * Apply streaming padding for offline mode (matching mistral_common AudioEncoder.pad).
+     *
+     * - Left pad: N_LEFT_PAD_TOKENS * RAW_AUDIO_LENGTH_PER_TOK (32 * 1280 = 40960 samples)
+     * - Right pad: alignment to RAW_AUDIO_LENGTH_PER_TOK + N_RIGHT_PAD_TOKENS * RAW_AUDIO_LENGTH_PER_TOK
+     *
+     * @param {Float32Array} audio Raw audio samples.
+     * @returns {Float32Array} Padded audio (silence = zeros).
+     */
+    _pad_audio_streaming(audio) {
+        const leftPad = N_LEFT_PAD_TOKENS * RAW_AUDIO_LENGTH_PER_TOK;
+        const alignPad = (RAW_AUDIO_LENGTH_PER_TOK - (audio.length % RAW_AUDIO_LENGTH_PER_TOK)) % RAW_AUDIO_LENGTH_PER_TOK;
+        const rightPad = alignPad + N_RIGHT_PAD_TOKENS * RAW_AUDIO_LENGTH_PER_TOK;
+
+        const padded = new Float32Array(leftPad + audio.length + rightPad);
+        padded.set(audio, leftPad);
+        return padded;
+    }
+}


### PR DESCRIPTION
Adds full inference pipeline for VoxtralRealtime (Voxtral-Mini-4B-Realtime-2602):
- Custom model class with per-step audio embedding addition
- Mel spectrogram feature extraction with streaming audio padding
- Processor with streaming prefix token format [BOS, PAD*38]
- Force-EOS when audio positions exhausted
- SuppressTokensLogitsProcessor for generation

Architecture: audio_encoder (ONNX) -> audio_embeds + text_embeds at every decoder step, not just during prefill like standard multimodal models.

Usage:
```js
import {
  VoxtralRealtimeForConditionalGeneration,
  VoxtralRealtimeProcessor,
} from "@huggingface/transformers";

const model_id = "onnx-community/Voxtral-Mini-4B-Realtime-2602-ONNX";
const processor = await VoxtralRealtimeProcessor.from_pretrained(model_id);
const model = await VoxtralRealtimeForConditionalGeneration.from_pretrained(
  model_id,
  { dtype: { audio_encoder: "q4", embed_tokens: "q4", decoder_model_merged: "q4" }, device: "webgpu" },
);

// audio: Float32Array of 16kHz PCM samples
const inputs = await processor(null, audio);
const outputIds = await model.generate({ ...inputs, max_new_tokens: 512 });

const promptLen = inputs.input_ids.dims[1];
const genIds = Array.from(outputIds.data).slice(promptLen).map(Number);
const text = processor.tokenizer.decode(
  genIds.filter((id) => id !== 32 && id !== 2),
  { skip_special_tokens: true },
);
```