### PR TITLE
Fix auto device falling back when a provider fails to load

### DIFF
--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -7,7 +7,7 @@ import {
 } from '../backends/onnx.js';
 import { getCacheNames } from '../configs.js';
 import { DATA_TYPES, DEFAULT_DTYPE_SUFFIX_MAPPING, isWebGpuFp16Supported, selectDtype } from '../utils/dtypes.js';
-import { selectDevice } from '../utils/devices.js';
+import { selectDevice, DEVICE_TYPES } from '../utils/devices.js';
 import { apis } from '../env.js';
 import { getCoreModelFile, getModelDataFiles } from '../utils/model-loader.js';
 import { Tensor } from '../utils/tensor.js';
@@ -154,6 +154,36 @@ export async function constructSessions(pretrained_model_name_or_path, names, op
                     cache_config,
                     name,
                 );
+
+                // When device='auto', try each execution provider individually so that a failing
+                // accelerator (e.g. CUDA not installed) falls back cleanly to the next one.
+                // For any explicit device the caller already knows what they want — no fallback.
+                const isAuto =
+                    (options.device ?? options.config?.['transformers.js_config']?.device) === DEVICE_TYPES.auto;
+
+                if (isAuto) {
+                    const candidates = /** @type {import('onnxruntime-common').InferenceSession.ExecutionProviderConfig[]} */ (
+                        session_options.executionProviders
+                    );
+                    let lastError;
+                    for (const provider of candidates) {
+                        try {
+                            const opts = { ...session_options, executionProviders: [provider] };
+                            const session = await createInferenceSession(buffer_or_path, opts, {
+                                ...session_config,
+                                device: typeof provider === 'string' ? provider : provider.name,
+                            });
+                            return [name, session];
+                        } catch (err) {
+                            logger.warn(
+                                `Failed to create session with provider "${typeof provider === 'string' ? provider : provider.name}": ${err?.message ?? err}. Trying next provider.`,
+                            );
+                            lastError = err;
+                        }
+                    }
+                    throw lastError ?? new Error('All execution providers failed to initialize.');
+                }
+
                 const session = await createInferenceSession(buffer_or_path, session_options, session_config);
                 return [name, session];
             }),


### PR DESCRIPTION
Closes #1642

### Fix: auto device falls back gracefully when a provider fails to load

When `device: 'auto'` is used and a high-priority execution provider (e.g. CUDA on Linux without `libcuda.so` installed) is unavailable, `createInferenceSession` would throw instead of trying the next provider in the list.

The fallback now lives in `constructSessions` in `session.js`, where the device selection context is available. Each provider is tried individually — on failure a warning is logged and the next one is attempted. `createInferenceSession` itself is unchanged.

```js
// Before: hard crash on Linux x64 without libcuda.so
// After: warns and automatically falls back to the next available provider
await pipeline('text-generation', 'onnx-community/LFM2-1.2B-ONNX', { device: 'auto' });
