### PR TITLE
Fix: file size missing for cached files

### DIFF
--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -209,11 +209,14 @@ export async function storeCachedResource(path_or_repo_id, filename, cache, cach
         await cache.put(cacheKey, /** @type {Response} */ (response), wrapped_progress);
     } else if (typeof response !== 'string') {
         // NOTE: We use `new Response(buffer, ...)` instead of `response.clone()` to handle LFS files
+        // Explicitly set content-length from the buffer size, since the browser Cache API may strip it.
+        const headers = new Headers(response.headers);
+        headers.set('content-length', result.byteLength.toString());
         await cache
             .put(
                 cacheKey,
                 new Response(/** @type {any} */ (result), {
-                    headers: response.headers,
+                    headers,
                 }),
             )
             .catch((err) => {

--- a/packages/transformers/src/utils/model_registry/get_file_metadata.js
+++ b/packages/transformers/src/utils/model_registry/get_file_metadata.js
@@ -93,6 +93,7 @@ async function _get_file_metadata(path_or_repo_id, filename, options) {
                 if (typeof response !== 'string' && response.status !== 404) {
                     const size = response.headers.get('content-length');
                     const contentType = response.headers.get('content-type');
+
                     return {
                         exists: true,
                         size: size ? parseInt(size, 10) : undefined,


### PR DESCRIPTION
The browser Cache API strips `content-length` from cached responses, causing `get_file_metadata` to always return `size: undefined` for cache hits.

**Fix:** When storing a response in the browser cache, explicitly set `content-length` from the buffer's byte length before caching.
