### PR TITLE
Include `content-length` header in COS `Response`

### DIFF
--- a/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
+++ b/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
@@ -61,7 +61,7 @@ export class CrossOriginStorage {
             const blob = await handle.getFile();
             return new Response(blob, {
                 headers: {
-                    'content-length': String(blob.size),
+                    'Content-Length': String(blob.size),
                 },
             });
         } catch {


### PR DESCRIPTION
@nico-martin Quick follow-up to #1549 to navigate around a performance cliff. Without this header, we need to dynamically grow a buffer, which is really slow:

<img width="723" height="112" alt="Screenshot 2026-03-11 at 14 00 43" src="https://github.com/user-attachments/assets/5c2de330-faca-4b2d-aa53-eab440402694" />

With the header, the buffer is sized correctly from the start. 🚀
 