### PR TITLE
added fallback to chat_template_jinja if chat_template == null

### DIFF
--- a/packages/transformers/src/tokenization_utils.js
+++ b/packages/transformers/src/tokenization_utils.js
@@ -14,6 +14,7 @@ import { max } from './utils/maths.js';
 import { Tensor } from './utils/tensor.js';
 import { logger } from './utils/logger.js';
 import { CHAT_TEMPLATE_NAME } from './utils/constants.js';
+import { get_file_metadata } from './utils/model_registry/get_file_metadata.js';
 import { get_tokenizer_files } from './utils/model_registry/get_tokenizer_files.js';
 
 /**
@@ -40,7 +41,9 @@ export async function loadTokenizer(pretrained_model_name_or_path, options) {
                 ? configTemplate
                 : typeof fallbackTemplate === 'string'
                   ? fallbackTemplate
-                  : await getModelText(pretrained_model_name_or_path, CHAT_TEMPLATE_NAME, false, options);
+                  : (await get_file_metadata(pretrained_model_name_or_path, CHAT_TEMPLATE_NAME, options)).exists
+                    ? await getModelText(pretrained_model_name_or_path, CHAT_TEMPLATE_NAME, false, options)
+                    : null;
 
         if (typeof fileTemplate === 'string' && fileTemplate.length > 0) {
             tokenizerConfig.chat_template = fileTemplate;

--- a/packages/transformers/src/tokenization_utils.js
+++ b/packages/transformers/src/tokenization_utils.js
@@ -9,10 +9,11 @@ import { Template } from '@huggingface/jinja';
 import { Callable } from './utils/generic.js';
 
 import { isIntegralNumber, mergeArrays } from './utils/core.js';
-import { getModelJSON } from './utils/hub.js';
+import { getModelJSON, getModelText } from './utils/hub.js';
 import { max } from './utils/maths.js';
 import { Tensor } from './utils/tensor.js';
 import { logger } from './utils/logger.js';
+import { CHAT_TEMPLATE_NAME } from './utils/constants.js';
 import { get_tokenizer_files } from './utils/model_registry/get_tokenizer_files.js';
 
 /**
@@ -27,9 +28,26 @@ import { get_tokenizer_files } from './utils/model_registry/get_tokenizer_files.
  */
 export async function loadTokenizer(pretrained_model_name_or_path, options) {
     const tokenizerFiles = await get_tokenizer_files(pretrained_model_name_or_path);
-    return await Promise.all(
+    const [tokenizerJSON, tokenizerConfig] = await Promise.all(
         tokenizerFiles.map((file) => getModelJSON(pretrained_model_name_or_path, file, true, options)),
     );
+
+    if (tokenizerConfig?.chat_template == null) {
+        const configTemplate = tokenizerConfig?.chat_template_jinja;
+        const fallbackTemplate = /** @type {any} */ (options?.config)?.chat_template_jinja;
+        const fileTemplate =
+            typeof configTemplate === 'string'
+                ? configTemplate
+                : typeof fallbackTemplate === 'string'
+                  ? fallbackTemplate
+                  : await getModelText(pretrained_model_name_or_path, CHAT_TEMPLATE_NAME, false, options);
+
+        if (typeof fileTemplate === 'string' && fileTemplate.length > 0) {
+            tokenizerConfig.chat_template = fileTemplate;
+        }
+    }
+
+    return [tokenizerJSON, tokenizerConfig];
 }
 
 /**

--- a/packages/transformers/tests/tokenizers.test.js
+++ b/packages/transformers/tests/tokenizers.test.js
@@ -697,6 +697,32 @@ describe("Chat templates", () => {
     expect(() => tokenizer.apply_chat_template(chat, { tokenize: false })).toThrow("tokenizer.chat_template is not set and no template argument was passed");
   });
 
+  it("should fallback to config.chat_template_jinja", async () => {
+    const tokenizer = await AutoTokenizer.from_pretrained("Xenova/gpt-4o", {
+      config: {
+        chat_template_jinja: "{{ messages[0]['content'] }}",
+      },
+    });
+
+    const chat = [{ role: "user", content: "Hello, how are you?" }];
+    const text = tokenizer.apply_chat_template(chat, { tokenize: false });
+    expect(text).toEqual("Hello, how are you?");
+  });
+
+  it(
+    "should fallback to chat_template.jinja",
+    async () => {
+      const tokenizer = await AutoTokenizer.from_pretrained("onnx-community/gemma-4-E2B-it-ONNX");
+
+      const chat = [{ role: "user", content: "Hello, how are you?" }];
+      const text = tokenizer.apply_chat_template(chat, { tokenize: false, add_generation_prompt: true });
+
+      expect(typeof text).toBe("string");
+      expect(text).toContain("Hello, how are you?");
+    },
+    MAX_TOKENIZER_LOAD_TIME,
+  );
+
   it("should support default parameters", async () => {
     const tokenizer = await AutoTokenizer.from_pretrained("Xenova/Meta-Llama-3.1-Tokenizer");
 


### PR DESCRIPTION
I had a problem with Gemma 4 E2B:
```Uncaught Error: Cannot use apply_chat_template() because tokenizer.chat_template is not set and no template argument was passed! For information about writing templates and setting the tokenizer.chat_template attribute, please see the documentation at ...```

The problem is that `chat_template` is missing in https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/blob/main/tokenizer_config.json

Same issue is also described here: https://github.com/huggingface/transformers.js/issues/1660

This fix adds a fallback to `loadTokenizer`  to resolve a missing chat_template during from_pretrained with this fallback order:

1. existing tokenizer_config.chat_template (unchanged behavior)
2. tokenizer_config.chat_template_jinja
3. options.config.chat_template_jinja (covers pipeline-loaded model config)
4. chat_template.jinja fetched from the repo via getModelText(...)

If a non-empty fallback template is found, it is assigned to tokenizerConfig.chat_template before tokenizer construction, so apply_chat_template(...) stays synchronous and unchanged.                                                                                  