### PR TITLE
Fix num_logits_to_keep default and add get_available_devices()

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -154,6 +154,25 @@ if (ORT_SYMBOL in globalThis) {
 const InferenceSession = ONNX.InferenceSession;
 
 /**
+ * Returns the list of devices available in the current environment, sorted by priority/performance.
+ *
+ * **Example:** Check available devices before loading a model.
+ * ```javascript
+ * import { get_available_devices } from '@huggingface/transformers';
+ *
+ * const devices = get_available_devices();
+ * // Node.js (Windows):  ['dml', 'webgpu', 'cpu']
+ * // Node.js (Linux x64): ['cuda', 'webgpu', 'cpu']
+ * // Browser (WebGPU):   ['webgpu', 'wasm']
+ * // Browser (no WebGPU): ['wasm']
+ * ```
+ * @returns {import("../utils/devices.js").DeviceType[]} The list of available devices.
+ */
+export function get_available_devices() {
+    return [...supportedDevices];
+}
+
+/**
  * Map a device to the execution providers to use for the given device.
  * @param {import("../utils/devices.js").DeviceType|"auto"|null} [device=null] (Optional) The device to run the inference on.
  * @returns {ONNXExecutionProviders[]} The execution providers to use for the given device.

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -1325,7 +1325,7 @@ export async function decoder_forward(self, model_inputs, is_encoder_decoder = f
         // logits will be calculated. During generation, the default is 1 because only the logits of the last
         // prompt token are needed for generation. For long sequences, the logits for the entire sequence may
         // use a lot of memory so, setting `num_logits_to_keep=1` will reduce memory footprint significantly.
-        new_model_inputs.num_logits_to_keep = new Tensor('int64', [0n], []);
+        new_model_inputs.num_logits_to_keep = new Tensor('int64', [1n], []);
     }
 
     // Unpack the `past_key_values` object into model inputs

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -58,6 +58,9 @@ export { DynamicCache } from './cache_utils.js';
 // Cache and file management
 export { ModelRegistry } from './utils/model_registry/ModelRegistry.js';
 
+// Device utilities
+export { get_available_devices } from './backends/onnx.js';
+
 // Expose common types used across the library for developers to access
 /**
  * @typedef {import('./utils/hub.js').PretrainedModelOptions} PretrainedModelOptions

--- a/packages/transformers/tests/utils/utils.test.js
+++ b/packages/transformers/tests/utils/utils.test.js
@@ -1,4 +1,4 @@
-import { AutoProcessor } from "../../src/transformers.js";
+import { AutoProcessor, get_available_devices } from "../../src/transformers.js";
 import { hamming, hanning, mel_filter_bank } from "../../src/utils/audio.js";
 import { getFile } from "../../src/utils/hub.js";
 import { RawImage } from "../../src/utils/image.js";
@@ -116,5 +116,25 @@ describe("Utilities", () => {
       expect(resized.width).toBe(300);
       expect(resized.height).toBe(200);
     });
+  });
+});
+
+describe("Device utilities", () => {
+  it("get_available_devices returns a non-empty array", () => {
+    const devices = get_available_devices();
+    expect(Array.isArray(devices)).toBe(true);
+    expect(devices.length).toBeGreaterThan(0);
+  });
+
+  it("get_available_devices always includes a CPU-class device (cpu or wasm)", () => {
+    const devices = get_available_devices();
+    expect(devices.includes("cpu") || devices.includes("wasm")).toBe(true);
+  });
+
+  it("get_available_devices returns a fresh copy each call", () => {
+    const a = get_available_devices();
+    const b = get_available_devices();
+    expect(a).not.toBe(b); // different array instances
+    expect(a).toEqual(b);  // same contents
   });
 });


### PR DESCRIPTION
Closes #1666, closes #1643.

### Fix: `num_logits_to_keep` default in `decoder_forward` (#1666)

`decoder_forward()` was passing `num_logits_to_keep=0`, which tells the model to compute logits for every input token. The comment above it already said the intent was `1` (last token only), matching what `generate()` uses. With `0`, models with large vocabularies and long prompts (e.g. Gemma 4) allocate logit tensors for the full prompt unnecessarily, causing significant memory bloat and OOM risk.

Before: `new Tensor('int64', [0n], [])`
After: `new Tensor('int64', [1n], [])`

### Feature: `get_available_devices()` (#1643)

Adds `get_available_devices()` to the public API so callers can inspect which execution providers are available in the current environment before loading a model.

```js
import { get_available_devices } from '@huggingface/transformers';

const devices = get_available_devices();
// Node.js on Windows:   ['dml', 'webgpu', 'cpu']
// Node.js on Linux x64: ['cuda', 'webgpu', 'cpu']
// Browser with WebGPU:  ['webgpu', 'wasm']
// Browser no WebGPU:    ['wasm']
