### PR TITLE
Fix transformers.js crashing in Bun --compile single binaries

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -18,9 +18,22 @@
 
 import { env, apis, LogLevel } from '../env.js';
 
-// NOTE: Import order matters here. We need to import `onnxruntime-node` before `onnxruntime-web`.
-// In either case, we select the default export if it exists, otherwise we use the named export.
-import * as ONNX_NODE from 'onnxruntime-node';
+// onnxruntime-node is loaded dynamically so that environments where its native
+// bindings are unavailable (e.g. Bun --compile single binaries) do not crash
+// at module load time. When the load fails we fall back to onnxruntime-web
+// (WASM backend) so the library still works without patching.
+//
+// Note: we previously used a static import here, but that caused Bun --compile
+// binaries to crash before the globalThis[Symbol.for('onnxruntime')] override
+// hook could even fire. See: https://github.com/huggingface/transformers.js/issues/1672
+let ONNX_NODE = null;
+if (apis.IS_NODE_ENV) {
+    try {
+        ONNX_NODE = await import('onnxruntime-node');
+    } catch {
+        // native bindings not available; will fall back to the WASM backend below
+    }
+}
 import * as ONNX_WEB from 'onnxruntime-web/webgpu';
 import { loadWasmBinary, loadWasmFactory } from './utils/cacheWasm.js';
 import { isBlobURL, toAbsoluteURL } from '../utils/hub/utils.js';
@@ -102,11 +115,17 @@ let defaultDevices;
 let ONNX;
 const ORT_SYMBOL = Symbol.for('onnxruntime');
 
+// Tracks whether the native onnxruntime-node backend is active.
+// model-loader uses this to decide whether to pass file paths (efficient for
+// the native backend) or load buffers (required by the WASM backend).
+export let _nodeOnnxActive = false;
+
 if (ORT_SYMBOL in globalThis) {
     // If the JS runtime exposes their own ONNX runtime, use it
     ONNX = globalThis[ORT_SYMBOL];
-} else if (apis.IS_NODE_ENV) {
+} else if (apis.IS_NODE_ENV && ONNX_NODE) {
     ONNX = ONNX_NODE;
+    _nodeOnnxActive = true;
 
     // Updated as of ONNX Runtime 1.23.0-dev.20250612-70f14d7670
     // The following table lists the supported versions of ONNX Runtime Node.js binding provided with pre-built binaries.

--- a/packages/transformers/src/utils/image.js
+++ b/packages/transformers/src/utils/image.js
@@ -13,9 +13,19 @@ import { apis } from '../env.js';
 import { Tensor } from './tensor.js';
 import { saveBlob } from './io.js';
 
-// Will be empty (or not used) if running in browser or web-worker
-import sharp from 'sharp';
 import { logger } from './logger.js';
+
+// sharp is loaded dynamically so that environments where its native bindings
+// are unavailable (e.g. Bun --compile single binaries) do not crash at module
+// load time. Text-only pipelines that never process images are unaffected.
+let sharp = null;
+if (!apis.IS_WEB_ENV) {
+    try {
+        ({ default: sharp } = await import('sharp'));
+    } catch {
+        // sharp not available; image operations will throw when actually invoked
+    }
+}
 
 let createCanvasFunction;
 let ImageDataClass;
@@ -48,7 +58,8 @@ if (apis.IS_WEB_ENV) {
         return newImage;
     };
 } else {
-    throw new Error('Unable to load image processing library.');
+    // sharp not available; loadImageFunction remains null and image
+    // operations will throw with a clear message when actually invoked
 }
 
 // Defined here: https://github.com/python-pillow/Pillow/blob/a405e8406b83f8bfb8916e93971edc7407b8b1ff/src/libImaging/Imaging.h#L262-L268
@@ -175,6 +186,9 @@ export class RawImage {
 
             return new this(ctx.getImageData(0, 0, img.width, img.height).data, img.width, img.height, 4);
         } else {
+            if (!sharp) {
+                throw new Error('Unable to load image processing library. Please install the `sharp` package.');
+            }
             // Use sharp.js to read (and possible resize) the image.
             const img = sharp(await blob.arrayBuffer());
 
@@ -800,6 +814,9 @@ export class RawImage {
     toSharp() {
         if (apis.IS_WEB_ENV) {
             throw new Error('toSharp() is only supported in server-side environments.');
+        }
+        if (!sharp) {
+            throw new Error('Unable to load image processing library. Please install the `sharp` package.');
         }
 
         return sharp(this.data, {

--- a/packages/transformers/src/utils/model-loader.js
+++ b/packages/transformers/src/utils/model-loader.js
@@ -1,5 +1,6 @@
 import { getModelFile, MAX_EXTERNAL_DATA_CHUNKS } from './hub.js';
 import { apis } from '../env.js';
+import { _nodeOnnxActive } from '../backends/onnx.js';
 
 /**
  * Resolves an `use_external_data_format` config value to the number of data chunks for a given file.
@@ -45,7 +46,10 @@ export async function getCoreModelFile(pretrained_model_name_or_path, fileName, 
     const baseName = `${fileName}${suffix}.onnx`;
     const fullPath = `${options.subfolder ?? ''}/${baseName}`;
 
-    return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, apis.IS_NODE_ENV);
+    // Return a file path (not a buffer) only when the native onnxruntime-node
+    // backend is active — it reads paths efficiently. The WASM backend (used as
+    // fallback when native bindings are unavailable) requires a buffer.
+    return await getModelFile(pretrained_model_name_or_path, fullPath, true, options, _nodeOnnxActive);
 }
 
 /**
@@ -68,7 +72,7 @@ export async function getModelDataFiles(
     session_options = {},
 ) {
     const baseName = `${fileName}${suffix}.onnx`;
-    const return_path = apis.IS_NODE_ENV;
+    const return_path = _nodeOnnxActive;
 
     /** @type {Promise<string|{path: string, data: Uint8Array}>[]} */
     let externalDataPromises = [];


### PR DESCRIPTION
Closes #1672

Addresses all three root causes described in the issue.

### 1. `onnxruntime-node` static import crash

The static top-level `import * as ONNX_NODE from 'onnxruntime-node'` crashed with `ERR_DLOPEN_FAILED` before the `globalThis[Symbol.for('onnxruntime')]` override hook could fire. Now loaded via `await import()` wrapped in try/catch. On failure the library falls back to `onnxruntime-web` (WASM) automatically. Normal Node.js usage is completely unaffected.

### 2. `sharp` static import crash

Same issue as above. `import sharp from 'sharp'` crashed at module load time even for text-only pipelines. `sharp` is now loaded dynamically and only attempted when image processing is actually invoked. Text-only pipelines (`feature-extraction`, `text-generation`, etc.) no longer crash on import regardless of whether `sharp` is installed.

### 3. Model file paths instead of buffers

`getCoreModelFile` and `getModelDataFiles` returned file path strings (efficient for native `onnxruntime-node`) even when the WASM backend was active. The bundled `ort-web` has its `node:fs` read path eliminated by tree-shaking and tried to `fetch()` the bare path, failing with `ERR_INVALID_URL`. Both functions now return buffers when the WASM backend is active, using a `_nodeOnnxActive` flag exported from `onnx.js`.
