### PR TITLE
feat: export deviceToExecutionProviders and getSupportedDevices

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -178,6 +178,20 @@ export function deviceToExecutionProviders(device = null) {
 }
 
 /**
+ * Get the list of supported devices for the current platform, sorted by
+ * priority/performance (best first, CPU/WASM last).
+ *
+ * This is the same ordering used internally when `device` is set to `"auto"`.
+ * Returns a shallow copy so callers can mutate or iterate without affecting
+ * library internals.
+ *
+ * @returns {import("../utils/devices.js").DeviceType[]} The supported devices.
+ */
+export function getSupportedDevices() {
+    return /** @type {import("../utils/devices.js").DeviceType[]} */ ([...supportedDevices]);
+}
+
+/**
  * Currently, Transformers.js doesn't support simultaneous loading of sessions in WASM/WebGPU.
  * For this reason, we need to chain the loading calls.
  * @type {Promise<any>}

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -55,6 +55,9 @@ export { random } from './utils/random.js';
 
 export { DynamicCache } from './cache_utils.js';
 
+// Device utilities
+export { deviceToExecutionProviders, getSupportedDevices } from './backends/onnx.js';
+
 // Cache and file management
 export { ModelRegistry } from './utils/model_registry/ModelRegistry.js';
 


### PR DESCRIPTION
## Summary

Export two device utility functions from the public API so downstream libraries can implement their own device fallback logic:

- **`deviceToExecutionProviders(device)`** — maps a device string (e.g. `"auto"`, `"cuda"`, `"cpu"`) to the corresponding ONNX execution providers list. Already existed internally, just not re-exported.
- **`getSupportedDevices()`** — returns a copy of the platform-specific `supportedDevices` array in priority order (e.g. `["cuda", "webgpu", "cpu"]` on Linux x64, `["coreml", "webgpu", "cpu"]` on macOS).

## Why

When `device="auto"` and a provider crashes hard (e.g. CUDA when `libcudnn.so` is missing — see #1642), downstream code needs to retry providers individually. Without access to the device list, libraries have to hardcode their own copy of the platform detection logic, which drifts when transformers.js updates.

### Example usage

```js
import { getSupportedDevices } from '@huggingface/transformers';

// Walk devices one at a time, catching provider crashes
for (const device of getSupportedDevices()) {
  try {
    model = await AutoModel.from_pretrained(modelId, { device });
    break;
  } catch (err) {
    console.warn(`device=${device} failed: ${err.message}`);
  }
}
```

## Changes

- `src/backends/onnx.js`: added `getSupportedDevices()` function
- `src/transformers.js`: re-exported `deviceToExecutionProviders` and `getSupportedDevices`

Closes #1645