### PR TITLE
Use inputMetadata API for simplified internals

### DIFF
--- a/packages/transformers/src/configs.js
+++ b/packages/transformers/src/configs.js
@@ -322,146 +322,82 @@ function getNormalizedConfig(config) {
 }
 
 /**
- *
  * @param {PretrainedConfig} config
- * @returns {Record<string, number[]>}
+ * @param {{ prefix?: string, session_name?: string }} [options]
+ * @returns {Set<string>}
  */
-export function getCacheShapes(config, options) {
+export function getCacheNames(config, options) {
     if (!(config instanceof PretrainedConfig)) {
         config = new PretrainedConfig(config);
     }
 
-    const batch_size = options?.batch_size ?? 1;
-    if (['lfm2', 'lfm2_moe'].includes(config.model_type)) {
-        const pkv_prefix = options?.prefix ?? 'past_key_values';
-        const conv_prefix = pkv_prefix === 'present' ? 'present' : 'past';
+    const pkv_prefix = options?.prefix ?? 'past_key_values';
+    const conv_prefix = pkv_prefix === 'present' ? 'present' : 'past';
+    /** @type {Set<string>} */
+    const names = new Set();
 
-        /** @type {Record<string, number[]>} */
-        const cache_values = {};
-        const { layer_types, num_attention_heads, num_key_value_heads, hidden_size, conv_L_cache } =
-            /** @type {any} */ (config);
-        const head_dim = hidden_size / num_attention_heads;
+    if (['lfm2', 'lfm2_moe'].includes(config.model_type)) {
+        const { layer_types } = /** @type {any} */ (config);
         for (let i = 0; i < layer_types.length; ++i) {
             if (layer_types[i] === 'full_attention') {
-                for (const kv of ['key', 'value']) {
-                    cache_values[`${pkv_prefix}.${i}.${kv}`] = [batch_size, num_key_value_heads, 0, head_dim];
-                }
+                names.add(`${pkv_prefix}.${i}.key`);
+                names.add(`${pkv_prefix}.${i}.value`);
             } else if (layer_types[i] === 'conv') {
-                cache_values[`${conv_prefix}_conv.${i}`] = [batch_size, hidden_size, conv_L_cache];
+                names.add(`${conv_prefix}_conv.${i}`);
             } else {
                 throw new Error(`Unsupported layer type: ${layer_types[i]}`);
             }
         }
-        return cache_values;
+        return names;
     } else if (['granitemoehybrid', 'falcon_h1', 'nemotron_h'].includes(config.model_type)) {
-        const pkv_prefix = options?.prefix ?? 'past_key_values';
-        const conv_prefix = pkv_prefix === 'present' ? 'present' : 'past';
-
         const c = /** @type {any} */ (config);
-
-        // Normalize config field names across model types
         const layer_types = c.layer_types ?? c.layers_block_type;
         const num_layers = c.num_hidden_layers ?? layer_types?.length;
-        const num_key_value_heads = c.num_key_value_heads;
-        const head_dim = c.head_dim ?? c.hidden_size / c.num_attention_heads;
-        const mamba_n_heads = c.mamba_n_heads ?? c.mamba_num_heads;
-        const mamba_d_head = c.mamba_d_head ?? c.mamba_head_dim;
-        const mamba_d_state = c.mamba_d_state ?? c.ssm_state_size;
-        const mamba_n_groups = c.mamba_n_groups ?? c.n_groups;
-        const mamba_d_conv = c.mamba_d_conv ?? c.conv_kernel;
-        const mamba_d_ssm =
-            c.mamba_d_ssm ?? (c.mamba_expand ? c.mamba_expand * c.hidden_size : mamba_n_heads * mamba_d_head);
-        const conv_d_inner = mamba_d_ssm + 2 * mamba_n_groups * mamba_d_state;
-
-        /** @type {Record<string, number[]>} */
-        const cache_values = {};
 
         for (let i = 0; i < num_layers; ++i) {
             if (!layer_types || layer_types[i] === 'mamba') {
-                cache_values[`${conv_prefix}_conv.${i}`] = [batch_size, conv_d_inner, mamba_d_conv];
-                cache_values[`${conv_prefix}_ssm.${i}`] = [batch_size, mamba_n_heads, mamba_d_head, mamba_d_state];
+                names.add(`${conv_prefix}_conv.${i}`);
+                names.add(`${conv_prefix}_ssm.${i}`);
             }
             if (!layer_types || layer_types[i] === 'attention') {
-                for (const kv of ['key', 'value']) {
-                    cache_values[`${pkv_prefix}.${i}.${kv}`] = [batch_size, num_key_value_heads, 0, head_dim];
-                }
+                names.add(`${pkv_prefix}.${i}.key`);
+                names.add(`${pkv_prefix}.${i}.value`);
             }
         }
-        return cache_values;
+        return names;
     } else if (['qwen3_next', 'qwen3_5_text', 'qwen3_5_moe_text', 'olmo_hybrid'].includes(config.model_type)) {
-        const pkv_prefix = options?.prefix ?? 'past_key_values';
-        const conv_prefix = pkv_prefix === 'present' ? 'present' : 'past';
-
-        /** @type {Record<string, number[]>} */
-        const cache_values = {};
-        const {
-            head_dim,
-            layer_types,
-            num_attention_heads,
-            num_key_value_heads,
-            hidden_size,
-            linear_num_value_heads,
-            linear_num_key_heads,
-            linear_key_head_dim,
-            linear_value_head_dim,
-            linear_conv_kernel_dim,
-        } = /** @type {any} */ (config);
-
-        const key_dim = linear_key_head_dim * linear_num_key_heads;
-        const value_dim = linear_value_head_dim * linear_num_value_heads;
-
-        const final_head_dim = head_dim ?? hidden_size / num_attention_heads;
+        const { layer_types } = /** @type {any} */ (config);
         for (let i = 0; i < layer_types.length; ++i) {
             if (layer_types[i] === 'full_attention') {
-                for (const kv of ['key', 'value']) {
-                    cache_values[`${pkv_prefix}.${i}.${kv}`] = [batch_size, num_key_value_heads, 0, final_head_dim];
-                }
+                names.add(`${pkv_prefix}.${i}.key`);
+                names.add(`${pkv_prefix}.${i}.value`);
             } else if (layer_types[i] === 'linear_attention') {
                 if (config.model_type === 'olmo_hybrid') {
-                    cache_values[`${conv_prefix}_conv.${i}.key`] = [batch_size, key_dim, linear_conv_kernel_dim];
-                    cache_values[`${conv_prefix}_conv.${i}.value`] = [batch_size, value_dim, linear_conv_kernel_dim];
-                    cache_values[`${conv_prefix}_conv.${i}.query`] = [batch_size, key_dim, linear_conv_kernel_dim];
+                    names.add(`${conv_prefix}_conv.${i}.key`);
+                    names.add(`${conv_prefix}_conv.${i}.value`);
+                    names.add(`${conv_prefix}_conv.${i}.query`);
                 } else {
-                    const conv_dim = key_dim * 2 + value_dim;
-                    cache_values[`${conv_prefix}_conv.${i}`] = [batch_size, conv_dim, linear_conv_kernel_dim];
+                    names.add(`${conv_prefix}_conv.${i}`);
                 }
-                cache_values[`${conv_prefix}_recurrent.${i}`] = [
-                    batch_size,
-                    linear_num_value_heads,
-                    linear_key_head_dim,
-                    linear_value_head_dim,
-                ];
+                names.add(`${conv_prefix}_recurrent.${i}`);
             } else {
                 throw new Error(`Unsupported layer type: ${layer_types[i]}`);
             }
         }
-        return cache_values;
+        return names;
     } else if (['gemma4', 'gemma4_text'].includes(config.model_type)) {
         const c = /** @type {any} */ (
             config.model_type === 'gemma4' ? /** @type {any} */ (config).text_config : config
         );
-        const pkv_prefix = options?.prefix ?? 'past_key_values';
-
-        /** @type {Record<string, number[]>} */
-        const cache_values = {};
         const num_hidden_layers = c.num_hidden_layers;
         const num_kv_shared_layers = c.num_kv_shared_layers ?? 0;
         const num_kv_layers = num_hidden_layers - num_kv_shared_layers;
-        const num_key_value_heads = c.num_key_value_heads;
-        const head_dim = c.head_dim;
-        const global_head_dim = c.global_head_dim ?? head_dim;
-        const layer_types = c.layer_types ?? [];
 
-        // Create `num_kv_layers` unique KV entries, corresponding to the first `num_kv_layers`
-        // model layers (the remaining layers share caches with earlier ones).
-        // Full attention layers use global_head_dim, sliding attention layers use head_dim.
         for (let i = 0; i < num_kv_layers; ++i) {
-            const dim = layer_types[i] === 'full_attention' ? global_head_dim : head_dim;
-            for (const kv of ['key', 'value']) {
-                cache_values[`${pkv_prefix}.${i}.${kv}`] = [batch_size, num_key_value_heads, 0, dim];
-            }
+            names.add(`${pkv_prefix}.${i}.key`);
+            names.add(`${pkv_prefix}.${i}.value`);
         }
-        return cache_values;
+        return names;
     } else if (['lfm2_vl', 'qwen3_5', 'qwen3_5_moe', 'voxtral_realtime'].includes(config.model_type)) {
         let subConfig;
         if (config.model_type === 'voxtral_realtime' && options?.session_name === 'audio_encoder') {
@@ -469,16 +405,20 @@ export function getCacheShapes(config, options) {
         } else {
             subConfig = /** @type {any} */ (config).text_config;
         }
-        return getCacheShapes(subConfig, options);
+        return getCacheNames(subConfig, options);
     }
 
-    return getKeyValueShapes(config, options);
+    return getKeyValueNames(config, { prefix: pkv_prefix });
 }
 
-/** @type {typeof getKeyValueShapes} */
-function getKeyValueShapes(config, { prefix = 'past_key_values', batch_size = 1 } = {}) {
-    /** @type {Record<string, number[]>} */
-    const decoderFeeds = {};
+/**
+ * @param {PretrainedConfig} config
+ * @param {{ prefix?: string }} [options]
+ * @returns {Set<string>}
+ */
+function getKeyValueNames(config, { prefix = 'past_key_values' } = {}) {
+    /** @type {Set<string>} */
+    const names = new Set();
     const normalized_config = config.normalized_config;
 
     if (
@@ -486,70 +426,25 @@ function getKeyValueShapes(config, { prefix = 'past_key_values', batch_size = 1 
         'num_encoder_heads' in normalized_config &&
         'num_decoder_heads' in normalized_config
     ) {
-        const encoder_dim_kv =
-            normalized_config.encoder_dim_kv ??
-            normalized_config.encoder_hidden_size / normalized_config.num_encoder_heads;
-        const decoder_dim_kv =
-            normalized_config.decoder_dim_kv ??
-            normalized_config.decoder_hidden_size / normalized_config.num_decoder_heads;
-
-        const encoder_dims = [batch_size, normalized_config.num_encoder_heads, 0, encoder_dim_kv];
-        const decoder_dims = [batch_size, normalized_config.num_decoder_heads, 0, decoder_dim_kv];
         for (let i = 0; i < normalized_config.num_decoder_layers; ++i) {
-            decoderFeeds[`${prefix}.${i}.encoder.key`] = encoder_dims;
-            decoderFeeds[`${prefix}.${i}.encoder.value`] = encoder_dims;
-            decoderFeeds[`${prefix}.${i}.decoder.key`] = decoder_dims;
-            decoderFeeds[`${prefix}.${i}.decoder.value`] = decoder_dims;
+            names.add(`${prefix}.${i}.encoder.key`);
+            names.add(`${prefix}.${i}.encoder.value`);
+            names.add(`${prefix}.${i}.decoder.key`);
+            names.add(`${prefix}.${i}.decoder.value`);
+        }
+    } else if (normalized_config.multi_query) {
+        // e.g., for `gpt_bigcode`
+        for (let i = 0; i < normalized_config.num_layers; ++i) {
+            names.add(`${prefix}.${i}.key_value`);
         }
     } else {
-        // Decoders
-        const num_heads = normalized_config.num_heads;
-        const num_layers = normalized_config.num_layers;
-        const dim_kv =
-            normalized_config.dim_kv ??
-            normalized_config.hidden_size / (normalized_config.num_attention_heads ?? num_heads);
-
-        if (normalized_config.model_type === 'falcon') {
-            // NOTE: Custom implementation for Falcon
-            const dims = [batch_size * num_heads, 0, dim_kv];
-            for (let i = 0; i < num_layers; ++i) {
-                decoderFeeds[`${prefix}.${i}.key`] = dims;
-                decoderFeeds[`${prefix}.${i}.value`] = dims;
-            }
-        } else if (normalized_config.multi_query) {
-            // e.g., for `gpt_bigcode`
-            const dims = [batch_size * num_heads, 0, 2 * dim_kv];
-
-            for (let i = 0; i < num_layers; ++i) {
-                decoderFeeds[`${prefix}.${i}.key_value`] = dims;
-            }
-        } else if (normalized_config.model_type === 'bloom') {
-            // NOTE: Custom implementation for Bloom
-
-            const keyDims = [batch_size * num_heads, dim_kv, 0]; // [batch_size x num_heads,64,past_sequence_length]
-            const valueDims = [batch_size * num_heads, 0, dim_kv]; // [batch_size x num_heads,past_sequence_length,64]
-            for (let i = 0; i < num_layers; ++i) {
-                decoderFeeds[`${prefix}.${i}.key`] = keyDims;
-                decoderFeeds[`${prefix}.${i}.value`] = valueDims;
-            }
-        } else if (normalized_config.model_type === 'openelm') {
-            for (let i = 0; i < num_layers; ++i) {
-                const dims = [batch_size, num_heads[i], 0, dim_kv];
-
-                decoderFeeds[`${prefix}.${i}.key`] = dims;
-                decoderFeeds[`${prefix}.${i}.value`] = dims;
-            }
-        } else {
-            // Decoder-only
-            const dims = [batch_size, num_heads, 0, dim_kv];
-            for (let i = 0; i < num_layers; ++i) {
-                decoderFeeds[`${prefix}.${i}.key`] = dims;
-                decoderFeeds[`${prefix}.${i}.value`] = dims;
-            }
+        for (let i = 0; i < normalized_config.num_layers; ++i) {
+            names.add(`${prefix}.${i}.key`);
+            names.add(`${prefix}.${i}.value`);
         }
     }
 
-    return decoderFeeds;
+    return names;
 }
 /**
  * Base class for all configuration classes. For more information, see the corresponding

--- a/packages/transformers/src/configs.js
+++ b/packages/transformers/src/configs.js
@@ -521,7 +521,6 @@ export class AutoConfig {
  * Transformers.js-specific configuration, possibly present in config.json under the key `transformers.js_config`.
  * @typedef {Object} TransformersJSConfig
  * @property {Record<import('./utils/devices.js').DeviceType, DeviceConfig>} [device_config] Device-specific configurations.
- * @property {import('./utils/tensor.js').DataType|Record<import('./utils/dtypes.js').DataType, import('./utils/tensor.js').DataType>|boolean} [kv_cache_dtype] The data type of the key-value cache.
  * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
  * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides
  * for more information.

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -1,6 +1,6 @@
 import { Callable } from '../utils/generic.js';
 import { constructSessions, sessionRun } from './session.js';
-import { AutoConfig, getCacheShapes } from '../configs.js';
+import { AutoConfig, getCacheNames } from '../configs.js';
 import { Tensor, full_like, cat, zeros_like, ones_like, ones } from '../utils/tensor.js';
 import { DataTypeMap } from '../utils/dtypes.js';
 
@@ -1234,6 +1234,23 @@ export function getAttentions(model_output) {
 }
 
 /**
+ * Resolve symbolic dims from ONNX inputMetadata for empty-cache initialization.
+ * Each symbolic dim name is looked up in `symbols`; numeric dims pass through.
+ * `past_sequence_length` defaults to 0 (empty cache) unless overridden in `symbols`.
+ * @param {ReadonlyArray<number|string>} metadataShape
+ * @param {Record<string, number>} symbols
+ * @returns {number[]}
+ */
+export function resolveCacheShape(metadataShape, symbols) {
+    return metadataShape.map((d) => {
+        if (typeof d === 'number') return d;
+        if (d in symbols) return symbols[d];
+        if (d === 'past_sequence_length') return 0;
+        throw new Error(`Unresolved symbolic dim: ${d}`);
+    });
+}
+
+/**
  * Adds past key values to the decoder feeds object. If pastKeyValues is null,
  * creates a new DynamicCache with zero-filled tensors for each cache entry.
  *
@@ -1253,14 +1270,22 @@ export function addPastKeyValues(self, decoderFeeds, pastKeyValues) {
 
     const dtype = session?.config?.kv_cache_dtype ?? 'float32';
     const cls = dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
-    const shapes = getCacheShapes(self.config, { batch_size });
+    const names = getCacheNames(self.config);
+    const num_heads = self.config?.normalized_config?.num_heads;
+    /** @type {Record<string, number>} */
+    const symbols = { batch_size };
+    if (typeof num_heads === 'number') {
+        symbols['batch_size x num_heads'] = batch_size * num_heads;
+    }
     /** @type {Record<string, Tensor>} */
     const entries = Object.create(null);
-    for (const name in shapes) {
-        const size = shapes[name].reduce((a, b) => a * b, 1);
-        const t = new Tensor(dtype, new cls(size), shapes[name]);
-        decoderFeeds[name] = t;
-        entries[name] = t;
+    for (const meta of session.inputMetadata) {
+        if (!names.has(meta.name)) continue;
+        const shape = resolveCacheShape(meta.shape, symbols);
+        const size = shape.reduce((a, b) => a * b, 1);
+        const t = new Tensor(dtype, new cls(size), shape);
+        decoderFeeds[meta.name] = t;
+        entries[meta.name] = t;
     }
     if (pastKeyValues) {
         // Populate the (empty) user-provided cache in-place

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -1236,7 +1236,7 @@ export function getAttentions(model_output) {
 /**
  * Resolve symbolic dims from ONNX inputMetadata for empty-cache initialization.
  * Each symbolic dim name is looked up in `symbols`; numeric dims pass through.
- * `past_sequence_length` defaults to 0 (empty cache) unless overridden in `symbols`.
+ * Any unresolved symbolic dim defaults to 0.
  * @param {ReadonlyArray<number|string>} metadataShape
  * @param {Record<string, number>} symbols
  * @returns {number[]}
@@ -1244,9 +1244,7 @@ export function getAttentions(model_output) {
 export function resolveCacheShape(metadataShape, symbols) {
     return metadataShape.map((d) => {
         if (typeof d === 'number') return d;
-        if (d in symbols) return symbols[d];
-        if (d === 'past_sequence_length') return 0;
-        throw new Error(`Unresolved symbolic dim: ${d}`);
+        return symbols[d] ?? 0;
     });
 }
 

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -1268,8 +1268,6 @@ export function addPastKeyValues(self, decoderFeeds, pastKeyValues) {
     const session = self.sessions['decoder_model_merged'] ?? self.sessions['model'];
     const batch_size = (decoderFeeds[self.main_input_name] ?? decoderFeeds.attention_mask)?.dims?.[0] ?? 1;
 
-    const dtype = session?.config?.kv_cache_dtype ?? 'float32';
-    const cls = dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
     const names = getCacheNames(self.config);
     const num_heads = self.config?.normalized_config?.num_heads;
     /** @type {Record<string, number>} */
@@ -1283,7 +1281,8 @@ export function addPastKeyValues(self, decoderFeeds, pastKeyValues) {
         if (!names.has(meta.name)) continue;
         const shape = resolveCacheShape(meta.shape, symbols);
         const size = shape.reduce((a, b) => a * b, 1);
-        const t = new Tensor(dtype, new cls(size), shape);
+        const cls = DataTypeMap[meta.type];
+        const t = new Tensor(meta.type, new cls(size), shape);
         decoderFeeds[meta.name] = t;
         entries[meta.name] = t;
     }

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -5,7 +5,7 @@ import {
     isONNXTensor,
     runInferenceSession,
 } from '../backends/onnx.js';
-import { getCacheShapes } from '../configs.js';
+import { getCacheNames } from '../configs.js';
 import { DATA_TYPES, DEFAULT_DTYPE_SUFFIX_MAPPING, isWebGpuFp16Supported, selectDtype } from '../utils/dtypes.js';
 import { selectDevice } from '../utils/devices.js';
 import { apis } from '../env.js';
@@ -120,15 +120,15 @@ async function getSession(
     }
 
     if (cache_config && selectedDevice === 'webgpu' && kv_cache_dtype_config !== false) {
-        const shapes = getCacheShapes(options.config, {
+        const names = getCacheNames(options.config, {
             prefix: 'present',
             session_name,
         });
-        if (Object.keys(shapes).length > 0 && !isONNXProxy()) {
-            // Only set preferredOutputLocation if shapes are present and we aren't proxying ONNX
+        if (names.size > 0 && !isONNXProxy()) {
+            // Only set preferredOutputLocation if names are present and we aren't proxying ONNX
             /** @type {Record<string, import('onnxruntime-common').Tensor.DataLocation>} */
             const preferredOutputLocation = {};
-            for (const key in shapes) {
+            for (const key of names) {
                 preferredOutputLocation[key] = 'gpu-buffer';
             }
             session_options.preferredOutputLocation = preferredOutputLocation;

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -71,18 +71,6 @@ async function getSession(
         throw new Error(`The device (${selectedDevice}) does not support fp16.`);
     }
 
-    // Only valid for models with a decoder
-    const kv_cache_dtype_config = custom_config.kv_cache_dtype;
-    const kv_cache_dtype = kv_cache_dtype_config
-        ? typeof kv_cache_dtype_config === 'string'
-            ? kv_cache_dtype_config
-            : (kv_cache_dtype_config[selectedDtype] ?? 'float32')
-        : undefined;
-
-    if (kv_cache_dtype && !['float32', 'float16'].includes(kv_cache_dtype)) {
-        throw new Error(`Invalid kv_cache_dtype: ${kv_cache_dtype}. Should be one of: float32, float16`);
-    }
-
     // Construct the model file suffix
     const suffix = DEFAULT_DTYPE_SUFFIX_MAPPING[selectedDtype];
 
@@ -119,7 +107,7 @@ async function getSession(
         session_options.externalData = externalData;
     }
 
-    if (cache_config && selectedDevice === 'webgpu' && kv_cache_dtype_config !== false) {
+    if (cache_config && selectedDevice === 'webgpu') {
         const names = getCacheNames(options.config, {
             prefix: 'present',
             session_name,
@@ -138,7 +126,6 @@ async function getSession(
     const buffer_or_path = await bufferOrPathPromise;
     const session_config = {
         dtype: selectedDtype,
-        kv_cache_dtype,
         device: selectedDevice,
     };
     return { buffer_or_path, session_options, session_config };

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -36,22 +36,28 @@ function createEncoderState(model, input_features) {
 
     // Initialize encoder KV cache
     const enc_kv_cache = new DynamicCache();
-    const enc_dtype = encoder_session?.config?.kv_cache_dtype ?? 'float32';
-    const enc_cls = enc_dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
     const enc_names = getCacheNames(audio_config);
     const enc_symbols = { batch_size: 1 };
+    /** @type {import('onnxruntime-common').Tensor.Type} */
+    let padding_type = 'float32';
     for (const meta of encoder_session.inputMetadata) {
+        if (meta.name === 'past_padding_cache') {
+            padding_type = meta.type;
+            continue;
+        }
         if (!enc_names.has(meta.name)) continue;
         const shape = resolveCacheShape(meta.shape, enc_symbols);
         const size = shape.reduce((a, b) => a * b, 1);
-        enc_kv_cache[meta.name] = new Tensor(enc_dtype, new enc_cls(size), shape);
+        const cls = DataTypeMap[meta.type];
+        enc_kv_cache[meta.name] = new Tensor(meta.type, new cls(size), shape);
     }
 
-    const enc_padding_cache = new Tensor(enc_dtype, new enc_cls(PADDING_CACHE_CHANNELS * CONV1_LEFT_PAD), [
-        1,
-        PADDING_CACHE_CHANNELS,
-        CONV1_LEFT_PAD,
-    ]);
+    const padding_cls = DataTypeMap[padding_type];
+    const enc_padding_cache = new Tensor(
+        padding_type,
+        new padding_cls(PADDING_CACHE_CHANNELS * CONV1_LEFT_PAD),
+        [1, PADDING_CACHE_CHANNELS, CONV1_LEFT_PAD],
+    );
 
     // Set up iterator from input_features
     const chunks_iter = input_features[Symbol.asyncIterator]?.() ?? input_features[Symbol.iterator]?.();

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -1,6 +1,6 @@
-import { PreTrainedModel, addPastKeyValues } from '../modeling_utils.js';
+import { PreTrainedModel, addPastKeyValues, resolveCacheShape } from '../modeling_utils.js';
 import { sessionRun } from '../session.js';
-import { getCacheShapes } from '../../configs.js';
+import { getCacheNames } from '../../configs.js';
 import { Tensor, ones } from '../../utils/tensor.js';
 import { DataTypeMap } from '../../utils/dtypes.js';
 import { pick } from '../../utils/core.js';
@@ -38,10 +38,13 @@ function createEncoderState(model, input_features) {
     const enc_kv_cache = new DynamicCache();
     const enc_dtype = encoder_session?.config?.kv_cache_dtype ?? 'float32';
     const enc_cls = enc_dtype === 'float16' ? DataTypeMap.float16 : DataTypeMap.float32;
-    const enc_shapes = getCacheShapes(audio_config, { batch_size: 1 });
-    for (const name in enc_shapes) {
-        const size = enc_shapes[name].reduce((a, b) => a * b, 1);
-        enc_kv_cache[name] = new Tensor(enc_dtype, new enc_cls(size), enc_shapes[name]);
+    const enc_names = getCacheNames(audio_config);
+    const enc_symbols = { batch_size: 1 };
+    for (const meta of encoder_session.inputMetadata) {
+        if (!enc_names.has(meta.name)) continue;
+        const shape = resolveCacheShape(meta.shape, enc_symbols);
+        const size = shape.reduce((a, b) => a * b, 1);
+        enc_kv_cache[meta.name] = new Tensor(enc_dtype, new enc_cls(size), shape);
     }
 
     const enc_padding_cache = new Tensor(enc_dtype, new enc_cls(PADDING_CACHE_CHANNELS * CONV1_LEFT_PAD), [


### PR DESCRIPTION

This also enables using qwen3.5 models with custom conv cache ops (https://huggingface.co/onnx-community/Qwen3.5-0.8B-Text-ONNX/discussions/2)

This gives over 2x speedup for qwen3.5 decode. 🔥 

We can also just ignore `kv_cache_dtype` config values 👍 (no longer needed). not a breaking change.