### PR TITLE
Cached generation improvements (+ past_key_values via pipeline function)

### DIFF
--- a/packages/transformers/docs/plugins/preprocess.js
+++ b/packages/transformers/docs/plugins/preprocess.js
@@ -14,24 +14,39 @@ function extractBalancedBraces(text, start) {
   return depth === 0 ? { content: text.slice(start + 1, i - 1), endIndex: i } : null;
 }
 
+function stripLeadingGenericParams(expr) {
+  if (expr[0] !== "<") return expr;
+  let depth = 1, i = 1;
+  while (i < expr.length && depth > 0) {
+    if (expr[i] === "<") depth++;
+    else if (expr[i] === ">") depth--;
+    i++;
+  }
+  return depth === 0 ? expr.slice(i) : expr;
+}
+
 function transformType(expr) {
   let result = expr,
     prev = "";
   while (result !== prev) {
     prev = result;
+    result = stripLeadingGenericParams(result); // <T extends X>(...) -> (...)
     result = result
       .replace(/import\([^)]+\)((?:\.\w+)*)/g, (_, p) => p?.slice(1) || "any") // import() -> Type
       .replace(/\w+\[['"][^\]]+['"]\]\s+extends\s+[^}]+/g, "any") // X['p'] extends ... -> any
       .replace(/(\w+)(?:<[^>]+>)?\[[^\]]+\]/g, "$1") // Type[x] or Type<T>[x] -> Type
       .replace(/keyof\s+typeof\s+\w+/g, "string") // keyof typeof X -> string
       .replace(/typeof\s+\w+/g, "Object") // typeof X -> Object
+      .replace(/\binfer\s+\w+/g, "any") // infer K -> any
+      .replace(/\(\s*\w[\w<>, ]*\s+extends\s+\w+\s*\?[^)]*\)/g, "any") // (X extends Y ? A : B) -> any
+      .replace(/(?<!\w)\(\s*(\w+)\s*\)/g, "$1") // (any) -> any (unwrap parens around simple types, not after words like "function")
       .replace(/(\w+)\?\s*:/g, "$1:") // x?: T -> x: T
       .replace(/;\s*([}\n])/g, " $1")
       .replace(/;\s+/g, ", ") // semicolons -> commas
       .replace(/\{\s*\[\w+\s+in\s+[^\]]+\][^}]*\}/g, "Object") // mapped types -> Object
       .replace(/new\s*\([^)]*\)\s*=>\s*\{[^}]*\}/g, "Function") // new () => {...} -> Function
       .replace(/new\s*\([^)]*\)\s*=>\s*\w+/g, "Function") // new () => T -> Function
-      .replace(/\([^()]*\)\s*=>\s*\w[\w<>|[\]]*/g, "Function") // () => T -> Function
+      .replace(/\([^()]*\)\s*=>\s*\w[\w<>|[\], ]*/g, "Function") // () => T -> Function
       .replace(/\{[^{}]*\}\[\]/g, "Array") // {x:T}[] -> Array
       .replace(/(\w+)<[^>]+>\[\]/g, "Array.<$1>") // T<U>[] -> Array.<T>
       .replace(/\([^()]+\)\[\]/g, "Array") // (A|B)[] -> Array

--- a/packages/transformers/src/cache_utils.js
+++ b/packages/transformers/src/cache_utils.js
@@ -74,7 +74,7 @@ class _DynamicCache {
 }
 
 /**
- * @typedef {_DynamicCache & Record<string, Tensor>} DynamicCache
+ * @typedef {Record<string, Tensor> & _DynamicCache} DynamicCache
  */
 
 export const DynamicCache = /** @type {new (entries?: Record<string, Tensor>) => DynamicCache} */ (

--- a/packages/transformers/src/cache_utils.js
+++ b/packages/transformers/src/cache_utils.js
@@ -29,6 +29,11 @@ class _DynamicCache {
     get_seq_length() {
         /** @type {Record<string, Tensor>} */
         const self = /** @type {any} */ (this);
+
+        if (Object.keys(self).length === 0) {
+            return 0;
+        }
+
         for (const name in self) {
             if (name.startsWith('past_key_values.')) {
                 return self[name].dims.at(-2);

--- a/packages/transformers/src/cache_utils.js
+++ b/packages/transformers/src/cache_utils.js
@@ -43,6 +43,21 @@ class _DynamicCache {
     }
 
     /**
+     * Update the cache in-place with new entries, disposing replaced GPU tensors.
+     * @param {Record<string, Tensor>} newEntries The new name → Tensor mappings.
+     */
+    update(newEntries) {
+        for (const key in newEntries) {
+            const oldValue = this[key];
+            const newValue = newEntries[key];
+            if (oldValue && oldValue !== newValue && oldValue.location === 'gpu-buffer') {
+                oldValue.dispose();
+            }
+            this[key] = newValue;
+        }
+    }
+
+    /**
      * Dispose all contained tensors whose data resides on the GPU.
      * Returns a promise that resolves when all disposals are complete.
      * @returns {Promise<void>} Promise that resolves when all GPU tensors are disposed.

--- a/packages/transformers/src/generation/parameters.js
+++ b/packages/transformers/src/generation/parameters.js
@@ -30,6 +30,9 @@
  * through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
  * @property {number[]} [decoder_input_ids=null] (`number[]`, *optional*):
  * If the model is an encoder-decoder model, this argument is used to pass the `decoder_input_ids`.
+ * @property {import('../cache_utils.js').DynamicCache | null} [past_key_values=null] (`DynamicCache`, *optional*):
+ * A cache object that stores previously computed key/value states. When provided, the model will
+ * use these cached states to avoid recomputing them, significantly speeding up sequential generation.
  */
 
 /**

--- a/packages/transformers/src/generation/parameters.js
+++ b/packages/transformers/src/generation/parameters.js
@@ -36,7 +36,7 @@
  */
 
 /**
- * @typedef {GenerationFunctionParametersBase & Partial<import('./configuration_utils.js').GenerationConfig> & Record<string, any>} GenerationFunctionParameters
+ * @typedef {GenerationFunctionParametersBase & Partial<import('./configuration_utils.js').GenerationConfig> & {[key: string]: unknown}} GenerationFunctionParameters
  */
 
 export {}; // Ensure this file is treated as a module

--- a/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
+++ b/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
@@ -168,7 +168,7 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
         );
 
         const new_tokens = sequences.slice(null, [
-            params.input_ids.dims[1], // Exclude start of speech token
+            /** @type {Tensor} */ (params.input_ids).dims[1], // Exclude start of speech token
             -1, // Exclude end of speech token
         ]);
 

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -204,6 +204,7 @@ export class PreTrainedModel extends Callable {
     forward_params = ['input_ids', 'attention_mask'];
 
     _return_dict_in_generate_keys = null;
+
     /**
      * Creates a new instance of the `PreTrainedModel` class.
      * @param {import('../configs.js').PretrainedConfig} config The model configuration.
@@ -664,7 +665,7 @@ export class PreTrainedModel extends Callable {
      */
     _update_model_kwargs_for_generation({ generated_input_ids, outputs, model_inputs, is_encoder_decoder }) {
         // update past_key_values
-        model_inputs['past_key_values'] = this.getPastKeyValues(outputs, model_inputs.past_key_values);
+        model_inputs['past_key_values'] = getPastKeyValues(outputs, model_inputs.past_key_values);
 
         // update inputs for next run
         model_inputs['input_ids'] = new Tensor('int64', generated_input_ids.flat(), [generated_input_ids.length, 1]);
@@ -966,7 +967,7 @@ export class PreTrainedModel extends Callable {
             if (generation_config.return_dict_in_generate) {
                 if (generation_config.output_attentions) {
                     // Get attentions if they are present
-                    const token_attentions = this.getAttentions(outputs);
+                    const token_attentions = getAttentions(outputs);
                     for (const key in token_attentions) {
                         if (!(key in attentions)) {
                             attentions[key] = [];
@@ -1030,11 +1031,25 @@ export class PreTrainedModel extends Callable {
             streamer.end();
         }
 
-        // Retrieve and dispose all final past key values (including encoder attentions)
-        const past_key_values = this.getPastKeyValues(outputs, model_inputs.past_key_values, true);
-
         // TODO: ensure all_input_ids is padded correctly...
         const sequences = new Tensor('int64', all_input_ids.flat(), [all_input_ids.length, all_input_ids[0].length]);
+
+        // Update past key values from the final forward pass
+        const past_key_values = getPastKeyValues(outputs, model_inputs.past_key_values);
+
+        // Dispose output tensors not held by the cache
+        const cachedTensors = new Set(Object.values(past_key_values));
+        for (const tensor of Object.values(outputs)) {
+            if (tensor.location === 'gpu-buffer' && !cachedTensors.has(tensor)) {
+                tensor.dispose();
+            }
+        }
+
+        // Dispose cache tensors if no one needs them
+        const keepCacheAlive = 'past_key_values' in kwargs || generation_config.return_dict_in_generate;
+        if (!keepCacheAlive) {
+            await past_key_values.dispose();
+        }
 
         if (generation_config.return_dict_in_generate) {
             return {
@@ -1046,106 +1061,8 @@ export class PreTrainedModel extends Callable {
                 // scores,
                 // logits,
             };
-        } else {
-            // Dispose all remaining tensors
-            for (const tensor of Object.values(outputs)) {
-                if (tensor.location === 'gpu-buffer') {
-                    tensor.dispose();
-                }
-            }
-            return sequences;
         }
-    }
-
-    /**
-     * Returns a DynamicCache containing past key values from the given decoder results object.
-     *
-     * @param {Object} decoderResults The decoder results object.
-     * @param {DynamicCache} pastKeyValues The previous past key values.
-     * @param {boolean} [disposeEncoderPKVs=false] Whether to dispose encoder past key values.
-     * @returns {DynamicCache} A new DynamicCache containing the updated past key values.
-     */
-    getPastKeyValues(decoderResults, pastKeyValues, disposeEncoderPKVs = false) {
-        /** @type {Record<string, Tensor>} */
-        const pkvs = Object.create(null);
-
-        for (const name in decoderResults) {
-            if (name.startsWith('present')) {
-                const newName = name
-                    // Hybrid cache architecture
-                    .replace('present_ssm', 'past_ssm') // Mamba
-                    .replace('present_conv', 'past_conv') // LFM2
-                    .replace('present_recurrent', 'past_recurrent') // Qwen3.5
-
-                    // Standard cache architecture
-                    .replace('present', 'past_key_values');
-                const is_encoder_pkv = name.includes('encoder');
-                if (is_encoder_pkv && pastKeyValues) {
-                    // Optimization introduced by optimum to reuse past key values.
-                    // So, we just replace the constant outputs (`decoderResults[name]`) with the previous past key values.
-                    // https://github.com/huggingface/optimum/blob/0bf2c05fb7e1182b52d21b703cfc95fd9e4ea3dc/optimum/onnxruntime/base.py#L677-L704
-                    pkvs[newName] = pastKeyValues[newName];
-                } else {
-                    // decoder or using first encoder PKVs
-                    pkvs[newName] = decoderResults[name];
-                }
-
-                if (pastKeyValues && (!is_encoder_pkv || disposeEncoderPKVs)) {
-                    // - Always dispose decoder PKVs
-                    // - Only dispose encoder past key values when requested (after generation)
-                    const t = pastKeyValues[newName];
-                    if (t.location === 'gpu-buffer') {
-                        t.dispose();
-                    }
-                }
-            }
-        }
-        return new DynamicCache(pkvs);
-    }
-
-    /**
-     * Returns an object containing attentions from the given model output object.
-     *
-     * @param {Object} model_output The output of the model.
-     * @returns {{cross_attentions?: Tensor[]}} An object containing attentions.
-     */
-    getAttentions(model_output) {
-        const attentions = {};
-
-        for (const attnName of ['cross_attentions', 'encoder_attentions', 'decoder_attentions']) {
-            for (const name in model_output) {
-                if (name.startsWith(attnName)) {
-                    if (!(attnName in attentions)) {
-                        attentions[attnName] = [];
-                    }
-                    attentions[attnName].push(model_output[name]);
-                }
-            }
-        }
-        return attentions;
-    }
-
-    /**
-     * Adds past key values to the decoder feeds object. If pastKeyValues is null, creates new tensors for past key values.
-     *
-     * @param {Record<string, any>} decoderFeeds The decoder feeds object to add past key values to.
-     * @param {DynamicCache|null} pastKeyValues The cache containing past key values.
-     */
-    addPastKeyValues(decoderFeeds, pastKeyValues) {
-        if (pastKeyValues) {
-            Object.assign(decoderFeeds, pastKeyValues);
-        } else {
-            const session = this.sessions['decoder_model_merged'] ?? this.sessions['model'];
-            const batch_size = (decoderFeeds[this.main_input_name] ?? decoderFeeds.attention_mask)?.dims?.[0] ?? 1;
-
-            const dtype = session?.config?.kv_cache_dtype ?? 'float32';
-            const cls = dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
-            const shapes = getCacheShapes(this.config, { batch_size });
-            for (const name in shapes) {
-                const size = shapes[name].reduce((a, b) => a * b, 1);
-                decoderFeeds[name] = new Tensor(dtype, new cls(size), shapes[name]);
-            }
-        }
+        return sequences;
     }
 
     /**
@@ -1254,6 +1171,106 @@ export async function auto_encoder_forward(self, model_inputs) {
 }
 
 /**
+ * Returns a DynamicCache containing past key values from the given decoder results object.
+ * Always updates in-place when pastKeyValues is provided; creates a new DynamicCache otherwise.
+ *
+ * @param {Object} decoderResults The decoder results object.
+ * @param {DynamicCache} pastKeyValues The previous past key values.
+ * @returns {DynamicCache} The updated past key values cache.
+ */
+export function getPastKeyValues(decoderResults, pastKeyValues) {
+    /** @type {Record<string, Tensor>} */
+    const pkvs = Object.create(null);
+
+    for (const name in decoderResults) {
+        if (name.startsWith('present')) {
+            const newName = name
+                // Hybrid cache architecture
+                .replace('present_ssm', 'past_ssm') // Mamba
+                .replace('present_conv', 'past_conv') // LFM2
+                .replace('present_recurrent', 'past_recurrent') // Qwen3.5
+
+                // Standard cache architecture
+                .replace('present', 'past_key_values');
+            const is_encoder_pkv = name.includes('encoder');
+            if (is_encoder_pkv && pastKeyValues) {
+                // Optimization introduced by optimum to reuse past key values.
+                // So, we just replace the constant outputs (`decoderResults[name]`) with the previous past key values.
+                // https://github.com/huggingface/optimum/blob/0bf2c05fb7e1182b52d21b703cfc95fd9e4ea3dc/optimum/onnxruntime/base.py#L677-L704
+                pkvs[newName] = pastKeyValues[newName];
+            } else {
+                pkvs[newName] = decoderResults[name];
+            }
+        }
+    }
+
+    if (pastKeyValues) {
+        pastKeyValues.update(pkvs);
+        return pastKeyValues;
+    }
+    return new DynamicCache(pkvs);
+}
+
+/**
+ * Returns an object containing attentions from the given model output object.
+ *
+ * @param {Object} model_output The output of the model.
+ * @returns {{cross_attentions?: Tensor[]}} An object containing attentions.
+ */
+export function getAttentions(model_output) {
+    const attentions = {};
+
+    for (const attnName of ['cross_attentions', 'encoder_attentions', 'decoder_attentions']) {
+        for (const name in model_output) {
+            if (name.startsWith(attnName)) {
+                if (!(attnName in attentions)) {
+                    attentions[attnName] = [];
+                }
+                attentions[attnName].push(model_output[name]);
+            }
+        }
+    }
+    return attentions;
+}
+
+/**
+ * Adds past key values to the decoder feeds object. If pastKeyValues is null,
+ * creates a new DynamicCache with zero-filled tensors for each cache entry.
+ *
+ * @param {PreTrainedModel} self The model instance.
+ * @param {Record<string, any>} decoderFeeds The decoder feeds object to add past key values to.
+ * @param {DynamicCache|null} pastKeyValues The cache containing past key values.
+ * @returns {DynamicCache} The past key values cache (existing or newly created).
+ */
+export function addPastKeyValues(self, decoderFeeds, pastKeyValues) {
+    if (pastKeyValues && Object.keys(pastKeyValues).length > 0) {
+        Object.assign(decoderFeeds, pastKeyValues);
+        return pastKeyValues;
+    }
+
+    const session = self.sessions['decoder_model_merged'] ?? self.sessions['model'];
+    const batch_size = (decoderFeeds[self.main_input_name] ?? decoderFeeds.attention_mask)?.dims?.[0] ?? 1;
+
+    const dtype = session?.config?.kv_cache_dtype ?? 'float32';
+    const cls = dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
+    const shapes = getCacheShapes(self.config, { batch_size });
+    /** @type {Record<string, Tensor>} */
+    const entries = Object.create(null);
+    for (const name in shapes) {
+        const size = shapes[name].reduce((a, b) => a * b, 1);
+        const t = new Tensor(dtype, new cls(size), shapes[name]);
+        decoderFeeds[name] = t;
+        entries[name] = t;
+    }
+    if (pastKeyValues) {
+        // Populate the (empty) user-provided cache in-place
+        pastKeyValues.update(entries);
+        return pastKeyValues;
+    }
+    return new DynamicCache(entries);
+}
+
+/**
  * Forward pass of a decoder model.
  * @param {Object} self The decoder model.
  * @param {Object} model_inputs The input data to be used for the forward pass.
@@ -1266,7 +1283,9 @@ export async function decoder_forward(self, model_inputs, is_encoder_decoder = f
     const { past_key_values, ...new_model_inputs } = model_inputs;
 
     if (session.inputNames.includes('use_cache_branch')) {
-        new_model_inputs.use_cache_branch = boolTensor(!!past_key_values);
+        new_model_inputs.use_cache_branch = boolTensor(
+            past_key_values != null && Object.keys(past_key_values).length > 0,
+        );
     }
     if (
         session.inputNames.includes('position_ids') &&
@@ -1288,7 +1307,7 @@ export async function decoder_forward(self, model_inputs, is_encoder_decoder = f
     }
 
     // Unpack the `past_key_values` object into model inputs
-    self.addPastKeyValues(new_model_inputs, past_key_values);
+    addPastKeyValues(self, new_model_inputs, past_key_values);
 
     // Select only the inputs that are needed for the current session
     const fixed = pick(new_model_inputs, session.inputNames);

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -852,7 +852,7 @@ export class PreTrainedModel extends Callable {
         // 3. Define model inputs
         let { inputs_tensor, model_inputs, model_input_name } = this._prepare_model_inputs({
             inputs,
-            model_kwargs: kwargs,
+            model_kwargs: /** @type {Record<string, Tensor|number[]>} */ (kwargs),
         });
 
         const is_encoder_decoder = this.config.is_encoder_decoder;

--- a/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
+++ b/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
@@ -127,7 +127,7 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
     async generate_images(options) {
         this._generation_mode = 'image';
 
-        const start_num_tokens = (options.inputs ?? options[this.main_input_name]).dims[1];
+        const start_num_tokens = /** @type {Tensor} */ (options.inputs ?? options[this.main_input_name]).dims[1];
         const all_tokens = await super.generate(options);
 
         const generated_tokens = /** @type {Tensor} */ (all_tokens).slice(null, [start_num_tokens, null]);

--- a/packages/transformers/src/models/speecht5/modeling_speecht5.js
+++ b/packages/transformers/src/models/speecht5/modeling_speecht5.js
@@ -1,4 +1,4 @@
-import { PreTrainedModel, encoder_forward, boolTensor } from '../modeling_utils.js';
+import { PreTrainedModel, encoder_forward, boolTensor, addPastKeyValues, getPastKeyValues } from '../modeling_utils.js';
 import { sessionRun } from '../session.js';
 import { Tensor, cat } from '../../utils/tensor.js';
 
@@ -127,9 +127,9 @@ export class SpeechT5ForTextToSpeech extends SpeechT5PreTrainedModel {
                 encoder_hidden_states: encoder_outputs,
             };
 
-            this.addPastKeyValues(decoderFeeds, past_key_values);
+            addPastKeyValues(this, decoderFeeds, past_key_values);
             decoder_outputs = await sessionRun(this.sessions['decoder_model_merged'], decoderFeeds);
-            past_key_values = this.getPastKeyValues(decoder_outputs, past_key_values);
+            past_key_values = getPastKeyValues(decoder_outputs, past_key_values);
 
             const { prob, spectrum } = decoder_outputs;
             spectrogramParts.push(spectrum);

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -1,4 +1,4 @@
-import { PreTrainedModel } from '../modeling_utils.js';
+import { PreTrainedModel, addPastKeyValues } from '../modeling_utils.js';
 import { sessionRun } from '../session.js';
 import { getCacheShapes } from '../../configs.js';
 import { Tensor, ones } from '../../utils/tensor.js';
@@ -209,7 +209,7 @@ export class VoxtralRealtimeForConditionalGeneration extends VoxtralRealtimePreT
         }
 
         const decoder_feeds = { inputs_embeds, ...kwargs };
-        this.addPastKeyValues(decoder_feeds, past_key_values);
+        addPastKeyValues(this, decoder_feeds, past_key_values);
 
         const session = this.sessions['decoder_model_merged'];
         const fixed = pick(decoder_feeds, session.inputNames);

--- a/packages/transformers/src/pipelines/audio-classification.js
+++ b/packages/transformers/src/pipelines/audio-classification.js
@@ -20,23 +20,16 @@ import { softmax } from '../utils/maths.js';
  * If the provided number is `null` or higher than the number of labels available in the model configuration,
  * it will default to the number of labels.
  *
- * @callback AudioClassificationPipelineCallbackSingle Classify a single audio input.
- * @param {AudioInput} audio The input audio file(s) to be classified. The input is either:
- * - `string` or `URL` that is the filename/URL of the audio file, the file will be read at the processor's sampling rate
- * to get the waveform using the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) API.
- * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
- * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
- * @param {AudioClassificationPipelineOptions} [options] The options to use for audio classification.
- * @returns {Promise<AudioClassificationOutput>} An array containing the predicted labels and scores.
- *
- * @callback AudioClassificationPipelineCallbackBatch Classify multiple audio inputs.
- * @param {AudioInput[]} audio The audio inputs to be classified.
- * @param {AudioClassificationPipelineOptions} [options] The options to use for audio classification.
- * @returns {Promise<AudioClassificationOutput[]>} An array of prediction arrays corresponding to each input.
- *
- * @typedef {AudioClassificationPipelineCallbackSingle & AudioClassificationPipelineCallbackBatch} AudioClassificationPipelineCallback
- *
  * @typedef {AudioPipelineConstructorArgs & AudioClassificationPipelineCallback & Disposable} AudioClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends AudioInput[] ? AudioClassificationOutput[] : AudioClassificationOutput} AudioClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends AudioInput | AudioInput[]>(audio: T, options?: AudioClassificationPipelineOptions) => Promise<AudioClassificationPipelineResult<T>>} AudioClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/automatic-speech-recognition.js
+++ b/packages/transformers/src/pipelines/automatic-speech-recognition.js
@@ -32,27 +32,16 @@ import { logger } from '../utils/logger.js';
  * @property {number} [num_frames] The number of frames in the input audio.
  * @typedef {import('../generation/parameters.js').GenerationFunctionParameters & AutomaticSpeechRecognitionSpecificParams} AutomaticSpeechRecognitionConfig
  *
- * @callback AutomaticSpeechRecognitionPipelineCallbackSingle Transcribe the audio sequence given as inputs to text.
- * @param {AudioInput} audio The input audio file(s) to be transcribed. The input is either:
- * - `string` or `URL` that is the filename/URL of the audio file, the file will be read at the processor's sampling rate
- * to get the waveform using the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) API.
- * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
- * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
- * @param {Partial<AutomaticSpeechRecognitionConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<AutomaticSpeechRecognitionOutput>} An object containing the transcription text and optionally timestamps if `return_timestamps` is `true`.
- *
- * @callback AutomaticSpeechRecognitionPipelineCallbackBatch Transcribe the audio sequences given as inputs to text.
- * @param {AudioInput[]} audio The input audio file(s) to be transcribed. Each entry is either:
- * - `string` or `URL` that is the filename/URL of the audio file, the file will be read at the processor's sampling rate
- * to get the waveform using the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) API.
- * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
- * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
- * @param {Partial<AutomaticSpeechRecognitionConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<AutomaticSpeechRecognitionOutput[]>} An object containing the transcription text and optionally timestamps if `return_timestamps` is `true`.
- *
- * @typedef {AutomaticSpeechRecognitionPipelineCallbackSingle & AutomaticSpeechRecognitionPipelineCallbackBatch} AutomaticSpeechRecognitionPipelineCallback
- *
  * @typedef {TextAudioPipelineConstructorArgs & AutomaticSpeechRecognitionPipelineCallback & Disposable} AutomaticSpeechRecognitionPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends AudioInput[] ? AutomaticSpeechRecognitionOutput[] : AutomaticSpeechRecognitionOutput} AutomaticSpeechRecognitionPipelineResult
+ */
+
+/**
+ * @typedef {<T extends AudioInput | AudioInput[]>(audio: T, options?: Partial<AutomaticSpeechRecognitionConfig>) => Promise<AutomaticSpeechRecognitionPipelineResult<T>>} AutomaticSpeechRecognitionPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/background-removal.js
+++ b/packages/transformers/src/pipelines/background-removal.js
@@ -11,19 +11,16 @@ import { RawImage } from '../utils/image.js';
 /**
  * @typedef {Object} BackgroundRemovalPipelineOptions Parameters specific to background removal pipelines.
  *
- * @callback BackgroundRemovalPipelineCallbackSingle Remove the background from the image passed as input.
- * @param {ImageInput} images The input image.
- * @param {BackgroundRemovalPipelineOptions} [options] The options to use for background removal.
- * @returns {Promise<RawImage>} The image with the background removed.
- *
- * @callback BackgroundRemovalPipelineCallbackBatch Remove the background from the images passed as inputs.
- * @param {ImageInput[]} images The input images.
- * @param {BackgroundRemovalPipelineOptions} [options] The options to use for background removal.
- * @returns {Promise<RawImage[]>} The images with the background removed.
- *
- * @typedef {BackgroundRemovalPipelineCallbackSingle & BackgroundRemovalPipelineCallbackBatch} BackgroundRemovalPipelineCallback
- *
  * @typedef {ImagePipelineConstructorArgs & BackgroundRemovalPipelineCallback & Disposable} BackgroundRemovalPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? RawImage[] : RawImage} BackgroundRemovalPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T, options?: BackgroundRemovalPipelineOptions) => Promise<BackgroundRemovalPipelineResult<T>>} BackgroundRemovalPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/depth-estimation.js
+++ b/packages/transformers/src/pipelines/depth-estimation.js
@@ -14,17 +14,16 @@ import { interpolate_4d } from '../utils/tensor.js';
  * @property {import('../utils/tensor.js').Tensor} predicted_depth The raw depth map predicted by the model.
  * @property {RawImage} depth The processed depth map as an image (with the same size as the input image).
  *
- * @callback DepthEstimationPipelineCallbackSingle Predicts the depth for a single image input.
- * @param {ImageInput} images The image to compute depth for.
- * @returns {Promise<DepthEstimationOutput>} An object containing the depth estimation result.
- *
- * @callback DepthEstimationPipelineCallbackBatch Predicts the depth for multiple image inputs.
- * @param {ImageInput[]} images The images to compute depth for.
- * @returns {Promise<DepthEstimationOutput[]>} A list of objects containing depth estimation results.
- *
- * @typedef {DepthEstimationPipelineCallbackSingle & DepthEstimationPipelineCallbackBatch} DepthEstimationPipelineCallback
- *
  * @typedef {ImagePipelineConstructorArgs & DepthEstimationPipelineCallback & Disposable} DepthEstimationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? DepthEstimationOutput[] : DepthEstimationOutput} DepthEstimationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T) => Promise<DepthEstimationPipelineResult<T>>} DepthEstimationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/fill-mask.js
+++ b/packages/transformers/src/pipelines/fill-mask.js
@@ -19,20 +19,16 @@ import { softmax } from '../utils/maths.js';
  * @typedef {Object} FillMaskPipelineOptions Parameters specific to fill mask pipelines.
  * @property {number} [top_k=5] When passed, overrides the number of predictions to return.
  *
- * @callback FillMaskPipelineCallbackSingle Fill the masked token in the text given as input.
- * @param {string} texts The text with masked tokens.
- * @param {FillMaskPipelineOptions} [options] The options to use for masked language modelling.
- * @returns {Promise<FillMaskOutput>} An array of objects containing the score, predicted token, predicted token string,
- * and the sequence with the predicted token filled in.
- *
- * @callback FillMaskPipelineCallbackBatch Fill the masked token in the texts given as inputs.
- * @param {string[]} texts A list of texts with masked tokens.
- * @param {FillMaskPipelineOptions} [options] The options to use for masked language modelling.
- * @returns {Promise<FillMaskOutput[]>} An array where each entry corresponds to the predictions for an input text.
- *
- * @typedef {FillMaskPipelineCallbackSingle & FillMaskPipelineCallbackBatch} FillMaskPipelineCallback
- *
  * @typedef {TextPipelineConstructorArgs & FillMaskPipelineCallback & Disposable} FillMaskPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends string[] ? FillMaskOutput[] : FillMaskOutput} FillMaskPipelineResult
+ */
+
+/**
+ * @typedef {<T extends string | string[]>(texts: T, options?: FillMaskPipelineOptions) => Promise<FillMaskPipelineResult<T>>} FillMaskPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/image-classification.js
+++ b/packages/transformers/src/pipelines/image-classification.js
@@ -18,19 +18,16 @@ import { softmax } from '../utils/maths.js';
  * @typedef {Object} ImageClassificationPipelineOptions Parameters specific to image classification pipelines.
  * @property {number} [top_k=1] The number of top labels that will be returned by the pipeline.
  *
- * @callback ImageClassificationPipelineCallbackSingle Assign labels to the image passed as input.
- * @param {ImageInput} images The input image to be classified.
- * @param {ImageClassificationPipelineOptions} [options] The options to use for image classification.
- * @returns {Promise<ImageClassificationOutput>} An array containing the predicted labels and scores.
- *
- * @callback ImageClassificationPipelineCallbackBatch Assign labels to the images passed as inputs.
- * @param {ImageInput[]} images The input images to be classified.
- * @param {ImageClassificationPipelineOptions} [options] The options to use for image classification.
- * @returns {Promise<ImageClassificationOutput[]>} An array where each entry contains the predictions for the corresponding input image.
- *
- * @typedef {ImageClassificationPipelineCallbackSingle & ImageClassificationPipelineCallbackBatch} ImageClassificationPipelineCallback
- *
  * @typedef {ImagePipelineConstructorArgs & ImageClassificationPipelineCallback & Disposable} ImageClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? ImageClassificationOutput[] : ImageClassificationOutput} ImageClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T, options?: ImageClassificationPipelineOptions) => Promise<ImageClassificationPipelineResult<T>>} ImageClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/image-to-image.js
+++ b/packages/transformers/src/pipelines/image-to-image.js
@@ -8,17 +8,16 @@ import { RawImage } from '../utils/image.js';
  */
 
 /**
- * @callback ImageToImagePipelineCallbackSingle Transform the image passed as input.
- * @param {ImageInput} images The image to transform.
- * @returns {Promise<RawImage>} The transformed image.
- *
- * @callback ImageToImagePipelineCallbackBatch Transform the images passed as inputs.
- * @param {ImageInput[]} images The images to transform.
- * @returns {Promise<RawImage[]>} The transformed images.
- *
- * @typedef {ImageToImagePipelineCallbackSingle & ImageToImagePipelineCallbackBatch} ImageToImagePipelineCallback
- *
  * @typedef {ImagePipelineConstructorArgs & ImageToImagePipelineCallback & Disposable} ImageToImagePipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? RawImage[] : RawImage} ImageToImagePipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T) => Promise<ImageToImagePipelineResult<T>>} ImageToImagePipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/image-to-text.js
+++ b/packages/transformers/src/pipelines/image-to-text.js
@@ -13,19 +13,16 @@ import { Tensor } from '../utils/tensor.js';
  * @property {string} generated_text The generated text.
  * @typedef {ImageToTextSingle[]} ImageToTextOutput
  *
- * @callback ImageToTextPipelineCallbackSingle Assign labels to the image passed as input.
- * @param {ImageInput} texts The image to be captioned.
- * @param {Partial<import('../generation/parameters.js').GenerationFunctionParameters>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<ImageToTextOutput>} An object containing the generated text(s).
- *
- * @callback ImageToTextPipelineCallbackBatch Assign labels to the images passed as inputs.
- * @param {ImageInput[]} texts The images to be captioned.
- * @param {Partial<import('../generation/parameters.js').GenerationFunctionParameters>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<ImageToTextOutput[]>} An array containing the generated text(s) for each image.
- *
- * @typedef {ImageToTextPipelineCallbackSingle & ImageToTextPipelineCallbackBatch} ImageToTextPipelineCallback
- *
  * @typedef {TextImagePipelineConstructorArgs & ImageToTextPipelineCallback & Disposable} ImageToTextPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? ImageToTextOutput[] : ImageToTextOutput} ImageToTextPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(texts: T, options?: Partial<import('../generation/parameters.js').GenerationFunctionParameters>) => Promise<ImageToTextPipelineResult<T>>} ImageToTextPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/object-detection.js
+++ b/packages/transformers/src/pipelines/object-detection.js
@@ -18,19 +18,16 @@ import { Pipeline, prepareImages, get_bounding_box } from './_base.js';
  * @property {number} [threshold=0.9] The threshold used to filter boxes by score.
  * @property {boolean} [percentage=false] Whether to return the boxes coordinates in percentage (true) or in pixels (false).
  *
- * @callback ObjectDetectionPipelineCallbackSingle Detect objects (bounding boxes & classes) in the image passed as input.
- * @param {ImageInput} images The input image.
- * @param {ObjectDetectionPipelineOptions} [options] The options to use for object detection.
- * @returns {Promise<ObjectDetectionOutput>} A list of detected objects.
- *
- * @callback ObjectDetectionPipelineCallbackBatch Detect objects (bounding boxes & classes) in the images passed as inputs.
- * @param {ImageInput[]} images The input images.
- * @param {ObjectDetectionPipelineOptions} [options] The options to use for object detection.
- * @returns {Promise<ObjectDetectionOutput[]>} A list where each entry contains the detections for the corresponding input image.
- *
- * @typedef {ObjectDetectionPipelineCallbackSingle & ObjectDetectionPipelineCallbackBatch} ObjectDetectionPipelineCallback
- *
  * @typedef {ImagePipelineConstructorArgs & ObjectDetectionPipelineCallback & Disposable} ObjectDetectionPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? ObjectDetectionOutput[] : ObjectDetectionOutput} ObjectDetectionPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T, options?: ObjectDetectionPipelineOptions) => Promise<ObjectDetectionPipelineResult<T>>} ObjectDetectionPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/question-answering.js
+++ b/packages/transformers/src/pipelines/question-answering.js
@@ -18,33 +18,21 @@ import { softmax } from '../utils/maths.js';
  * @typedef {Object} QuestionAnsweringPipelineOptions Parameters specific to question answering pipelines.
  * @property {number} [top_k=1] The number of top answer predictions to be returned.
  *
- * @callback QuestionAnsweringPipelineCallbackSingleTop1 Answer the question given as input by using the context.
- * @param {string} question The question.
- * @param {string} context The context.
- * @param {{top_k: 1} | {} | undefined} [options] The options to use for question answering.
- * @returns {Promise<QuestionAnsweringOutput>} The answer.
- *
- * @callback QuestionAnsweringPipelineCallbackSingleTopK Answer the question given as input by using the context.
- * @param {string} question The question.
- * @param {string} context The context.
- * @param {{top_k: number}} [options] The options to use for question answering.
- * @returns {Promise<QuestionAnsweringOutput[]>} The answers.
- *
- * @callback QuestionAnsweringPipelineCallbackBatchTop1 Answer the questions given as inputs by using the contexts.
- * @param {string[]} question The questions.
- * @param {string[]} context The contexts.
- * @param {{top_k: 1} | {} | undefined} [options] The options to use for question answering.
- * @returns {Promise<QuestionAnsweringOutput[]>} The answers.
- *
- * @callback QuestionAnsweringPipelineCallbackBatchTopK Answer the questions given as inputs by using the contexts.
- * @param {string[]} question The questions.
- * @param {string[]} context The contexts.
- * @param {{top_k: number}} [options] The options to use for question answering.
- * @returns {Promise<QuestionAnsweringOutput[][]>} The answers.
- *
- * @typedef {QuestionAnsweringPipelineCallbackSingleTop1 & QuestionAnsweringPipelineCallbackSingleTopK & QuestionAnsweringPipelineCallbackBatchTop1 & QuestionAnsweringPipelineCallbackBatchTopK} QuestionAnsweringPipelineCallback
- *
  * @typedef {TextPipelineConstructorArgs & QuestionAnsweringPipelineCallback & Disposable} QuestionAnsweringPipelineType
+ */
+
+/**
+ * @template O
+ * @typedef {O extends { top_k: infer K } ? (1 extends K ? false : true) : false} QuestionAnsweringIsTopK
+ */
+
+/**
+ * @template Q, O
+ * @typedef {Q extends string[] ? (QuestionAnsweringIsTopK<O> extends true ? QuestionAnsweringOutput[][] : QuestionAnsweringOutput[]) : (QuestionAnsweringIsTopK<O> extends true ? QuestionAnsweringOutput[] : QuestionAnsweringOutput)} QuestionAnsweringPipelineResult
+ */
+
+/**
+ * @typedef {<Q extends string | string[], const O extends { top_k?: number } = {}>(question: Q, context: Q, options?: O) => Promise<QuestionAnsweringPipelineResult<Q, O>>} QuestionAnsweringPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/text-classification.js
+++ b/packages/transformers/src/pipelines/text-classification.js
@@ -16,25 +16,20 @@ import { softmax } from '../utils/maths.js';
  *
  * @typedef {Object} TextClassificationPipelineOptions Parameters specific to text classification pipelines.
  * @property {number|null} [top_k=1] The number of top predictions to be returned. If set to `null`, all predictions are returned.
- *
- * @callback TextClassificationPipelineCallbackSingle Classify a single text.
- * @param {string} texts The input text to be classified.
- * @param {TextClassificationPipelineOptions} [options] The options to use for text classification.
- * @returns {Promise<TextClassificationOutput>} An object containing the predicted labels and scores.
- *
- * @callback TextClassificationPipelineCallbackBatchTopK Classify a batch of texts and return top-k results for each.
- * @param {string[]} texts The input texts to be classified.
- * @param {{top_k: number|null}} [options] The options to use for text classification.
- * @returns {Promise<TextClassificationOutput[]>} An array of objects containing the predicted labels and scores.
- *
- * @callback TextClassificationPipelineCallbackBatchTop1 Classify a batch of texts and return the top-1 result for each.
- * @param {string[]} texts The input texts to be classified.
- * @param {{top_k: 1} | {} | undefined} [options] The options to use for text classification (where `top_k` is 1 or omitted).
- * @returns {Promise<TextClassificationOutput>} An object containing the predicted labels and scores.
  */
 
 /**
- * @typedef {TextClassificationPipelineCallbackSingle & TextClassificationPipelineCallbackBatchTop1 & TextClassificationPipelineCallbackBatchTopK} TextClassificationPipelineCallback
+ * @template O
+ * @typedef {O extends { top_k: infer K } ? (1 extends K ? false : true) : false} TextClassificationIsTopK
+ */
+
+/**
+ * @template Q, O
+ * @typedef {Q extends string[] ? (TextClassificationIsTopK<O> extends true ? TextClassificationOutput[] : TextClassificationOutput) : TextClassificationOutput} TextClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<Q extends string | string[], const O extends TextClassificationPipelineOptions = {}>(texts: Q, options?: O) => Promise<TextClassificationPipelineResult<Q, O>>} TextClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -41,17 +41,9 @@ function isChat(x) {
  * @param {Partial<TextGenerationConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
  * @returns {Promise<TextGenerationChatOutput>} An array containing the generated chat(s).
  *
- * @callback TextGenerationPipelineCallbackStringBatched
- * @param {string[]} texts Several prompts to complete.
- * @param {Partial<TextGenerationConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<TextGenerationStringOutput[]>} An array of arrays, each containing the generated text(s) for the corresponding input.
+ * @typedef {<T extends string[] | Chat[]>(texts: T, options?: Partial<TextGenerationConfig>) => Promise<T extends Chat[] ? TextGenerationChatOutput[] : TextGenerationStringOutput[]>} TextGenerationPipelineCallbackBatched
  *
- * @callback TextGenerationPipelineCallbackChatBatched
- * @param {Chat[]} texts Several chats to complete.
- * @param {Partial<TextGenerationConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<TextGenerationChatOutput[]>} An array of arrays, each containing the generated chat(s) for the corresponding input.
- *
- * @typedef {TextGenerationPipelineCallbackString & TextGenerationPipelineCallbackChat & TextGenerationPipelineCallbackStringBatched & TextGenerationPipelineCallbackChatBatched} TextGenerationPipelineCallback
+ * @typedef {TextGenerationPipelineCallbackString & TextGenerationPipelineCallbackChat & TextGenerationPipelineCallbackBatched} TextGenerationPipelineCallback
  *
  * @typedef {TextPipelineConstructorArgs & TextGenerationPipelineCallback & Disposable} TextGenerationPipelineType
  */

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -31,21 +31,16 @@ function isChat(x) {
  * If the text input is a chat, it is passed to `apply_chat_template`. Otherwise, it is passed to the tokenizer's call function.
  * @typedef {import('../generation/parameters.js').GenerationFunctionParameters & TextGenerationSpecificParams} TextGenerationConfig
  *
- * @callback TextGenerationPipelineCallbackString
- * @param {string} texts One prompt to complete.
- * @param {Partial<TextGenerationConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<TextGenerationStringOutput>} An array containing the generated text(s).
- *
- * @callback TextGenerationPipelineCallbackChat
- * @param {Chat} texts One chat to complete.
- * @param {Partial<TextGenerationConfig>} [options] Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<TextGenerationChatOutput>} An array containing the generated chat(s).
- *
- * @typedef {<T extends string[] | Chat[]>(texts: T, options?: Partial<TextGenerationConfig>) => Promise<T extends Chat[] ? TextGenerationChatOutput[] : TextGenerationStringOutput[]>} TextGenerationPipelineCallbackBatched
- *
- * @typedef {TextGenerationPipelineCallbackString & TextGenerationPipelineCallbackChat & TextGenerationPipelineCallbackBatched} TextGenerationPipelineCallback
- *
  * @typedef {TextPipelineConstructorArgs & TextGenerationPipelineCallback & Disposable} TextGenerationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends string ? TextGenerationStringOutput : T extends Chat ? TextGenerationChatOutput : T extends string[] ? TextGenerationStringOutput[] : T extends Chat[] ? TextGenerationChatOutput[] : never} TextGenerationResult
+ */
+
+/**
+ * @typedef {<T extends string | Chat | string[] | Chat[]>(texts: T, options?: Partial<TextGenerationConfig>) => Promise<TextGenerationResult<T>>} TextGenerationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/text-to-audio.js
+++ b/packages/transformers/src/pipelines/text-to-audio.js
@@ -27,19 +27,16 @@ import { env } from '../env.js';
  * More denoising steps usually lead to higher quality audio but slower inference.
  * @property {number} [speed] The speed of the generated audio (if the model supports it).
  *
- * @callback TextToAudioPipelineCallbackSingle Generate speech/audio from a single text input.
- * @param {string} text The text to generate.
- * @param {TextToAudioPipelineOptions} [options] Parameters passed to the model generation/forward method.
- * @returns {Promise<RawAudio>} An object containing the generated audio and sampling rate.
- *
- * @callback TextToAudioPipelineCallbackBatch Generate speech/audio from multiple text inputs.
- * @param {string[]} texts The texts to generate.
- * @param {TextToAudioPipelineOptions} [options] Parameters passed to the model generation/forward method.
- * @returns {Promise<TextToAudioOutput>} An array of objects containing the generated audio and sampling rate.
- *
- * @typedef {TextToAudioPipelineCallbackSingle & TextToAudioPipelineCallbackBatch} TextToAudioPipelineCallback
- *
  * @typedef {TextToAudioPipelineConstructorArgs & TextToAudioPipelineCallback & Disposable} TextToAudioPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends string[] ? TextToAudioOutput : RawAudio} TextToAudioPipelineResult
+ */
+
+/**
+ * @typedef {<T extends string | string[]>(text: T, options?: TextToAudioPipelineOptions) => Promise<TextToAudioPipelineResult<T>>} TextToAudioPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/token-classification.js
+++ b/packages/transformers/src/pipelines/token-classification.js
@@ -20,19 +20,16 @@ import { max, softmax } from '../utils/maths.js';
  * @typedef {Object} TokenClassificationPipelineOptions Parameters specific to token classification pipelines.
  * @property {string[]} [ignore_labels] A list of labels to ignore.
  *
- * @callback TokenClassificationPipelineCallbackSingle Classify each token of a single text.
- * @param {string} texts The text to classify.
- * @param {TokenClassificationPipelineOptions} [options] The options to use for token classification.
- * @returns {Promise<TokenClassificationOutput>} The result.
- *
- * @callback TokenClassificationPipelineCallbackBatch Classify each token of multiple texts.
- * @param {string[]} texts The texts to classify.
- * @param {TokenClassificationPipelineOptions} [options] The options to use for token classification.
- * @returns {Promise<TokenClassificationOutput[]>} The result.
- *
- * @typedef {TokenClassificationPipelineCallbackSingle & TokenClassificationPipelineCallbackBatch} TokenClassificationPipelineCallback
- *
  * @typedef {TextPipelineConstructorArgs & TokenClassificationPipelineCallback & Disposable} TokenClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends string[] ? TokenClassificationOutput[] : TokenClassificationOutput} TokenClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends string | string[]>(texts: T, options?: TokenClassificationPipelineOptions) => Promise<TokenClassificationPipelineResult<T>>} TokenClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/zero-shot-audio-classification.js
+++ b/packages/transformers/src/pipelines/zero-shot-audio-classification.js
@@ -20,29 +20,16 @@ import { softmax } from '../utils/maths.js';
  * to attempt the audio classification by replacing the placeholder with the candidate_labels.
  * Then likelihood is estimated by using `logits_per_audio`.
  *
- * @callback ZeroShotAudioClassificationPipelineCallbackSingle Classify the sequence(s) given as inputs.
- * @param {AudioInput} audio The input audio file(s) to be classified. The input is either:
- * - `string` or `URL` that is the filename/URL of the audio file, the file will be read at the processor's sampling rate
- * to get the waveform using the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) API.
- * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
- * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
- * @param {string[]} candidate_labels The candidate labels for this audio.
- * @param {ZeroShotAudioClassificationPipelineOptions} [options] The options to use for zero-shot audio classification.
- * @returns {Promise<ZeroShotAudioClassificationOutput>} An array of objects containing the predicted labels and scores.
- *
- * @callback ZeroShotAudioClassificationPipelineCallbackBatch Classify the sequence(s) given as inputs.
- * @param {AudioInput[]} audio The input audio file(s) to be classified. The input is either:
- * - `string` or `URL` that is the filename/URL of the audio file, the file will be read at the processor's sampling rate
- * to get the waveform using the [`AudioContext`](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext) API.
- * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
- * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
- * @param {string[]} candidate_labels The candidate labels for this audio.
- * @param {ZeroShotAudioClassificationPipelineOptions} [options] The options to use for zero-shot audio classification.
- * @returns {Promise<ZeroShotAudioClassificationOutput[]>} An array of objects containing the predicted labels and scores.
- *
- * @typedef {ZeroShotAudioClassificationPipelineCallbackSingle & ZeroShotAudioClassificationPipelineCallbackBatch} ZeroShotAudioClassificationPipelineCallback
- *
  * @typedef {TextAudioPipelineConstructorArgs & ZeroShotAudioClassificationPipelineCallback & Disposable} ZeroShotAudioClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends AudioInput[] ? ZeroShotAudioClassificationOutput[] : ZeroShotAudioClassificationOutput} ZeroShotAudioClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends AudioInput | AudioInput[]>(audio: T, candidate_labels: string[], options?: ZeroShotAudioClassificationPipelineOptions) => Promise<ZeroShotAudioClassificationPipelineResult<T>>} ZeroShotAudioClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/zero-shot-classification.js
+++ b/packages/transformers/src/pipelines/zero-shot-classification.js
@@ -22,23 +22,16 @@ import { logger } from '../utils/logger.js';
  * is 1. If `true`, the labels are considered independent and probabilities are normalized for each
  * candidate by doing a softmax of the entailment score vs. the contradiction score.
  *
- * @callback ZeroShotClassificationPipelineCallbackSingle Classify the sequence(s) given as inputs.
- * @param {string} texts The sequence(s) to classify, will be truncated if the model input is too large.
- * @param {string|string[]} candidate_labels The set of possible class labels to classify each sequence into.
- * Can be a single label, a string of comma-separated labels, or a list of labels.
- * @param {ZeroShotClassificationPipelineOptions} [options] The options to use for zero-shot classification.
- * @returns {Promise<ZeroShotClassificationOutput>} An array or object containing the predicted labels and scores.
- *
- * @callback ZeroShotClassificationPipelineCallbackBatch Classify the sequence(s) given as inputs.
- * @param {string[]} texts The sequence(s) to classify, will be truncated if the model input is too large.
- * @param {string|string[]} candidate_labels The set of possible class labels to classify each sequence into.
- * Can be a single label, a string of comma-separated labels, or a list of labels.
- * @param {ZeroShotClassificationPipelineOptions} [options] The options to use for zero-shot classification.
- * @returns {Promise<ZeroShotClassificationOutput[]>} An array or object containing the predicted labels and scores.
- *
- * @typedef {ZeroShotClassificationPipelineCallbackSingle & ZeroShotClassificationPipelineCallbackBatch} ZeroShotClassificationPipelineCallback
- *
  * @typedef {TextPipelineConstructorArgs & ZeroShotClassificationPipelineCallback & Disposable} ZeroShotClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends string[] ? ZeroShotClassificationOutput[] : ZeroShotClassificationOutput} ZeroShotClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends string | string[]>(texts: T, candidate_labels: string | string[], options?: ZeroShotClassificationPipelineOptions) => Promise<ZeroShotClassificationPipelineResult<T>>} ZeroShotClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/zero-shot-image-classification.js
+++ b/packages/transformers/src/pipelines/zero-shot-image-classification.js
@@ -21,21 +21,16 @@ import { softmax } from '../utils/maths.js';
  * to attempt the image classification by replacing the placeholder with the candidate_labels.
  * Then likelihood is estimated by using `logits_per_image`.
  *
- * @callback ZeroShotImageClassificationPipelineCallbackSingle Assign labels to the image(s) passed as inputs.
- * @param {ImageInput} images The input images.
- * @param {string[]} candidate_labels The candidate labels for this image.
- * @param {ZeroShotImageClassificationPipelineOptions} [options] The options to use for zero-shot image classification.
- * @returns {Promise<ZeroShotImageClassificationOutput>} An array of objects containing the predicted labels and scores.
- *
- * @callback ZeroShotImageClassificationPipelineCallbackBatch Assign labels to the image(s) passed as inputs.
- * @param {ImageInput[]} images The input images.
- * @param {string[]} candidate_labels The candidate labels for this image.
- * @param {ZeroShotImageClassificationPipelineOptions} [options] The options to use for zero-shot image classification.
- * @returns {Promise<ZeroShotImageClassificationOutput[]>} An array of objects containing the predicted labels and scores.
- *
- * @typedef {ZeroShotImageClassificationPipelineCallbackSingle & ZeroShotImageClassificationPipelineCallbackBatch} ZeroShotImageClassificationPipelineCallback
- *
  * @typedef {TextImagePipelineConstructorArgs & ZeroShotImageClassificationPipelineCallback & Disposable} ZeroShotImageClassificationPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? ZeroShotImageClassificationOutput[] : ZeroShotImageClassificationOutput} ZeroShotImageClassificationPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T, candidate_labels: string[], options?: ZeroShotImageClassificationPipelineOptions) => Promise<ZeroShotImageClassificationPipelineResult<T>>} ZeroShotImageClassificationPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/pipelines/zero-shot-object-detection.js
+++ b/packages/transformers/src/pipelines/zero-shot-object-detection.js
@@ -22,21 +22,16 @@ import { Pipeline, prepareImages, get_bounding_box } from './_base.js';
  * to the number of predictions.
  * @property {boolean} [percentage=false] Whether to return the boxes coordinates in percentage (true) or in pixels (false).
  *
- * @callback ZeroShotObjectDetectionPipelineCallbackSingle Detect objects (bounding boxes & classes) in the image(s) passed as inputs.
- * @param {ImageInput} images The input images.
- * @param {string[]} candidate_labels What the model should recognize in the image.
- * @param {ZeroShotObjectDetectionPipelineOptions} [options] The options to use for zero-shot object detection.
- * @returns {Promise<ZeroShotObjectDetectionOutput>} An array of objects containing the predicted labels, scores, and bounding boxes.
- *
- * @callback ZeroShotObjectDetectionPipelineCallbackBatch Detect objects (bounding boxes & classes) in the image(s) passed as inputs.
- * @param {ImageInput[]} images The input images.
- * @param {string[]} candidate_labels What the model should recognize in the image.
- * @param {ZeroShotObjectDetectionPipelineOptions} [options] The options to use for zero-shot object detection.
- * @returns {Promise<ZeroShotObjectDetectionOutput[]>} An array of objects containing the predicted labels, scores, and bounding boxes.
- *
- * @typedef {ZeroShotObjectDetectionPipelineCallbackSingle & ZeroShotObjectDetectionPipelineCallbackBatch} ZeroShotObjectDetectionPipelineCallback
- *
  * @typedef {TextImagePipelineConstructorArgs & ZeroShotObjectDetectionPipelineCallback & Disposable} ZeroShotObjectDetectionPipelineType
+ */
+
+/**
+ * @template T
+ * @typedef {T extends ImageInput[] ? ZeroShotObjectDetectionOutput[] : ZeroShotObjectDetectionOutput} ZeroShotObjectDetectionPipelineResult
+ */
+
+/**
+ * @typedef {<T extends ImageInput | ImageInput[]>(images: T, candidate_labels: string[], options?: ZeroShotObjectDetectionPipelineOptions) => Promise<ZeroShotObjectDetectionPipelineResult<T>>} ZeroShotObjectDetectionPipelineCallback
  */
 
 /**

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -46,7 +46,7 @@ export * from './generation/streamers.js';
 export * from './generation/stopping_criteria.js';
 export * from './generation/logits_process.js';
 
-export { read_audio, RawAudio } from './utils/audio.js';
+export { load_audio, read_audio, RawAudio } from './utils/audio.js';
 export { load_image, RawImage } from './utils/image.js';
 export { load_video, RawVideo, RawVideoFrame } from './utils/video.js';
 export * from './utils/tensor.js';

--- a/packages/transformers/src/utils/audio.js
+++ b/packages/transformers/src/utils/audio.js
@@ -15,12 +15,12 @@ import { Tensor, matmul } from './tensor.js';
 import { logger } from './logger.js';
 
 /**
- * Helper function to read audio from a path/URL.
+ * Helper function to load audio from a path/URL.
  * @param {string|URL} url The path/URL to load the audio from.
  * @param {number} sampling_rate The sampling rate to use when decoding the audio.
  * @returns {Promise<Float32Array>} The decoded audio as a `Float32Array`.
  */
-export async function read_audio(url, sampling_rate) {
+export async function load_audio(url, sampling_rate) {
     if (typeof AudioContext === 'undefined') {
         // Running in node or an environment without AudioContext
         throw Error(
@@ -73,6 +73,11 @@ export async function read_audio(url, sampling_rate) {
 
     return audio;
 }
+
+/**
+ * @deprecated Use {@link load_audio} instead.
+ */
+export const read_audio = load_audio;
 
 /**
  * Helper function to generate windows that are special cases of the generalized cosine window.

--- a/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
@@ -1,4 +1,4 @@
-import { pipeline, TextGenerationPipeline } from "../../src/transformers.js";
+import { pipeline, TextGenerationPipeline, DynamicCache } from "../../src/transformers.js";
 
 import { MAX_MODEL_LOAD_TIME, MAX_TEST_EXECUTION_TIME, MAX_MODEL_DISPOSE_TIME, DEFAULT_MODEL_OPTIONS } from "../init.js";
 
@@ -182,6 +182,63 @@ export default () => {
             ],
           },
         ]);
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+
+    afterAll(async () => {
+      await pipe?.dispose();
+    }, MAX_MODEL_DISPOSE_TIME);
+  });
+
+  describe("Text Generation (LFM2 model, DynamicCache PKV)", () => {
+    const model_id = "onnx-internal-testing/tiny-random-Lfm2ForCausalLM";
+
+    /** @type {TextGenerationPipeline} */
+    let pipe;
+    beforeAll(async () => {
+      pipe = await pipeline(PIPELINE_ID, model_id, DEFAULT_MODEL_OPTIONS);
+    }, MAX_MODEL_LOAD_TIME);
+
+    it("should be an instance of TextGenerationPipeline", () => {
+      expect(pipe).toBeInstanceOf(TextGenerationPipeline);
+    });
+
+    it(
+      "multi-turn with past_key_values matches without",
+      async () => {
+        const generate_kwargs = { max_new_tokens: 8, do_sample: false };
+        const past_key_values = new DynamicCache();
+
+        const messages = [{ role: "user", content: "What is the capital of France?" }];
+
+        // Turn 1
+        {
+          const with_pkv = await pipe(messages, { ...generate_kwargs, past_key_values });
+          const without_pkv = await pipe(messages, generate_kwargs);
+          expect(with_pkv[0].generated_text.at(-1).content).toEqual(without_pkv[0].generated_text.at(-1).content);
+          expect(past_key_values.get_seq_length()).toBeGreaterThan(0);
+          messages.push(with_pkv[0].generated_text.at(-1));
+        }
+
+        // Turn 2
+        {
+          messages.push({ role: "user", content: "What about Germany?" });
+          const with_pkv = await pipe(messages, { ...generate_kwargs, past_key_values });
+          const without_pkv = await pipe(messages, generate_kwargs);
+          expect(with_pkv[0].generated_text.at(-1).content).toEqual(without_pkv[0].generated_text.at(-1).content);
+          messages.push(with_pkv[0].generated_text.at(-1));
+        }
+
+        // Turn 3
+        {
+          messages.push({ role: "user", content: "And Spain?" });
+          const with_pkv = await pipe(messages, { ...generate_kwargs, past_key_values });
+          const without_pkv = await pipe(messages, generate_kwargs);
+          expect(with_pkv[0].generated_text.at(-1).content).toEqual(without_pkv[0].generated_text.at(-1).content);
+        }
+
+        await past_key_values.dispose();
       },
       MAX_TEST_EXECUTION_TIME,
     );

--- a/packages/transformers/tests/types.test.js
+++ b/packages/transformers/tests/types.test.js
@@ -1,27 +1,119 @@
 import ts from "typescript";
 
+const TS_OPTIONS = {
+  noEmit: true,
+  skipLibCheck: true,
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ESNext,
+};
+
+function getDiagnostics(file) {
+  const program = ts.createProgram([file], TS_OPTIONS);
+  return ts.getPreEmitDiagnostics(program);
+}
+
+function formatDiagnostics(diagnostics) {
+  const formatHost = {
+    getCanonicalFileName: (path) => path,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    getNewLine: () => ts.sys.newLine,
+  };
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost);
+}
+
+/**
+ * Compile an inline TypeScript source string and return diagnostics.
+ * Uses a virtual file path under tests/types/ so relative imports resolve correctly.
+ */
+function getDiagnosticsFromSource(source) {
+  const virtualPath = "tests/types/__virtual.ts";
+  const defaultHost = ts.createCompilerHost(TS_OPTIONS);
+  const host = {
+    ...defaultHost,
+    fileExists: (f) => f === virtualPath || defaultHost.fileExists(f),
+    readFile: (f) => (f === virtualPath ? source : defaultHost.readFile(f)),
+    getSourceFile: (f, lang) => (f === virtualPath ? ts.createSourceFile(f, source, lang, true) : defaultHost.getSourceFile(f, lang)),
+  };
+  const program = ts.createProgram([virtualPath], TS_OPTIONS, host);
+  return [...ts.getPreEmitDiagnostics(program)];
+}
+
 describe("TypeScript compilation succeeds", () => {
   const DIR = "tests/types/";
   const FILES = ["pipelines.ts", "cache.ts"];
   for (const file of FILES) {
     it(`compiles ${file} without errors`, () => {
-      const program = ts.createProgram([`${DIR}${file}`], {
-        noEmit: true,
-        skipLibCheck: true,
-        module: ts.ModuleKind.ESNext,
-        target: ts.ScriptTarget.ESNext,
-      });
-
-      const diagnostics = ts.getPreEmitDiagnostics(program);
-
+      const diagnostics = getDiagnostics(`${DIR}${file}`);
       if (diagnostics.length > 0) {
-        const formatHost = {
-          getCanonicalFileName: (path) => path,
-          getCurrentDirectory: ts.sys.getCurrentDirectory,
-          getNewLine: () => ts.sys.newLine,
-        };
-        const message = ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost);
-        throw new Error(message);
+        throw new Error(formatDiagnostics(diagnostics));
+      }
+    });
+  }
+});
+
+describe("TypeScript expected errors", () => {
+  /** @type {Record<string, { code: string, errors: Array<{ code: number, underline: string, messageIncludes: string }> }>} */
+  const ERROR_CASES = {
+    "past_key_values rejects string (chat input)": {
+      code: `
+        import { pipeline } from "../../types/transformers.js";
+        const generator = await pipeline("text-generation", "model-id");
+        const messages = [{ role: "user", content: "Hello!" }];
+        await generator(messages, { past_key_values: "hello" });
+      `,
+      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+    },
+    "past_key_values rejects number (string input)": {
+      code: `
+        import { pipeline } from "../../types/transformers.js";
+        const generator = await pipeline("text-generation", "model-id");
+        await generator("hi", { past_key_values: 42 });
+      `,
+      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+    },
+    "past_key_values rejects boolean": {
+      code: `
+        import { pipeline } from "../../types/transformers.js";
+        const generator = await pipeline("text-generation", "model-id");
+        await generator("hi", { past_key_values: true });
+      `,
+      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+    },
+    "past_key_values accepts DynamicCache": {
+      code: `
+        import { DynamicCache, pipeline } from "../../types/transformers.js";
+        const generator = await pipeline("text-generation", "model-id");
+        await generator("hi", { past_key_values: new DynamicCache() });
+      `,
+      errors: [],
+    },
+    "past_key_values accepts null": {
+      code: `
+        import { pipeline } from "../../types/transformers.js";
+        const generator = await pipeline("text-generation", "model-id");
+        await generator("hi", { past_key_values: null });
+      `,
+      errors: [],
+    },
+  };
+
+  for (const [name, { code, errors }] of Object.entries(ERROR_CASES)) {
+    it(name, () => {
+      const diagnostics = getDiagnosticsFromSource(code);
+
+      expect(diagnostics).toHaveLength(errors.length);
+
+      for (let i = 0; i < errors.length; i++) {
+        const diag = diagnostics[i];
+        const expected = errors[i];
+
+        expect(diag.code).toBe(expected.code);
+
+        const underlined = diag.file?.text?.slice(diag.start, diag.start + diag.length);
+        expect(underlined).toBe(expected.underline);
+
+        const message = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
+        expect(message).toContain(expected.messageIncludes);
       }
     });
   }

--- a/packages/transformers/tests/types.test.js
+++ b/packages/transformers/tests/types.test.js
@@ -52,69 +52,277 @@ describe("TypeScript compilation succeeds", () => {
 });
 
 describe("TypeScript expected errors", () => {
-  /** @type {Record<string, { code: string, errors: Array<{ code: number, underline: string, messageIncludes: string }> }>} */
-  const ERROR_CASES = {
-    "past_key_values rejects string (chat input)": {
-      code: `
-        import { pipeline } from "../../types/transformers.js";
-        const generator = await pipeline("text-generation", "model-id");
-        const messages = [{ role: "user", content: "Hello!" }];
-        await generator(messages, { past_key_values: "hello" });
-      `,
-      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
-    },
-    "past_key_values rejects number (string input)": {
-      code: `
-        import { pipeline } from "../../types/transformers.js";
-        const generator = await pipeline("text-generation", "model-id");
-        await generator("hi", { past_key_values: 42 });
-      `,
-      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
-    },
-    "past_key_values rejects boolean": {
-      code: `
-        import { pipeline } from "../../types/transformers.js";
-        const generator = await pipeline("text-generation", "model-id");
-        await generator("hi", { past_key_values: true });
-      `,
-      errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
-    },
-    "past_key_values accepts DynamicCache": {
-      code: `
-        import { DynamicCache, pipeline } from "../../types/transformers.js";
-        const generator = await pipeline("text-generation", "model-id");
-        await generator("hi", { past_key_values: new DynamicCache() });
-      `,
-      errors: [],
-    },
-    "past_key_values accepts null": {
-      code: `
-        import { pipeline } from "../../types/transformers.js";
-        const generator = await pipeline("text-generation", "model-id");
-        await generator("hi", { past_key_values: null });
-      `,
-      errors: [],
-    },
+  /**
+   * Helper: generates inline source for a pipeline error test.
+   * @param {string} task Pipeline task name
+   * @param {string} callArgs Arguments to pass to the pipeline call (e.g., `'"hi", { top_k: "bad" }')`)
+   */
+  const src = (task, callArgs) => `
+    import { pipeline } from "../../types/transformers.js";
+    const p = await pipeline("${task}", "model-id");
+    await p(${callArgs});
+  `;
+
+  /** @param {string} task @param {string} callArgs */
+  const srcWithDynamicCache = (task, callArgs) => `
+    import { DynamicCache, pipeline } from "../../types/transformers.js";
+    const p = await pipeline("${task}", "model-id");
+    await p(${callArgs});
+  `;
+
+  /**
+   * Pipeline error test cases.
+   *
+   * Each pipeline task maps to an array of test cases. Each test case has:
+   * - `name`: test description
+   * - `code`: inline TypeScript source (use `src()` helper for convenience)
+   * - `errors`: expected diagnostics (empty = should compile without errors)
+   *
+   * @type {Record<string, Array<{ name: string, code: string, errors: Array<{ code: number, underline: string, messageIncludes: string }> }>>}
+   */
+  const PIPELINE_CASES = {
+    "text-generation": [
+      {
+        name: "past_key_values rejects string (chat input)",
+        code: src("text-generation", `[{role:"user",content:"hi"}], { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+      {
+        name: "past_key_values rejects string (string input)",
+        code: src("text-generation", `"hi", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+      {
+        name: "past_key_values rejects number",
+        code: src("text-generation", `"hi", { past_key_values: 42 }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+      {
+        name: "past_key_values rejects boolean",
+        code: src("text-generation", `"hi", { past_key_values: true }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+      {
+        name: "past_key_values accepts DynamicCache",
+        code: srcWithDynamicCache("text-generation", `"hi", { past_key_values: new DynamicCache() }`),
+        errors: [],
+      },
+      {
+        name: "past_key_values accepts null",
+        code: src("text-generation", `"hi", { past_key_values: null }`),
+        errors: [],
+      },
+    ],
+
+    "text2text-generation": [
+      {
+        name: "past_key_values rejects string",
+        code: src("text2text-generation", `"translate: hello", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    translation: [
+      {
+        name: "past_key_values rejects string",
+        code: src("translation", `"Bonjour", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    summarization: [
+      {
+        name: "past_key_values rejects string",
+        code: src("summarization", `"Long article text...", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    "image-to-text": [
+      {
+        name: "past_key_values rejects string",
+        code: src("image-to-text", `"http://img.png", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    "automatic-speech-recognition": [
+      {
+        name: "past_key_values rejects string",
+        code: src("automatic-speech-recognition", `new Float32Array(16000), { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    "document-question-answering": [
+      {
+        name: "past_key_values rejects string",
+        code: src("document-question-answering", `"http://img.png", "What is this?", { past_key_values: "bad" }`),
+        errors: [{ code: 2322, underline: "past_key_values", messageIncludes: "DynamicCache" }],
+      },
+    ],
+
+    "audio-classification": [
+      {
+        name: "top_k rejects string",
+        code: src("audio-classification", `new Float32Array(16000), { top_k: "bad" }`),
+        errors: [{ code: 2322, underline: "top_k", messageIncludes: "number" }],
+      },
+    ],
+
+    "fill-mask": [
+      {
+        name: "top_k rejects string",
+        code: src("fill-mask", `"The [MASK] sat on the mat.", { top_k: "bad" }`),
+        errors: [{ code: 2322, underline: "top_k", messageIncludes: "number" }],
+      },
+    ],
+
+    "image-classification": [
+      {
+        name: "top_k rejects string",
+        code: src("image-classification", `"http://img.png", { top_k: "bad" }`),
+        errors: [{ code: 2322, underline: "top_k", messageIncludes: "number" }],
+      },
+    ],
+
+    "object-detection": [
+      {
+        name: "threshold rejects string",
+        code: src("object-detection", `"http://img.png", { threshold: "bad" }`),
+        errors: [{ code: 2322, underline: "threshold", messageIncludes: "number" }],
+      },
+    ],
+
+    "token-classification": [
+      {
+        name: "ignore_labels rejects string",
+        code: src("token-classification", `"Hello world", { ignore_labels: "bad" }`),
+        errors: [{ code: 2322, underline: "ignore_labels", messageIncludes: "string[]" }],
+      },
+    ],
+
+    "text-classification": [
+      {
+        name: "top_k rejects string",
+        code: src("text-classification", `"I love this!", { top_k: "bad" }`),
+        errors: [{ code: 2322, underline: "top_k", messageIncludes: "number" }],
+      },
+    ],
+
+    "question-answering": [
+      {
+        name: "top_k rejects string",
+        code: src("question-answering", `"Who?", "Context.", { top_k: "bad" }`),
+        errors: [{ code: 2322, underline: "top_k", messageIncludes: "number" }],
+      },
+    ],
+
+    "feature-extraction": [
+      {
+        name: "pooling rejects number",
+        code: src("feature-extraction", `"text", { pooling: 123 }`),
+        errors: [{ code: 2322, underline: "pooling", messageIncludes: '"none" | "mean"' }],
+      },
+    ],
+
+    "image-segmentation": [
+      {
+        name: "threshold rejects string",
+        code: src("image-segmentation", `"http://img.png", { threshold: "bad" }`),
+        errors: [{ code: 2322, underline: "threshold", messageIncludes: "number" }],
+      },
+    ],
+
+    "image-feature-extraction": [
+      {
+        name: "pool rejects string",
+        code: src("image-feature-extraction", `"http://img.png", { pool: "bad" }`),
+        errors: [{ code: 2322, underline: "pool", messageIncludes: "boolean" }],
+      },
+    ],
+
+    "text-to-audio": [
+      {
+        name: "speaker_embeddings rejects number",
+        code: src("text-to-audio", `"Hello", { speaker_embeddings: 123 }`),
+        errors: [{ code: 2322, underline: "speaker_embeddings", messageIncludes: "Tensor" }],
+      },
+    ],
+
+    "zero-shot-classification": [
+      {
+        name: "multi_label rejects string",
+        code: src("zero-shot-classification", `"text", ["a", "b"], { multi_label: "bad" }`),
+        errors: [{ code: 2322, underline: "multi_label", messageIncludes: "boolean" }],
+      },
+    ],
+
+    "zero-shot-audio-classification": [
+      {
+        name: "hypothesis_template rejects number",
+        code: src("zero-shot-audio-classification", `new Float32Array(16000), ["a", "b"], { hypothesis_template: 123 }`),
+        errors: [{ code: 2322, underline: "hypothesis_template", messageIncludes: "string" }],
+      },
+    ],
+
+    "zero-shot-image-classification": [
+      {
+        name: "hypothesis_template rejects number",
+        code: src("zero-shot-image-classification", `"http://img.png", ["a", "b"], { hypothesis_template: 123 }`),
+        errors: [{ code: 2322, underline: "hypothesis_template", messageIncludes: "string" }],
+      },
+    ],
+
+    "zero-shot-object-detection": [
+      {
+        name: "threshold rejects string",
+        code: src("zero-shot-object-detection", `"http://img.png", ["a", "b"], { threshold: "bad" }`),
+        errors: [{ code: 2322, underline: "threshold", messageIncludes: "number" }],
+      },
+    ],
+
+    "depth-estimation": [
+      {
+        name: "rejects unexpected options argument",
+        code: src("depth-estimation", `"http://img.png", { bad: true }`),
+        errors: [{ code: 2554, underline: "{ bad: true }", messageIncludes: "Expected 1 arguments" }],
+      },
+    ],
+
+    "image-to-image": [
+      {
+        name: "rejects unexpected options argument",
+        code: src("image-to-image", `"http://img.png", { bad: true }`),
+        errors: [{ code: 2554, underline: "{ bad: true }", messageIncludes: "Expected 1 arguments" }],
+      },
+    ],
   };
 
-  for (const [name, { code, errors }] of Object.entries(ERROR_CASES)) {
-    it(name, () => {
-      const diagnostics = getDiagnosticsFromSource(code);
+  describe("pipeline errors", () => {
+    for (const [task, cases] of Object.entries(PIPELINE_CASES)) {
+      describe(task, () => {
+        for (const { name, code, errors } of cases) {
+          it(name, () => {
+            const diagnostics = getDiagnosticsFromSource(code);
 
-      expect(diagnostics).toHaveLength(errors.length);
+            expect(diagnostics).toHaveLength(errors.length);
 
-      for (let i = 0; i < errors.length; i++) {
-        const diag = diagnostics[i];
-        const expected = errors[i];
+            for (let i = 0; i < errors.length; i++) {
+              const diag = diagnostics[i];
+              const expected = errors[i];
 
-        expect(diag.code).toBe(expected.code);
+              expect(diag.code).toBe(expected.code);
 
-        const underlined = diag.file?.text?.slice(diag.start, diag.start + diag.length);
-        expect(underlined).toBe(expected.underline);
+              const underlined = diag.file?.text?.slice(diag.start, diag.start + diag.length);
+              expect(underlined).toBe(expected.underline);
 
-        const message = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
-        expect(message).toContain(expected.messageIncludes);
-      }
-    });
-  }
+              const message = ts.flattenDiagnosticMessageText(diag.messageText, "\n");
+              expect(message).toContain(expected.messageIncludes);
+            }
+          });
+        }
+      });
+    }
+  });
 });

--- a/packages/transformers/tests/types/_base.ts
+++ b/packages/transformers/tests/types/_base.ts
@@ -6,4 +6,7 @@ type Equal<X, Y> =
 // Throws a type error if T is not `true`
 type Expect<T extends true> = T;
 
-export type { Expect, Equal };
+// Throws a type error if T is not `false`
+type ExpectError<T extends false> = T;
+
+export type { Expect, Equal, ExpectError };

--- a/packages/transformers/tests/types/cache.ts
+++ b/packages/transformers/tests/types/cache.ts
@@ -2,8 +2,9 @@ import { DynamicCache } from "../../src/cache_utils.js";
 
 import type { Tensor } from "../../src/utils/tensor.js";
 
+import type { TextGenerationConfig } from "../../src/pipelines/text-generation.js";
 
-import type { Expect, Equal } from "./_base.ts";
+import type { Expect, Equal, ExpectError } from "./_base.ts";
 
 // Initialize Dynamic Cache
 const cache = new DynamicCache();
@@ -19,3 +20,18 @@ for (const key in cache) {
 
 // Ensure tensors in cache can be disposed
 type T4 = Expect<Equal<ReturnType<typeof cache.dispose>, Promise<void>>>;
+
+// Ensure past_key_values accepts DynamicCache or null
+type PastKeyValues = TextGenerationConfig['past_key_values'];
+type T5 = Expect<Equal<PastKeyValues, DynamicCache | null | undefined>>;
+
+// Ensure DynamicCache is assignable to past_key_values
+type IsAssignable<T, U> = T extends U ? true : false;
+type T6 = Expect<IsAssignable<DynamicCache, NonNullable<PastKeyValues>>>;
+type T7 = Expect<IsAssignable<null, PastKeyValues>>;
+
+// Ensure invalid types are NOT assignable to past_key_values
+type T8 = ExpectError<IsAssignable<string, NonNullable<PastKeyValues>>>;
+type T9 = ExpectError<IsAssignable<number, NonNullable<PastKeyValues>>>;
+type T10 = ExpectError<IsAssignable<boolean, NonNullable<PastKeyValues>>>;
+type T11 = ExpectError<IsAssignable<object, NonNullable<PastKeyValues>>>;

--- a/packages/transformers/tests/utils/generation.test.js
+++ b/packages/transformers/tests/utils/generation.test.js
@@ -10,7 +10,9 @@ import {
 
   // Other
   TextStreamer,
+  DynamicCache,
   random,
+  full,
 } from "../../src/transformers.js";
 
 import { init, MAX_TEST_EXECUTION_TIME, MAX_MODEL_LOAD_TIME, MAX_MODEL_DISPOSE_TIME, DEFAULT_MODEL_OPTIONS } from "../init.js";
@@ -448,6 +450,19 @@ describe("Streamers", () => {
       ];
       expect(chunks).toEqual(TARGET);
     });
+  });
+});
+
+describe("Dynamic Cache", () => {
+  it("should update and get sequence length correctly", () => {
+    const cache = new DynamicCache();
+    expect(cache.get_seq_length()).toEqual(0);
+
+    cache.update({
+      "past_key_values.0.key": full([1, 2, 16, 32], 0.0),
+      "past_key_values.0.value": full([1, 2, 16, 32], 0.0),
+    });
+    expect(cache.get_seq_length()).toEqual(16);
   });
 });
 


### PR DESCRIPTION
This PR now allows past_key_values to be used inside the pipeline function, leading to significantly faster generation for long conversations (no unnecessary recomputation)! 🙌 

Example usage:
```js
import {
  pipeline,
  DynamicCache,
} from "@huggingface/transformers";

// Create a text generation pipeline
const generator = await pipeline(
  "text-generation",
  "onnx-community/LFM2.5-350M-ONNX",
  { dtype: "q4", device: "webgpu" },
);

// NEW: Create a shared cache for multi-turn conversation
const past_key_values = new DynamicCache();

// Define the list of messages
const messages = [{ role: "user", content: "Tell me a very long story about cheese." }];

// === Turn 1 ===
let start = performance.now();
const output1 = await generator(messages, {
  max_new_tokens: 1024,
  do_sample: false,
  past_key_values,
});
const reply1 = output1[0].generated_text.at(-1);
console.log(`Turn 1: ${(performance.now() - start).toFixed(2)}ms | Cache seq length: ${past_key_values.get_seq_length()}`);

// === Turn 2 ===
messages.push(reply1);
messages.push({ role: "user", content: "Answer in one word: What is 1 + 1?" });

start = performance.now();
const output2 = await generator(messages, {
  max_new_tokens: 128,
  do_sample: false,
  past_key_values,
});
const reply2 = output2[0].generated_text.at(-1);
console.log(`Turn 2: ${(performance.now() - start).toFixed(2)}ms | Cache seq length: ${past_key_values.get_seq_length()}`);

// === Turn 3 ===
messages.push(reply2);
messages.push({ role: "user", content: "Answer in one word: What is 2 + 2?" });

start = performance.now();
await generator(messages, {
  max_new_tokens: 128,
  do_sample: false,
  past_key_values,
});
console.log(`Turn 3: ${(performance.now() - start).toFixed(2)}ms | Cache seq length: ${past_key_values.get_seq_length()}`);

// Clean up
await past_key_values.dispose();
```

outputs
```
Turn 1: 4235.52ms | Cache seq length: 996
Turn 2: 117.24ms | Cache seq length: 1025
Turn 3: 72.07ms | Cache seq length: 1049
```


without setting past_key_values, you get
```
Turn 1: 4355.55ms | Cache seq length: 0
Turn 2: 293.84ms | Cache seq length: 0
Turn 3: 248.94ms | Cache seq length: 0
```

🔥 Improvements will be even more noticeable for multimodal models, since we don't need to compute image features.