### PR TITLE
Fix duplicate model file downloads when progress_callback is active (#1663)

### DIFF
--- a/packages/transformers/src/utils/model_registry/get_file_metadata.js
+++ b/packages/transformers/src/utils/model_registry/get_file_metadata.js
@@ -51,12 +51,18 @@ async function fetch_file_head(urlOrPath) {
  * @returns {Promise<{exists: boolean, size?: number, contentType?: string, fromCache?: boolean}>} A Promise that resolves to file metadata.
  */
 export function get_file_metadata(path_or_repo_id, filename, options = {}) {
+    // Normalize option fields to their defaults so that callers passing explicit
+    // defaults (e.g. revision='main', cache_dir=null, local_files_only=false)
+    // share the same memoize key as callers that omit those options entirely.
+    // Without normalization, pipeline() and loadResourceFile() compute different
+    // keys for the same file, causing _get_file_metadata to run (and re-fetch)
+    // once per call site instead of being deduplicated.
     const key = JSON.stringify([
         path_or_repo_id,
         filename,
-        options?.revision,
-        options?.cache_dir,
-        options?.local_files_only,
+        options?.revision ?? 'main',
+        options?.cache_dir ?? null,
+        options?.local_files_only ?? false,
     ]);
     return memoizePromise(key, () => _get_file_metadata(path_or_repo_id, filename, options));
 }


### PR DESCRIPTION
When `progress_callback` is provided to `pipeline()`, model files are fetched from the server more times than necessary — `config.json` appears 3× and `tokenizer.json` 2× in the nginx logs, compared to once each without a callback.

The root cause is a memoize key mismatch in `get_file_metadata` (`src/utils/model_registry/get_file_metadata.js`). The key is built from `options.revision`, `options.cache_dir`, and `options.local_files_only` without normalizing defaults, so a call from `pipelines.js` with no options (`revision=undefined`, `cache_dir=undefined`, `local_files_only=undefined`) produces a different key than the call from `loadResourceFile` in `hub.js` with explicit defaults (`revision='main'`, `cache_dir=null`, `local_files_only=false`). Both represent the same logical request, but `memoizePromise` sees two distinct keys and invokes `_get_file_metadata` twice — each triggering an extra HTTP GET to the local server.

The fix normalizes the three options in the memoize key using `?? default` so that callers with different representations of the same default share the same memoize entry and the underlying fetch runs only once.

Fixes #1663
