### PR TITLE
fix: is_pipeline_cached for some models

### DIFF
--- a/packages/transformers/src/utils/model_registry/get_files.js
+++ b/packages/transformers/src/utils/model_registry/get_files.js
@@ -14,6 +14,7 @@ import { get_processor_files } from './get_processor_files.js';
  * @param {string|null} [options.model_file_name=null|null] Override the model file name (excluding .onnx suffix)
  * @param {boolean} [options.include_tokenizer=true] Whether to check for tokenizer files (set to false for vision-only models)
  * @param {boolean} [options.include_processor=true] Whether to check for processor files
+ * @param {number|null} [options.model_type_override=null] Override the resolved model type (one of MODEL_TYPES). Passed through to get_model_files.
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  */
 export async function get_files(
@@ -25,9 +26,10 @@ export async function get_files(
         model_file_name = null,
         include_tokenizer = true,
         include_processor = true,
+        model_type_override = null,
     } = {},
 ) {
-    const files = await get_model_files(modelId, { config, dtype, device, model_file_name });
+    const files = await get_model_files(modelId, { config, dtype, device, model_file_name, model_type_override });
 
     if (include_tokenizer) {
         const tokenizerFiles = await get_tokenizer_files(modelId);

--- a/packages/transformers/src/utils/model_registry/get_model_files.js
+++ b/packages/transformers/src/utils/model_registry/get_model_files.js
@@ -54,11 +54,18 @@ export function get_config(
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] Override dtype (use this if passing dtype to pipeline)
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] Override device (use this if passing device to pipeline)
  * @param {string} [options.model_file_name=null] Override the model file name (excluding .onnx suffix).
+ * @param {number|null} [options.model_type_override=null] Override the resolved model type (one of MODEL_TYPES). Used by get_pipeline_files to pass the type derived from the pipeline's auto class.
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  */
 export async function get_model_files(
     modelId,
-    { config = null, dtype: overrideDtype = null, device: overrideDevice = null, model_file_name = null } = {},
+    {
+        config = null,
+        dtype: overrideDtype = null,
+        device: overrideDevice = null,
+        model_file_name = null,
+        model_type_override = null,
+    } = {},
 ) {
     config = await get_config(modelId, { config });
 
@@ -74,8 +81,8 @@ export async function get_model_files(
     const rawDevice = overrideDevice ?? custom_config.device;
     let dtype = overrideDtype ?? custom_config.dtype;
 
-    // Infer model type from config
-    const modelType = resolve_model_type(config);
+    // Infer model type from config, or use the override provided by the caller (e.g., get_pipeline_files)
+    const modelType = model_type_override ?? resolve_model_type(config);
 
     const add_model_file = (fileName, baseName = null) => {
         baseName = baseName ?? fileName;

--- a/packages/transformers/src/utils/model_registry/get_pipeline_files.js
+++ b/packages/transformers/src/utils/model_registry/get_pipeline_files.js
@@ -3,6 +3,64 @@ import { get_config } from './get_model_files.js';
 import { resolve_model_type } from './resolve_model_type.js';
 import { getTextOnlySessions } from '../../models/session_config.js';
 import { SUPPORTED_TASKS, TASK_ALIASES } from '../../pipelines/index.js';
+import { MODEL_TYPE_MAPPING } from '../../models/modeling_utils.js';
+
+/**
+ * Determines the effective model type for a given pipeline task and model config by simulating
+ * the auto class resolution that `pipeline()` itself would perform.
+ *
+ * `resolve_model_type` uses `config.architectures` (e.g. `["Qwen3ForCausalLM"]`) which maps to
+ * `DecoderOnly` and includes `optional_configs` like `generation_config.json`. But a task like
+ * `feature-extraction` uses `AutoModel`, which iterates its `MODEL_CLASS_MAPPINGS` in order and
+ * finds the *base* model class (e.g. `Qwen3Model` → `DecoderOnlyWithoutHead`) — a type that has
+ * no `optional_configs`. This function replicates that lookup so the file list matches what the
+ * pipeline actually loads.
+ *
+ * Cross-architecture detection is also replicated: when a `ForCausalLM` class loads a model
+ * whose native architecture ends in `ForConditionalGeneration`, the native type is used instead
+ * (matching the logic in `resolveTypeConfig` in `modeling_utils.js`).
+ *
+ * @param {Object} taskConfig - The pipeline task config from SUPPORTED_TASKS.
+ * @param {import('../../configs.js').PretrainedConfig} config - The model config.
+ * @returns {number|null} The resolved MODEL_TYPES value, or null if unresolvable (fall back to resolve_model_type).
+ */
+function resolveEffectiveModelType(taskConfig, config) {
+    const { model_type } = config;
+    if (!model_type) return null;
+
+    // @ts-ignore - architectures is assigned dynamically via Object.assign in PretrainedConfig
+    const nativeArch = config.architectures?.[0];
+    // @ts-ignore - model is a dynamic property on SUPPORTED_TASKS entries
+    const autoClasses = Array.isArray(taskConfig.model) ? taskConfig.model : [taskConfig.model];
+
+    for (const autoClass of autoClasses) {
+        if (!autoClass?.MODEL_CLASS_MAPPINGS) continue;
+
+        for (const mapping of autoClass.MODEL_CLASS_MAPPINGS) {
+            const className = mapping.get(model_type);
+            if (className === undefined) continue;
+
+            let type = MODEL_TYPE_MAPPING.get(className);
+            if (type === undefined) continue;
+
+            // Replicate cross-architecture detection from resolveTypeConfig in modeling_utils.js:
+            // A ForCausalLM class loading a ForConditionalGeneration model uses the native type.
+            if (
+                nativeArch &&
+                nativeArch !== className &&
+                className.endsWith('ForCausalLM') &&
+                nativeArch.endsWith('ForConditionalGeneration')
+            ) {
+                const nativeType = MODEL_TYPE_MAPPING.get(nativeArch);
+                if (nativeType !== undefined) type = nativeType;
+            }
+
+            return type;
+        }
+    }
+
+    return null;
+}
 
 /**
  * Get all files needed for a specific pipeline task.
@@ -39,17 +97,28 @@ export async function get_pipeline_files(task, modelId, options = {}) {
     const include_tokenizer = type !== 'audio' && type !== 'image';
     const include_processor = type !== 'text';
 
+    // Resolve the config once up front so we can derive the effective model type.
+    // get_config is memoized, so this doesn't add a redundant network fetch.
+    const config = await get_config(modelId, options);
+
+    // Determine which model type the pipeline would actually load (based on its auto class), not
+    // just what config.architectures says. This prevents including optional config files (e.g.
+    // generation_config.json) that the pipeline never fetches for base-model tasks like
+    // feature-extraction.
+    const model_type_override = resolveEffectiveModelType(taskConfig, config);
+
     const files = await get_files(modelId, {
         ...options,
+        config,
         include_tokenizer,
         include_processor,
+        model_type_override,
     });
 
     // When loading multimodal models via the text-generation pipeline,
     // only load the sessions needed for text generation (embed_tokens, decoder_model_merged)
     if (task === 'text-generation') {
-        const config = await get_config(modelId, options);
-        const modelType = resolve_model_type(config);
+        const modelType = model_type_override ?? resolve_model_type(config);
         const textOnlySessions = getTextOnlySessions(modelType);
 
         if (textOnlySessions) {


### PR DESCRIPTION
Enhance ModelRegistry file retrieval by adding model_type_override parameter to get_files and get_model_files functions. This allows for more flexible model type resolution when loading files for pipelines.

Problem

`is_pipeline_cached("feature-extraction", "onnx-community/Qwen3-Embedding-0.6B-ONNX", ...)` incorrectly required
`generation_config.json` to be cached, even though the pipeline never fetches it.

The mismatch: get_pipeline_files used resolve_model_type(config) which reads config.architectures[0] = "Qwen3ForCausalLM" → DecoderOnly → has optional_configs: { generation_config }. But pipeline("feature-extraction", ...) uses AutoModel, which iterates its MODEL_CLASS_MAPPINGS in order and finds "qwen3" in MODEL_MAPPING_NAMES_DECODER_ONLY first → loads Qwen3Model → DecoderOnlyWithoutHead → no optional_configs. So generation_config.json is never fetched, but is_pipeline_cached thought it
  was required.

  Fix

Added resolveEffectiveModelType(taskConfig, config) in get_pipeline_files.js. Instead of using config.architectures to infer the model type, it simulates what the pipeline's auto class actually does: iterates autoClass.MODEL_CLASS_MAPPINGS using config.model_type to find the first matching class (e.g. Qwen3Model), then looks that up in MODEL_TYPE_MAPPING (→  DecoderOnlyWithoutHead). This resolved type is passed as model_type_override down through get_files → get_model_files, replacing the resolve_model_type call there.

Cross-architecture detection (e.g. Qwen3VLForCausalLM loading a ForConditionalGeneration model for text-generation) is also replicated to avoid regression.