### PR TITLE
Added `tools` to `TextGenerationPipeline`

### DIFF
--- a/packages/transformers/jest.config.mjs
+++ b/packages/transformers/jest.config.mjs
@@ -134,6 +134,9 @@ export default {
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
 
+  // Timeout in milliseconds for each test.
+  testTimeout: 32000,
+
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],
 

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -27,6 +27,10 @@ function isChat(x) {
  * @typedef {Object} TextGenerationSpecificParams Parameters specific to text-generation pipelines.
  * @property {boolean} [add_special_tokens] Whether or not to add special tokens when tokenizing the sequences.
  * @property {boolean} [return_full_text=true] If set to `false` only added text is returned, otherwise the full text is returned.
+ * @property {boolean} [add_generation_prompt=true] Whether to append the assistant generation prompt when applying a chat template.
+ * @property {Object[]|null} [tools=null] A list of tools to expose to chat templates that support tool use.
+ * @property {Record<string, string>[]|null} [documents=null] A list of documents to expose to chat templates that support RAG.
+ * @property {string|null} [chat_template=null] A specific chat template (or template name) to apply.
  * @property {Object} [tokenizer_encode_kwargs] Additional keyword arguments to pass along to the encoding step of the tokenizer.
  * If the text input is a chat, it is passed to `apply_chat_template`. Otherwise, it is passed to the tokenizer's call function.
  * @typedef {import('../generation/parameters.js').GenerationFunctionParameters & TextGenerationSpecificParams} TextGenerationConfig
@@ -98,16 +102,25 @@ export class TextGenerationPipeline
      * @param {Partial<TextGenerationConfig>} generate_kwargs
      */
     async _call(texts, generate_kwargs = {}) {
+        const {
+            add_special_tokens: add_special_tokens_arg,
+            return_full_text: return_full_text_arg,
+            add_generation_prompt,
+            tools,
+            documents,
+            chat_template,
+            tokenizer_encode_kwargs,
+            ...generation_kwargs
+        } = generate_kwargs;
+
         let isBatched = false;
         let isChatInput = false;
 
         // By default, do not add special tokens, unless the tokenizer specifies otherwise
         let add_special_tokens =
-            generate_kwargs.add_special_tokens ??
-            (this.tokenizer.add_bos_token || this.tokenizer.add_eos_token) ??
-            false;
+            add_special_tokens_arg ?? (this.tokenizer.add_bos_token || this.tokenizer.add_eos_token) ?? false;
 
-        let tokenizer_kwargs = generate_kwargs.tokenizer_encode_kwargs;
+        let tokenizer_kwargs = tokenizer_encode_kwargs;
 
         // Normalize inputs
         /** @type {string[]} */
@@ -128,17 +141,29 @@ export class TextGenerationPipeline
             isChatInput = true;
 
             // If the input is a chat, we need to apply the chat template
+            const chat_template_kwargs = {
+                tokenize: false,
+                add_generation_prompt: add_generation_prompt ?? true,
+                ...tokenizer_kwargs,
+            };
+
+            if (tools !== undefined && chat_template_kwargs.tools === undefined) {
+                chat_template_kwargs.tools = tools;
+            }
+
+            if (documents !== undefined && chat_template_kwargs.documents === undefined) {
+                chat_template_kwargs.documents = documents;
+            }
+
+            if (chat_template !== undefined && chat_template_kwargs.chat_template === undefined) {
+                chat_template_kwargs.chat_template = chat_template;
+            }
+
             inputs = /** @type {string[]} */ (
                 /** @type {Chat[]} */ (texts).map(
                     (x) =>
                         /** @type {string} */ (
-                            /** @type {unknown} */ (
-                                this.tokenizer.apply_chat_template(x, {
-                                    tokenize: false,
-                                    add_generation_prompt: true,
-                                    ...tokenizer_kwargs,
-                                })
-                            )
+                            /** @type {unknown} */ (this.tokenizer.apply_chat_template(x, chat_template_kwargs))
                         ),
                 )
             );
@@ -148,7 +173,7 @@ export class TextGenerationPipeline
         }
 
         // By default, return full text
-        const return_full_text = isChatInput ? false : (generate_kwargs.return_full_text ?? true);
+        const return_full_text = isChatInput ? false : (return_full_text_arg ?? true);
 
         this.tokenizer.padding_side = 'left';
         const text_inputs = this.tokenizer(inputs, {
@@ -162,7 +187,7 @@ export class TextGenerationPipeline
             await this.model.generate({
                 ...text_inputs,
                 ...this._default_generation_config,
-                ...generate_kwargs,
+                ...generation_kwargs,
             })
         );
 

--- a/packages/transformers/src/pipelines/text-generation.js
+++ b/packages/transformers/src/pipelines/text-generation.js
@@ -1,6 +1,7 @@
 import { Pipeline } from './_base.js';
 
 import { Tensor } from '../utils/tensor.js';
+import { pick } from '../utils/core.js';
 
 /**
  * @typedef {import('./_base.js').TextPipelineConstructorArgs} TextPipelineConstructorArgs
@@ -27,7 +28,6 @@ function isChat(x) {
  * @typedef {Object} TextGenerationSpecificParams Parameters specific to text-generation pipelines.
  * @property {boolean} [add_special_tokens] Whether or not to add special tokens when tokenizing the sequences.
  * @property {boolean} [return_full_text=true] If set to `false` only added text is returned, otherwise the full text is returned.
- * @property {boolean} [add_generation_prompt=true] Whether to append the assistant generation prompt when applying a chat template.
  * @property {Object[]|null} [tools=null] A list of tools to expose to chat templates that support tool use.
  * @property {Record<string, string>[]|null} [documents=null] A list of documents to expose to chat templates that support RAG.
  * @property {string|null} [chat_template=null] A specific chat template (or template name) to apply.
@@ -105,7 +105,6 @@ export class TextGenerationPipeline
         const {
             add_special_tokens: add_special_tokens_arg,
             return_full_text: return_full_text_arg,
-            add_generation_prompt,
             tools,
             documents,
             chat_template,
@@ -143,21 +142,10 @@ export class TextGenerationPipeline
             // If the input is a chat, we need to apply the chat template
             const chat_template_kwargs = {
                 tokenize: false,
-                add_generation_prompt: add_generation_prompt ?? true,
+                add_generation_prompt: true,
+                ...pick({ tools, documents, chat_template }, ['tools', 'documents', 'chat_template']),
                 ...tokenizer_kwargs,
             };
-
-            if (tools !== undefined && chat_template_kwargs.tools === undefined) {
-                chat_template_kwargs.tools = tools;
-            }
-
-            if (documents !== undefined && chat_template_kwargs.documents === undefined) {
-                chat_template_kwargs.documents = documents;
-            }
-
-            if (chat_template !== undefined && chat_template_kwargs.chat_template === undefined) {
-                chat_template_kwargs.chat_template = chat_template;
-            }
 
             inputs = /** @type {string[]} */ (
                 /** @type {Chat[]} */ (texts).map(

--- a/packages/transformers/tests/init.js
+++ b/packages/transformers/tests/init.js
@@ -58,7 +58,7 @@ export function init() {
   registerBackend("test", onnxruntimeBackend, Number.POSITIVE_INFINITY);
 }
 
-export const MAX_TOKENIZER_LOAD_TIME = 10_000; // 10 seconds
+export const MAX_TOKENIZER_LOAD_TIME = 32_000; // 32 seconds
 export const MAX_FEATURE_EXTRACTOR_LOAD_TIME = 10_000; // 10 seconds
 export const MAX_PROCESSOR_LOAD_TIME = 10_000; // 10 seconds
 export const MAX_MODEL_LOAD_TIME = 15_000; // 15 seconds

--- a/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
@@ -1,4 +1,5 @@
 import { pipeline, TextGenerationPipeline, DynamicCache } from "../../src/transformers.js";
+import { jest } from "@jest/globals";
 
 import { MAX_MODEL_LOAD_TIME, MAX_TEST_EXECUTION_TIME, MAX_MODEL_DISPOSE_TIME, DEFAULT_MODEL_OPTIONS } from "../init.js";
 
@@ -85,6 +86,39 @@ export default () => {
         async () => {
           const output = await pipe([chat_input], { max_new_tokens: 3 });
           expect(output).toEqual([chat_target]);
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+
+      it(
+        "chat input forwards top-level tools",
+        async () => {
+          const tools = [
+            {
+              name: "get_weather",
+              description: "Get the weather in a city",
+              parameter_definitions: {
+                location: {
+                  description: "City and country",
+                  type: "str",
+                  required: true,
+                },
+              },
+            },
+          ];
+
+          const spy = jest.spyOn(pipe.tokenizer, "apply_chat_template");
+          await pipe(chat_input, {
+            max_new_tokens: 3,
+            do_sample: false,
+            tools,
+            add_generation_prompt: false,
+          });
+
+          const [, options] = spy.mock.calls.at(-1);
+          expect(options.tools).toEqual(tools);
+          expect(options.add_generation_prompt).toBe(false);
+          spy.mockRestore();
         },
         MAX_TEST_EXECUTION_TIME,
       );

--- a/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_text_generation.js
@@ -112,12 +112,11 @@ export default () => {
             max_new_tokens: 3,
             do_sample: false,
             tools,
-            add_generation_prompt: false,
           });
 
           const [, options] = spy.mock.calls.at(-1);
           expect(options.tools).toEqual(tools);
-          expect(options.add_generation_prompt).toBe(false);
+          expect(options.add_generation_prompt).toBe(true);
           spy.mockRestore();
         },
         MAX_TEST_EXECUTION_TIME,


### PR DESCRIPTION
pipe(messages, { tools, ... }) is now supported directly in text-generation to align with @huggingface/transfomers:
https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/text_generation.py#L143

Top-level chat-template args are now handled in the pipeline:
- tools
- documents
- chat_template
- add_generation_prompt
- tokenizer_encode_kwargs still works and has precedence if both are provided