### PR TITLE
fix(onnx): pass externalData to session_options when using customCache in Node.js

### DIFF
--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -122,7 +122,7 @@ async function getSession(
         // However, when using a custom cache (which returns Uint8Array instead of a
         // file path), the ONNX runtime cannot find the files on disk, so we must
         // supply the data in-memory via session_options.externalData.
-        if (!apis.IS_NODE_ENV || externalData.some(item => typeof item !== 'string')) {
+        if (!apis.IS_NODE_ENV || externalData.some(item => item instanceof Uint8Array)) {
             session_options.externalData = externalData;
         }
     }


### PR DESCRIPTION
## Problem

When a model uses external data (e.g. `model.onnx_data`) and the user provides a `customCache` (which returns a `Uint8Array`/`Response` rather than a filesystem path), loading fails in Node.js with:

```
file_size: system cannot find the specified path: "model.onnx_data"
```

## Root Cause

`session.js` only sets `session_options.externalData` when `!IS_NODE_ENV`.

In Node.js with `useFSCache` this is intentional — the ONNX runtime locates `.onnx_data` files automatically relative to the on-disk model path.

But when `customCache` is used the data arrives as an in-memory `Uint8Array` (not a file path), so the runtime has no way to discover the sidecar files on disk.

## Fix

Check whether any resolved external-data entry is a `{path, data}` object (i.e. in-memory bytes from a custom cache). If so, pass `externalData` to `session_options` even in Node.js:

```javascript
// Before
if (externalData.length > 0 && !apis.IS_NODE_ENV) {
    session_options.externalData = externalData;
}

// After
if (externalData.length > 0) {
    if (!apis.IS_NODE_ENV || externalData.some(item => typeof item !== 'string')) {
        session_options.externalData = externalData;
    }
}
```

Fixes #1408
