### PR TITLE
Update default generation parameters

### DIFF
--- a/packages/transformers/src/pipelines/automatic-speech-recognition.js
+++ b/packages/transformers/src/pipelines/automatic-speech-recognition.js
@@ -141,6 +141,11 @@ export class AutomaticSpeechRecognitionPipeline
     )
 {
     async _call(audio, kwargs = {}) {
+        kwargs = {
+            max_new_tokens: 256,
+            num_beams: 5, 
+            ...kwargs
+        };
         switch (this.model.config.model_type) {
             case 'whisper':
             case 'lite-whisper':

--- a/packages/transformers/src/pipelines/automatic-speech-recognition.js
+++ b/packages/transformers/src/pipelines/automatic-speech-recognition.js
@@ -140,11 +140,15 @@ export class AutomaticSpeechRecognitionPipeline
         Pipeline
     )
 {
+    _default_generation_config = {
+        // TODO: figure out good defaults for ASR generation parameters
+        // max_new_tokens: 256,
+        // num_beams: 5,
+    };
     async _call(audio, kwargs = {}) {
         kwargs = {
-            max_new_tokens: 256,
-            num_beams: 5, 
-            ...kwargs
+            ...this._default_generation_config,
+            ...kwargs,
         };
         switch (this.model.config.model_type) {
             case 'whisper':

--- a/packages/transformers/src/pipelines/document-question-answering.js
+++ b/packages/transformers/src/pipelines/document-question-answering.js
@@ -44,6 +44,10 @@ export class DocumentQuestionAnsweringPipeline
     )
 {
     async _call(image, question, generate_kwargs = {}) {
+        generate_kwargs = {
+            max_new_tokens: 256,
+            ...generate_kwargs
+        };
         if (Array.isArray(image)) {
             if (image.length !== 1) {
                 throw Error('Document Question Answering pipeline currently only supports a batch size of 1.');

--- a/packages/transformers/src/pipelines/document-question-answering.js
+++ b/packages/transformers/src/pipelines/document-question-answering.js
@@ -43,11 +43,10 @@ export class DocumentQuestionAnsweringPipeline
         Pipeline
     )
 {
+    _default_generation_config = {
+        max_new_tokens: 256,
+    };
     async _call(image, question, generate_kwargs = {}) {
-        generate_kwargs = {
-            max_new_tokens: 256,
-            ...generate_kwargs
-        };
         if (Array.isArray(image)) {
             if (image.length !== 1) {
                 throw Error('Document Question Answering pipeline currently only supports a batch size of 1.');
@@ -73,6 +72,8 @@ export class DocumentQuestionAnsweringPipeline
             // @ts-expect-error Ts2339
             max_length: this.model.config.decoder.max_position_embeddings,
             decoder_input_ids,
+
+            ...this._default_generation_config,
             ...generate_kwargs,
         });
 

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -105,6 +105,12 @@ export class TextGenerationPipeline
      * @param {Partial<TextGenerationConfig>} generate_kwargs
      */
     async _call(texts, generate_kwargs = {}) {
+        generate_kwargs = { 
+            max_new_tokens: 256,
+            do_sample: true,
+            temperature: 0.7, 
+            ...generate_kwargs
+        };
         let isBatched = false;
         let isChatInput = false;
 

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -100,17 +100,17 @@ function isChat(x) {
 export class TextGenerationPipeline
     extends /** @type {new (options: TextPipelineConstructorArgs) => TextGenerationPipelineType} */ (Pipeline)
 {
+    _default_generation_config = {
+        max_new_tokens: 256,
+        // do_sample: true,
+        // temperature: 0.7,
+    };
+
     /**
      * @param {string | string[] | import('../tokenization_utils.js').Message[] | import('../tokenization_utils.js').Message[][]} texts
      * @param {Partial<TextGenerationConfig>} generate_kwargs
      */
     async _call(texts, generate_kwargs = {}) {
-        generate_kwargs = { 
-            max_new_tokens: 256,
-            do_sample: true,
-            temperature: 0.7, 
-            ...generate_kwargs
-        };
         let isBatched = false;
         let isChatInput = false;
 
@@ -169,6 +169,7 @@ export class TextGenerationPipeline
         const outputTokenIds = /** @type {Tensor} */ (
             await this.model.generate({
                 ...text_inputs,
+                ...this._default_generation_config,
                 ...generate_kwargs,
             })
         );

--- a/packages/transformers/src/pipelines/text2text-generation.js
+++ b/packages/transformers/src/pipelines/text2text-generation.js
@@ -42,6 +42,12 @@ export class Text2TextGenerationPipeline
 
     /** @type {Text2TextGenerationPipelineCallback} */
     async _call(texts, generate_kwargs = {}) {
+        generate_kwargs = { 
+            max_new_tokens: 256,
+            do_sample: true,
+            temperature: 0.7, 
+            ...generate_kwargs
+        };
         if (!Array.isArray(texts)) {
             texts = [texts];
         }

--- a/packages/transformers/src/pipelines/text2text-generation.js
+++ b/packages/transformers/src/pipelines/text2text-generation.js
@@ -37,17 +37,17 @@ import { Tensor } from '../utils/tensor.js';
 export class Text2TextGenerationPipeline
     extends /** @type {new (options: TextPipelineConstructorArgs) => Text2TextGenerationPipelineType} */ (Pipeline)
 {
+    _default_generation_config = {
+        max_new_tokens: 256,
+        // do_sample: true,
+        // temperature: 0.7,
+    };
+
     /** @type {'generated_text'} */
     _key = 'generated_text';
 
     /** @type {Text2TextGenerationPipelineCallback} */
     async _call(texts, generate_kwargs = {}) {
-        generate_kwargs = { 
-            max_new_tokens: 256,
-            do_sample: true,
-            temperature: 0.7, 
-            ...generate_kwargs
-        };
         if (!Array.isArray(texts)) {
             texts = [texts];
         }
@@ -86,7 +86,11 @@ export class Text2TextGenerationPipeline
             inputs = tokenizer(texts, tokenizer_options);
         }
 
-        const outputTokenIds = await this.model.generate({ ...inputs, ...generate_kwargs });
+        const outputTokenIds = await this.model.generate({
+            ...inputs,
+            ...this._default_generation_config,
+            ...generate_kwargs,
+        });
         return tokenizer
             .batch_decode(/** @type {Tensor} */ (outputTokenIds), {
                 skip_special_tokens: true,

--- a/packages/transformers/tests/pipelines/test_pipelines_document_question_answering.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_document_question_answering.js
@@ -25,7 +25,9 @@ export default () => {
           const dims = [64, 32, 3];
           const image = new RawImage(new Uint8ClampedArray(dims[0] * dims[1] * dims[2]).fill(255), ...dims);
           const question = "What is the invoice number?";
-          const output = await pipe(image, question);
+          const output = await pipe(image, question, {
+            max_new_tokens: 5,
+          });
 
           const target = [{ answer: null }];
           expect(output).toEqual(target);


### PR DESCRIPTION
supersedes https://github.com/huggingface/transformers.js/pull/1633

some notes:
- decided against adding `do_sample` as a default parameter for now as this is really a breaking change (after testing a bit more). Many tests fail if we do that because no defaults are specified there. Also, the additional overhead of sampling (and possible issues this could cause) isn't worth adding for now
- we will add `max_new_tokens` as a good default because this is pretty expected... especially when people generate and get no response (or max 1 new token), and will be less breaking because we will now generate to completion (more often).
- not updating ASR for now since whisper models have `max_length` set already to 448, meaning we generate to completion.

more than happy to revisit in future, but this is the best option we have at the moment, I'd say 😅 