### PR TITLE
Fix LlamaTokenizer to respect add_prefix_space when legacy=false

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -3442,12 +3442,21 @@ export class LlamaTokenizer extends PreTrainedTokenizer {
         super(tokenizerJSON, tokenizerConfig);
 
         this.legacy = tokenizerConfig.legacy ?? true;
+        this.add_prefix_space = tokenizerConfig.add_prefix_space ?? true;
+
+        // Respect padding_side from tokenizer config if provided
+        if (tokenizerConfig.padding_side) {
+            this.padding_side = tokenizerConfig.padding_side;
+        }
+
         if (!this.legacy) {
             // See https://github.com/huggingface/transformers/pull/24565 for more information
             this.normalizer = null;
+            // Respect add_prefix_space: use "never" when false, "first" when true (default)
+            const prepend_scheme = this.add_prefix_space ? "first" : "never";
             this.pre_tokenizer = new MetaspacePreTokenizer({
                 replacement: SPIECE_UNDERLINE,
-                prepend_scheme: "first",
+                prepend_scheme: prepend_scheme,
             });
         }
     }
@@ -3465,7 +3474,12 @@ export class LlamaTokenizer extends PreTrainedTokenizer {
             return super._encode_text(text);
         }
 
-        let tokens = super._encode_text(SPIECE_UNDERLINE + text.replaceAll(SPIECE_UNDERLINE, " "));
+        // Only prepend SPIECE_UNDERLINE when add_prefix_space is true
+        if (this.add_prefix_space) {
+            text = SPIECE_UNDERLINE + text.replaceAll(SPIECE_UNDERLINE, " ");
+        }
+
+        let tokens = super._encode_text(text);
         if (tokens.length > 1 && tokens[0] === SPIECE_UNDERLINE && this.special_tokens.includes(tokens[1])) {
             tokens = tokens.slice(1);
         }


### PR DESCRIPTION
## Description

This PR fixes #1612 where `LlamaTokenizer` was ignoring the `add_prefix_space` config option when `legacy=false`.

### Problem

When using models like `cl-nagoya/ruri-v3-30m` that have:
- `tokenizer_class=LlamaTokenizer`
- `legacy=false`
- `add_prefix_space=false`

The tokenizer was:
1. Hardcoding `prepend_scheme: "first"` instead of using `"never"` when `add_prefix_space=false`
2. Unconditionally prepending `▁` in `_encode_text()` even when `add_prefix_space=false`
3. Hardcoding `padding_side = "left"` instead of respecting the config

This caused tokenization mismatches with Python transformers, producing different token IDs (e.g., `Hello`=13085 vs `▁Hello`=33684).

### Changes

- Read `add_prefix_space` from tokenizer config (defaults to `true` for backward compatibility)
- Set `prepend_scheme` based on `add_prefix_space`: `"first"` when true, `"never"` when false
- Only prepend `SPIECE_UNDERLINE` in `_encode_text()` when `add_prefix_space=true`
- Respect `padding_side` from tokenizer config if provided

### Testing

Verified that:
- `add_prefix_space=false` → `prepend_scheme="never"`, no SPIECE_UNDERLINE prepended
- `add_prefix_space=true` → `prepend_scheme="first"`, SPIECE_UNDERLINE prepended
- `legacy=true` → behavior unchanged (no custom pre_tokenizer created)

Fixes #1612