### PR TITLE
Add get_available_dtypes to detect quantization levels for models

### DIFF
--- a/packages/transformers/src/utils/model_registry/ModelRegistry.js
+++ b/packages/transformers/src/utils/model_registry/ModelRegistry.js
@@ -98,6 +98,7 @@ import { get_processor_files } from './get_processor_files.js';
 import { is_cached, is_cached_files, is_pipeline_cached, is_pipeline_cached_files } from './is_cached.js';
 import { get_file_metadata } from './get_file_metadata.js';
 import { clear_cache, clear_pipeline_cache } from './clear_cache.js';
+import { get_available_dtypes } from './get_available_dtypes.js';
 
 /**
  * Static class for cache and file management operations.
@@ -191,6 +192,30 @@ export class ModelRegistry {
      */
     static async get_processor_files(modelId) {
         return get_processor_files(modelId);
+    }
+
+    /**
+     * Detects which quantization levels (dtypes) are available for a model
+     * by checking which ONNX files exist on the hub or locally.
+     *
+     * A dtype is considered available if all required model session files
+     * exist for that dtype.
+     *
+     * @param {string} modelId - The model id (e.g., "onnx-community/all-MiniLM-L6-v2-ONNX")
+     * @param {Object} [options] - Optional parameters
+     * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
+     * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string} [options.revision='main'] - Model revision
+     * @param {string} [options.cache_dir=null] - Custom cache directory
+     * @param {boolean} [options.local_files_only=false] - Only check local files
+     * @returns {Promise<string[]>} Array of available dtype strings (e.g., ['fp32', 'fp16', 'q4', 'q8'])
+     *
+     * @example
+     * const dtypes = await ModelRegistry.get_available_dtypes('onnx-community/all-MiniLM-L6-v2-ONNX');
+     * console.log(dtypes); // ['fp32', 'fp16', 'int8', 'uint8', 'q8', 'q4']
+     */
+    static async get_available_dtypes(modelId, options = {}) {
+        return get_available_dtypes(modelId, options);
     }
 
     /**

--- a/packages/transformers/src/utils/model_registry/get_available_dtypes.js
+++ b/packages/transformers/src/utils/model_registry/get_available_dtypes.js
@@ -1,0 +1,129 @@
+import { DATA_TYPES, DEFAULT_DTYPE_SUFFIX_MAPPING } from '../dtypes.js';
+import { get_file_metadata } from './get_file_metadata.js';
+import {
+    MODEL_TYPES,
+    MODEL_TYPE_MAPPING,
+    MODEL_MAPPING_NAMES,
+    getSessionsConfig,
+} from '../../models/modeling_utils.js';
+import { AutoConfig } from '../../configs.js';
+import { GITHUB_ISSUE_URL } from '../constants.js';
+import { logger } from '../logger.js';
+import { memoizePromise } from '../memoize_promise.js';
+
+/**
+ * @typedef {import('../../configs.js').PretrainedConfig} PretrainedConfig
+ */
+
+/**
+ * Returns a memoized AutoConfig for the given model ID and options.
+ * @param {string} modelId
+ * @param {Object} [options]
+ * @param {PretrainedConfig|null} [options.config=null]
+ * @param {string|null} [options.cache_dir=null]
+ * @param {boolean} [options.local_files_only=false]
+ * @param {string} [options.revision='main']
+ * @returns {Promise<PretrainedConfig>}
+ */
+function get_config(modelId, { config = null, cache_dir = null, local_files_only = false, revision = 'main' } = {}) {
+    if (config !== null) {
+        return AutoConfig.from_pretrained(modelId, { config, cache_dir, local_files_only, revision });
+    }
+    const key = JSON.stringify([modelId, cache_dir, local_files_only, revision]);
+    return memoizePromise(key, () =>
+        AutoConfig.from_pretrained(modelId, { config, cache_dir, local_files_only, revision }),
+    );
+}
+
+/**
+ * The dtypes to probe for availability (excludes 'auto' which is not a concrete dtype).
+ * @type {string[]}
+ */
+const CONCRETE_DTYPES = Object.keys(DEFAULT_DTYPE_SUFFIX_MAPPING);
+
+/**
+ * Detects which quantization levels (dtypes) are available for a model
+ * by checking which ONNX files exist on the hub or locally.
+ *
+ * A dtype is considered available if *all* required model session files
+ * exist for that dtype. For example, a Seq2Seq model needs both an encoder
+ * and decoder file — the dtype is only listed if both are present.
+ *
+ * @param {string} modelId The model id (e.g., "onnx-community/all-MiniLM-L6-v2-ONNX")
+ * @param {Object} [options] Optional parameters
+ * @param {PretrainedConfig} [options.config=null] Pre-loaded model config (optional, will be fetched if not provided)
+ * @param {string} [options.model_file_name=null] Override the model file name (excluding .onnx suffix)
+ * @param {string} [options.revision='main'] Model revision
+ * @param {string} [options.cache_dir=null] Custom cache directory
+ * @param {boolean} [options.local_files_only=false] Only check local files
+ * @returns {Promise<string[]>} Array of available dtype strings (e.g., ['fp32', 'fp16', 'q4', 'q8'])
+ */
+export async function get_available_dtypes(
+    modelId,
+    { config = null, model_file_name = null, revision = 'main', cache_dir = null, local_files_only = false } = {},
+) {
+    config = await get_config(modelId, { config, cache_dir, local_files_only, revision });
+
+    const subfolder = 'onnx';
+
+    // Determine model type (same logic as get_model_files)
+    let modelType;
+    const architectures = /** @type {string[]} */ (config.architectures || []);
+
+    let foundInMapping = false;
+    for (const arch of architectures) {
+        const mappedType = MODEL_TYPE_MAPPING.get(arch);
+        if (mappedType !== undefined) {
+            modelType = mappedType;
+            foundInMapping = true;
+            break;
+        }
+    }
+
+    if (!foundInMapping && config.model_type) {
+        const mappedType = MODEL_TYPE_MAPPING.get(config.model_type);
+        if (mappedType !== undefined) {
+            modelType = mappedType;
+            foundInMapping = true;
+        }
+
+        if (!foundInMapping) {
+            for (const mapping of Object.values(MODEL_MAPPING_NAMES)) {
+                if (mapping.has(config.model_type)) {
+                    modelType = MODEL_TYPE_MAPPING.get(mapping.get(config.model_type));
+                    foundInMapping = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!foundInMapping) {
+        modelType = MODEL_TYPES.EncoderOnly;
+    }
+
+    const { sessions } = getSessionsConfig(modelType, config, { model_file_name });
+
+    // Get all base names for model session files
+    const baseNames = Object.values(sessions);
+
+    // For each dtype, check if all session files exist
+    const metadataOptions = { revision, cache_dir, local_files_only };
+
+    // Probe all (dtype, baseName) combinations in parallel
+    const probeResults = await Promise.all(
+        CONCRETE_DTYPES.map(async (dtype) => {
+            const suffix = DEFAULT_DTYPE_SUFFIX_MAPPING[dtype] ?? '';
+            const allExist = await Promise.all(
+                baseNames.map(async (baseName) => {
+                    const filename = `${subfolder}/${baseName}${suffix}.onnx`;
+                    const metadata = await get_file_metadata(modelId, filename, metadataOptions);
+                    return metadata.exists;
+                }),
+            );
+            return { dtype, available: allExist.every(Boolean) };
+        }),
+    );
+
+    return probeResults.filter((r) => r.available).map((r) => r.dtype);
+}

--- a/packages/transformers/tests/utils/model_registry.test.js
+++ b/packages/transformers/tests/utils/model_registry.test.js
@@ -1,0 +1,44 @@
+import { ModelRegistry } from "../../src/transformers.js";
+
+const MAX_TEST_EXECUTION_TIME = 30_000;
+
+describe("ModelRegistry", () => {
+  describe("get_available_dtypes", () => {
+    it(
+      "should detect available dtypes for a model",
+      async () => {
+        const dtypes = await ModelRegistry.get_available_dtypes(
+          "onnx-community/all-MiniLM-L6-v2-ONNX",
+        );
+
+        // This model is known to have multiple quantization levels
+        expect(Array.isArray(dtypes)).toBe(true);
+        expect(dtypes.length).toBeGreaterThan(0);
+
+        // Should contain at least some common dtypes
+        // (fp32 is typically always available for ONNX models)
+        expect(dtypes).toContain("fp32");
+
+        // All returned values should be valid dtype strings
+        const validDtypes = ["fp32", "fp16", "int8", "uint8", "q8", "q4", "q4f16", "bnb4"];
+        for (const dtype of dtypes) {
+          expect(validDtypes).toContain(dtype);
+        }
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+
+    it(
+      "should return an empty array for a model with no ONNX files",
+      async () => {
+        // Use a model that likely doesn't have ONNX files
+        const dtypes = await ModelRegistry.get_available_dtypes(
+          "hf-internal-testing/tiny-random-GPTNeoForCausalLM",
+        );
+
+        expect(Array.isArray(dtypes)).toBe(true);
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a new `get_available_dtypes()` function to the ModelRegistry that detects which quantization levels (dtypes) are available for a model by checking which ONNX files exist on the Hugging Face Hub or locally.

## Key Changes
- **New utility function** `get_available_dtypes()` in `packages/transformers/src/utils/model_registry/get_available_dtypes.js`:
  - Probes for available quantization levels by checking ONNX file existence
  - Supports all concrete dtypes (fp32, fp16, int8, uint8, q8, q4, q4f16, bnb4)
  - Validates that ALL required session files exist for a dtype before marking it as available (important for multi-session models like Seq2Seq)
  - Uses memoization for config loading to avoid redundant fetches
  - Performs parallel probing of all dtype/file combinations for efficiency

- **ModelRegistry integration** in `packages/transformers/src/utils/model_registry/ModelRegistry.js`:
  - Exposes `get_available_dtypes()` as a static method on ModelRegistry
  - Includes comprehensive JSDoc with usage example

- **Test coverage** in `packages/transformers/tests/utils/model_registry.test.js`:
  - Tests detection of available dtypes for a known multi-quantization model
  - Tests graceful handling of models without ONNX files
  - Validates returned dtype strings against known valid values

## Implementation Details
- Reuses existing model type detection logic from `modeling_utils.js` to determine required session files
- Leverages `get_file_metadata()` to check file existence without downloading
- Supports optional pre-loaded config and custom cache directories for flexibility
- Returns empty array for models without ONNX files rather than throwing errors

https://claude.ai/code/session_01KDD4MYBMtZaanfXoY269wy