### PR TITLE
fix(docs): Fix typo in WebGPU documentation

### DIFF
--- a/packages/transformers/docs/source/guides/webgpu.md
+++ b/packages/transformers/docs/source/guides/webgpu.md
@@ -85,4 +85,4 @@ console.log(output);
 
 ## Reporting bugs and providing feedback
 
-Due to the experimental nature of WebGPU, especially in non-Chromium browsers, you may experience issues when trying to run a model (even it it can run in WASM). If you do, please open [an issue on GitHub](https://github.com/huggingface/transformers.js/issues/new?title=[WebGPU]%20Error%20running%20MODEL_GOES_HERE&assignees=&labels=bug,webgpu&projects=&template=1_bug-report.yml) and we'll do our best to address it. Thanks!
+Due to the experimental nature of WebGPU, especially in non-Chromium browsers, you may experience issues when trying to run a model (even if it can run in WASM). If you do, please open [an issue on GitHub](https://github.com/huggingface/transformers.js/issues/new?title=[WebGPU]%20Error%20running%20MODEL_GOES_HERE&assignees=&labels=bug,webgpu&projects=&template=1_bug-report.yml) and we'll do our best to address it. Thanks!


### PR DESCRIPTION
Quick typo fix in WebGPU docs:

"even it it can run in WASM" -> "even if it can run in WASM"