### PR TITLE
Fix whisper progress callbacks

### DIFF
--- a/packages/transformers/src/utils/core.js
+++ b/packages/transformers/src/utils/core.js
@@ -110,6 +110,8 @@ export class DefaultProgressCallback extends Callable {
         super();
         this.callback = callback;
         this.files_loading = files_loading;
+        /** @type {Map<string, Promise<string|Uint8Array|null>>} Pending and completed file loads, used to deduplicate work within a single pipeline() call. */
+        this.loads = new Map();
     }
 
     /**

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -502,9 +502,9 @@ function getLoadKey(path_or_repo_id, filename, fatal, options, return_path) {
 }
 
 /**
- * Gets the per-progress-callback file load map. Unlike INFLIGHT_LOADS,
- * this can retain resolved loads for the lifetime of one aggregate progress
- * callback so repeated component loads do not replay per-file progress events.
+ * Gets the per-progress-callback file load map, if aggregate progress
+ * tracking is active. Entries are scoped to the callback and become
+ * collectible with it.
  *
  * @param {import('./core.js').ProgressCallback | null | undefined} progress_callback
  * @returns {Map<string, Promise<string|Uint8Array|null>> | undefined}
@@ -551,18 +551,13 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         }
     }
 
-    // Deduplicate concurrent loads of the same file so progress events are
-    // only emitted by a single download. Without this, parallel callers
-    // (e.g. tokenizer + processor in pipeline()) would race on the same file
-    // and produce interleaved progress that breaks monotonic progress_total.
+    // Deduplicate loads of the same file within one aggregate progress
+    // callback. Loads without aggregate progress tracking still use the
+    // global pending-load map for concurrent request deduplication.
     const key = getLoadKey(path_or_repo_id, filename, fatal, options, return_path);
     const scopedLoads = getProgressCallbackLoads(options.progress_callback);
-    const pending = scopedLoads?.get(key) ?? INFLIGHT_LOADS.get(key);
+    const pending = scopedLoads?.get(key) ?? (scopedLoads ? undefined : INFLIGHT_LOADS.get(key));
     if (pending) {
-        if (scopedLoads && !scopedLoads.has(key)) {
-            pending.catch(() => scopedLoads.delete(key));
-            scopedLoads.set(key, pending);
-        }
         return await pending;
     }
 
@@ -572,20 +567,30 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         file: filename,
     });
 
-    /** @type {import('./cache.js').CacheInterface | null} */
-    const cache = await getCache(options?.cache_dir);
-    const promise = loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache).then(
+    const loadPromise = (async () => {
+        /** @type {import('./cache.js').CacheInterface | null} */
+        const cache = await getCache(options?.cache_dir);
+        return await loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache);
+    })();
+
+    const promise = loadPromise.then(
         (result) => {
-            INFLIGHT_LOADS.delete(key);
+            if (INFLIGHT_LOADS.get(key) === promise) {
+                INFLIGHT_LOADS.delete(key);
+            }
             return result;
         },
         (err) => {
-            INFLIGHT_LOADS.delete(key);
+            if (INFLIGHT_LOADS.get(key) === promise) {
+                INFLIGHT_LOADS.delete(key);
+            }
             scopedLoads?.delete(key);
             throw err;
         },
     );
-    INFLIGHT_LOADS.set(key, promise);
+    if (!scopedLoads) {
+        INFLIGHT_LOADS.set(key, promise);
+    }
     scopedLoads?.set(key, promise);
     return await promise;
 }

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -8,7 +8,7 @@ import { apis, env } from '../env.js';
 import { DefaultProgressCallback, dispatchCallback } from './core.js';
 import { FileResponse } from './hub/FileResponse.js';
 import { FileCache } from './cache/FileCache.js';
-import { handleError, isValidUrl, pathJoin, isValidHfModelId, readResponse } from './hub/utils.js';
+import { handleError, isValidUrl, pathJoin, isValidHfModelId, makePretrainedOptionsKey, readResponse } from './hub/utils.js';
 import { getCache, tryCache } from './cache.js';
 import { get_file_metadata } from './model_registry/get_file_metadata.js';
 import { logger } from './logger.js';
@@ -480,28 +480,6 @@ const INFLIGHT_LOADS = new Map();
 const PROGRESS_CALLBACK_LOADS = new WeakMap();
 
 /**
- * Builds an internal key for memoizing a resource load.
- *
- * @param {string} path_or_repo_id
- * @param {string} filename
- * @param {boolean} fatal
- * @param {PretrainedOptions} options
- * @param {boolean} return_path
- * @returns {string}
- */
-function getLoadKey(path_or_repo_id, filename, fatal, options, return_path) {
-    return JSON.stringify([
-        path_or_repo_id,
-        filename,
-        options.revision ?? 'main',
-        fatal,
-        return_path,
-        options.cache_dir ?? null,
-        options.local_files_only ?? false,
-    ]);
-}
-
-/**
  * Gets the per-progress-callback file load map, if aggregate progress
  * tracking is active. Entries are scoped to the callback and become
  * collectible with it.
@@ -554,7 +532,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     // Deduplicate loads of the same file within one aggregate progress
     // callback. Loads without aggregate progress tracking still use the
     // global pending-load map for concurrent request deduplication.
-    const key = getLoadKey(path_or_repo_id, filename, fatal, options, return_path);
+    const key = makePretrainedOptionsKey(path_or_repo_id, options, filename, fatal, return_path);
     const scopedLoads = getProgressCallbackLoads(options.progress_callback);
     const loads = scopedLoads ?? INFLIGHT_LOADS;
     const pending = loads.get(key);

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -556,7 +556,8 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     // global pending-load map for concurrent request deduplication.
     const key = getLoadKey(path_or_repo_id, filename, fatal, options, return_path);
     const scopedLoads = getProgressCallbackLoads(options.progress_callback);
-    const pending = scopedLoads?.get(key) ?? (scopedLoads ? undefined : INFLIGHT_LOADS.get(key));
+    const loads = scopedLoads ?? INFLIGHT_LOADS;
+    const pending = loads.get(key);
     if (pending) {
         return await pending;
     }
@@ -572,27 +573,20 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         const cache = await getCache(options?.cache_dir);
         return await loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache);
     })();
+    loads.set(key, loadPromise);
 
-    const promise = loadPromise.then(
-        (result) => {
-            if (INFLIGHT_LOADS.get(key) === promise) {
-                INFLIGHT_LOADS.delete(key);
-            }
-            return result;
-        },
-        (err) => {
-            if (INFLIGHT_LOADS.get(key) === promise) {
-                INFLIGHT_LOADS.delete(key);
-            }
-            scopedLoads?.delete(key);
-            throw err;
-        },
-    );
-    if (!scopedLoads) {
-        INFLIGHT_LOADS.set(key, promise);
+    try {
+        return await loadPromise;
+    } catch (err) {
+        if (loads.get(key) === loadPromise) {
+            loads.delete(key);
+        }
+        throw err;
+    } finally {
+        if (!scopedLoads && loads.get(key) === loadPromise) {
+            loads.delete(key);
+        }
     }
-    scopedLoads?.set(key, promise);
-    return await promise;
 }
 
 /**

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -521,10 +521,9 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             name: path_or_repo_id,
             file: filename,
         });
-        pending = (async () => {
-            const cache = await getCache(options?.cache_dir);
-            return await loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache);
-        })();
+        pending = getCache(options?.cache_dir).then((cache) =>
+            loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache),
+        );
         if (loads === INFLIGHT_LOADS) {
             pending = pending.finally(() => INFLIGHT_LOADS.delete(key));
         }

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -521,7 +521,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
             name: path_or_repo_id,
             file: filename,
         });
-        pending = getCache(options?.cache_dir).then((cache) =>
+        pending = getCache(options.cache_dir).then((cache) =>
             loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache),
         );
         if (loads === INFLIGHT_LOADS) {

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -5,7 +5,7 @@
  */
 
 import { apis, env } from '../env.js';
-import { dispatchCallback } from './core.js';
+import { DefaultProgressCallback, dispatchCallback } from './core.js';
 import { FileResponse } from './hub/FileResponse.js';
 import { FileCache } from './cache/FileCache.js';
 import { handleError, isValidUrl, pathJoin, isValidHfModelId, readResponse } from './hub/utils.js';
@@ -473,8 +473,51 @@ export async function loadResourceFile(
     throw new Error('Unable to get model file path or buffer.');
 }
 
-/** @type {Map<string, Promise<string|Uint8Array>>} In-flight file loads keyed by repo+filename. */
+/** @type {Map<string, Promise<string|Uint8Array|null>>} In-flight file loads keyed by resource identity. */
 const INFLIGHT_LOADS = new Map();
+
+/** @type {WeakMap<DefaultProgressCallback, Map<string, Promise<string|Uint8Array|null>>>} */
+const PROGRESS_CALLBACK_LOADS = new WeakMap();
+
+/**
+ * Builds an internal key for memoizing a resource load.
+ *
+ * @param {string} path_or_repo_id
+ * @param {string} filename
+ * @param {boolean} fatal
+ * @param {PretrainedOptions} options
+ * @param {boolean} return_path
+ * @returns {string}
+ */
+function getLoadKey(path_or_repo_id, filename, fatal, options, return_path) {
+    return JSON.stringify([
+        path_or_repo_id,
+        filename,
+        options.revision ?? 'main',
+        fatal,
+        return_path,
+        options.cache_dir ?? null,
+        options.local_files_only ?? false,
+    ]);
+}
+
+/**
+ * Gets the per-progress-callback file load map, if aggregate progress tracking is active.
+ *
+ * @param {import('./core.js').ProgressCallback | null | undefined} progress_callback
+ * @returns {Map<string, Promise<string|Uint8Array|null>> | undefined}
+ */
+function getProgressCallbackLoads(progress_callback) {
+    if (!(progress_callback instanceof DefaultProgressCallback)) {
+        return undefined;
+    }
+    let loads = PROGRESS_CALLBACK_LOADS.get(progress_callback);
+    if (!loads) {
+        loads = new Map();
+        PROGRESS_CALLBACK_LOADS.set(progress_callback, loads);
+    }
+    return loads;
+}
 
 /**
  * Retrieves a file from either a remote URL using the Fetch API or from the local file system using the FileSystem API.
@@ -506,34 +549,39 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         }
     }
 
+    // Deduplicate concurrent loads of the same file so progress events are
+    // only emitted by a single download. Without this, parallel callers
+    // (e.g. tokenizer + processor in pipeline()) would race on the same file
+    // and produce interleaved progress that breaks monotonic progress_total.
+    const key = getLoadKey(path_or_repo_id, filename, fatal, options, return_path);
+    const loadContext = getProgressCallbackLoads(options.progress_callback);
+    const pending = loadContext?.get(key) ?? INFLIGHT_LOADS.get(key);
+    if (pending) {
+        return await pending;
+    }
+
     dispatchCallback(options.progress_callback, {
         status: 'initiate',
         name: path_or_repo_id,
         file: filename,
     });
 
-    // Deduplicate concurrent loads of the same file so progress events are
-    // only emitted by a single download. Without this, parallel callers
-    // (e.g. tokenizer + processor in pipeline()) would race on the same file
-    // and produce interleaved progress that breaks monotonic progress_total.
-    const key = `${path_or_repo_id}::${filename}`;
-    let pending = INFLIGHT_LOADS.get(key);
-    if (!pending) {
-        /** @type {import('./cache.js').CacheInterface | null} */
-        const cache = await getCache(options?.cache_dir);
-        pending = loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache).then(
-            (result) => {
-                INFLIGHT_LOADS.delete(key);
-                return result;
-            },
-            (err) => {
-                INFLIGHT_LOADS.delete(key);
-                throw err;
-            },
-        );
-        INFLIGHT_LOADS.set(key, pending);
-    }
-    return await pending;
+    /** @type {import('./cache.js').CacheInterface | null} */
+    const cache = await getCache(options?.cache_dir);
+    const promise = loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache).then(
+        (result) => {
+            INFLIGHT_LOADS.delete(key);
+            return result;
+        },
+        (err) => {
+            INFLIGHT_LOADS.delete(key);
+            loadContext?.delete(key);
+            throw err;
+        },
+    );
+    INFLIGHT_LOADS.set(key, promise);
+    loadContext?.set(key, promise);
+    return await promise;
 }
 
 /**

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -476,29 +476,6 @@ export async function loadResourceFile(
 /** @type {Map<string, Promise<string|Uint8Array|null>>} Pending file loads keyed by resource identity. */
 const INFLIGHT_LOADS = new Map();
 
-/** @type {WeakMap<DefaultProgressCallback, Map<string, Promise<string|Uint8Array|null>>>} */
-const PROGRESS_CALLBACK_LOADS = new WeakMap();
-
-/**
- * Gets the per-progress-callback file load map, if aggregate progress
- * tracking is active. Entries are scoped to the callback and become
- * collectible with it.
- *
- * @param {import('./core.js').ProgressCallback | null | undefined} progress_callback
- * @returns {Map<string, Promise<string|Uint8Array|null>> | undefined}
- */
-function getProgressCallbackLoads(progress_callback) {
-    if (!(progress_callback instanceof DefaultProgressCallback)) {
-        return undefined;
-    }
-    let loads = PROGRESS_CALLBACK_LOADS.get(progress_callback);
-    if (!loads) {
-        loads = new Map();
-        PROGRESS_CALLBACK_LOADS.set(progress_callback, loads);
-    }
-    return loads;
-}
-
 /**
  * Retrieves a file from either a remote URL using the Fetch API or from the local file system using the FileSystem API.
  * If the filesystem is available and `env.useCache = true`, the file will be downloaded and cached.
@@ -529,42 +506,31 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         }
     }
 
-    // Deduplicate loads of the same file within one aggregate progress
-    // callback. Loads without aggregate progress tracking still use the
-    // global pending-load map for concurrent request deduplication.
+    // Deduplicate loads of the same file. When an aggregate progress callback
+    // is active, scope dedup to its `loads` map so concurrent and sequential
+    // sibling calls within one pipeline() share a single download (and a
+    // single `initiate` event). Otherwise fall back to the global in-flight
+    // map for concurrent dedup, with entries cleared on settle.
     const key = makePretrainedOptionsKey(path_or_repo_id, options, filename, fatal, return_path);
-    const scopedLoads = getProgressCallbackLoads(options.progress_callback);
-    const loads = scopedLoads ?? INFLIGHT_LOADS;
-    const pending = loads.get(key);
-    if (pending) {
-        return await pending;
-    }
-
-    dispatchCallback(options.progress_callback, {
-        status: 'initiate',
-        name: path_or_repo_id,
-        file: filename,
-    });
-
-    const loadPromise = (async () => {
-        /** @type {import('./cache.js').CacheInterface | null} */
-        const cache = await getCache(options?.cache_dir);
-        return await loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache);
-    })();
-    loads.set(key, loadPromise);
-
-    try {
-        return await loadPromise;
-    } catch (err) {
-        if (loads.get(key) === loadPromise) {
-            loads.delete(key);
+    const { progress_callback } = options;
+    const loads = progress_callback instanceof DefaultProgressCallback ? progress_callback.loads : INFLIGHT_LOADS;
+    let pending = loads.get(key);
+    if (!pending) {
+        dispatchCallback(progress_callback, {
+            status: 'initiate',
+            name: path_or_repo_id,
+            file: filename,
+        });
+        pending = (async () => {
+            const cache = await getCache(options?.cache_dir);
+            return await loadResourceFile(path_or_repo_id, filename, fatal, options, return_path, cache);
+        })();
+        if (loads === INFLIGHT_LOADS) {
+            pending = pending.finally(() => INFLIGHT_LOADS.delete(key));
         }
-        throw err;
-    } finally {
-        if (!scopedLoads && loads.get(key) === loadPromise) {
-            loads.delete(key);
-        }
+        loads.set(key, pending);
     }
+    return await pending;
 }
 
 /**

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -473,7 +473,7 @@ export async function loadResourceFile(
     throw new Error('Unable to get model file path or buffer.');
 }
 
-/** @type {Map<string, Promise<string|Uint8Array|null>>} In-flight file loads keyed by resource identity. */
+/** @type {Map<string, Promise<string|Uint8Array|null>>} Pending file loads keyed by resource identity. */
 const INFLIGHT_LOADS = new Map();
 
 /** @type {WeakMap<DefaultProgressCallback, Map<string, Promise<string|Uint8Array|null>>>} */
@@ -502,7 +502,9 @@ function getLoadKey(path_or_repo_id, filename, fatal, options, return_path) {
 }
 
 /**
- * Gets the per-progress-callback file load map, if aggregate progress tracking is active.
+ * Gets the per-progress-callback file load map. Unlike INFLIGHT_LOADS,
+ * this can retain resolved loads for the lifetime of one aggregate progress
+ * callback so repeated component loads do not replay per-file progress events.
  *
  * @param {import('./core.js').ProgressCallback | null | undefined} progress_callback
  * @returns {Map<string, Promise<string|Uint8Array|null>> | undefined}
@@ -554,9 +556,10 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     // (e.g. tokenizer + processor in pipeline()) would race on the same file
     // and produce interleaved progress that breaks monotonic progress_total.
     const key = getLoadKey(path_or_repo_id, filename, fatal, options, return_path);
-    const loadContext = getProgressCallbackLoads(options.progress_callback);
-    const pending = loadContext?.get(key) ?? INFLIGHT_LOADS.get(key);
+    const scopedLoads = getProgressCallbackLoads(options.progress_callback);
+    const pending = scopedLoads?.get(key) ?? INFLIGHT_LOADS.get(key);
     if (pending) {
+        scopedLoads?.set(key, pending);
         return await pending;
     }
 
@@ -575,12 +578,12 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         },
         (err) => {
             INFLIGHT_LOADS.delete(key);
-            loadContext?.delete(key);
+            scopedLoads?.delete(key);
             throw err;
         },
     );
     INFLIGHT_LOADS.set(key, promise);
-    loadContext?.set(key, promise);
+    scopedLoads?.set(key, promise);
     return await promise;
 }
 

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -559,7 +559,10 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
     const scopedLoads = getProgressCallbackLoads(options.progress_callback);
     const pending = scopedLoads?.get(key) ?? INFLIGHT_LOADS.get(key);
     if (pending) {
-        scopedLoads?.set(key, pending);
+        if (scopedLoads && !scopedLoads.has(key)) {
+            pending.catch(() => scopedLoads.delete(key));
+            scopedLoads.set(key, pending);
+        }
         return await pending;
     }
 

--- a/packages/transformers/src/utils/hub/utils.js
+++ b/packages/transformers/src/utils/hub/utils.js
@@ -59,6 +59,27 @@ export function isValidHfModelId(string) {
 }
 
 /**
+ * Builds a stable key for memoizing model/revision/cache scoped work.
+ *
+ * @param {string} model_id Model ID or local model path.
+ * @param {Object} [options] Pretrained loading options.
+ * @param {string} [options.revision='main'] Model revision.
+ * @param {string|null} [options.cache_dir=null] Custom cache directory.
+ * @param {boolean} [options.local_files_only=false] Whether to avoid remote lookups.
+ * @param {...unknown} parts Additional key parts for the specific operation.
+ * @returns {string}
+ */
+export function makePretrainedOptionsKey(model_id, options = {}, ...parts) {
+    return JSON.stringify([
+        model_id,
+        options?.revision ?? 'main',
+        options?.cache_dir ?? null,
+        options?.local_files_only ?? false,
+        ...parts,
+    ]);
+}
+
+/**
  * Helper method to handle fatal errors that occur while trying to load a file from the Hugging Face Hub.
  * @param {number} status The HTTP status code of the error.
  * @param {string} remoteURL The URL of the file that could not be loaded.

--- a/packages/transformers/src/utils/hub/utils.js
+++ b/packages/transformers/src/utils/hub/utils.js
@@ -72,9 +72,9 @@ export function isValidHfModelId(string) {
 export function makePretrainedOptionsKey(model_id, options = {}, ...parts) {
     return JSON.stringify([
         model_id,
-        options?.revision ?? 'main',
-        options?.cache_dir ?? null,
-        options?.local_files_only ?? false,
+        options.revision ?? 'main',
+        options.cache_dir ?? null,
+        options.local_files_only ?? false,
         ...parts,
     ]);
 }

--- a/packages/transformers/src/utils/model_registry/get_file_metadata.js
+++ b/packages/transformers/src/utils/model_registry/get_file_metadata.js
@@ -51,12 +51,6 @@ async function fetch_file_head(urlOrPath) {
  * @returns {Promise<{exists: boolean, size?: number, contentType?: string, fromCache?: boolean}>} A Promise that resolves to file metadata.
  */
 export function get_file_metadata(path_or_repo_id, filename, options = {}) {
-    // Normalize option fields to their defaults so that callers passing explicit
-    // defaults (e.g. revision='main', cache_dir=null, local_files_only=false)
-    // share the same memoize key as callers that omit those options entirely.
-    // Without normalization, pipeline() and loadResourceFile() compute different
-    // keys for the same file, causing _get_file_metadata to run (and re-fetch)
-    // once per call site instead of being deduplicated.
     const key = makePretrainedOptionsKey(path_or_repo_id, options, filename);
     return memoizePromise(key, () => _get_file_metadata(path_or_repo_id, filename, options));
 }

--- a/packages/transformers/src/utils/model_registry/get_file_metadata.js
+++ b/packages/transformers/src/utils/model_registry/get_file_metadata.js
@@ -5,7 +5,7 @@
 import { env } from '../../env.js';
 import { getCache } from '../cache.js';
 import { buildResourcePaths, checkCachedResource, getFetchHeaders, getFile } from '../hub.js';
-import { isValidUrl } from '../hub/utils.js';
+import { isValidUrl, makePretrainedOptionsKey } from '../hub/utils.js';
 import { logger } from '../logger.js';
 import { memoizePromise } from '../memoize_promise.js';
 
@@ -57,13 +57,7 @@ export function get_file_metadata(path_or_repo_id, filename, options = {}) {
     // Without normalization, pipeline() and loadResourceFile() compute different
     // keys for the same file, causing _get_file_metadata to run (and re-fetch)
     // once per call site instead of being deduplicated.
-    const key = JSON.stringify([
-        path_or_repo_id,
-        filename,
-        options?.revision ?? 'main',
-        options?.cache_dir ?? null,
-        options?.local_files_only ?? false,
-    ]);
+    const key = makePretrainedOptionsKey(path_or_repo_id, options, filename);
     return memoizePromise(key, () => _get_file_metadata(path_or_repo_id, filename, options));
 }
 

--- a/packages/transformers/src/utils/model_registry/get_model_files.js
+++ b/packages/transformers/src/utils/model_registry/get_model_files.js
@@ -3,6 +3,7 @@ import { selectDevice } from '../devices.js';
 import { resolveExternalDataFormat, getExternalDataChunkNames } from '../model-loader.js';
 import { getSessionsConfig } from '../../models/session_config.js';
 import { AutoConfig } from '../../configs.js';
+import { makePretrainedOptionsKey } from '../hub/utils.js';
 import { memoizePromise } from '../memoize_promise.js';
 import { resolve_model_type } from './resolve_model_type.js';
 
@@ -35,7 +36,7 @@ export function get_config(
     if (config !== null) {
         return AutoConfig.from_pretrained(modelId, { config, cache_dir, local_files_only, revision });
     }
-    const key = JSON.stringify([modelId, cache_dir, local_files_only, revision]);
+    const key = makePretrainedOptionsKey(modelId, { cache_dir, local_files_only, revision });
     return memoizePromise(key, () =>
         AutoConfig.from_pretrained(modelId, { config, cache_dir, local_files_only, revision }),
     );

--- a/packages/transformers/tests/progress_callbacks.test.js
+++ b/packages/transformers/tests/progress_callbacks.test.js
@@ -150,7 +150,18 @@ describe("Progress Callbacks", () => {
       async () => {
         const { events, dispose } = await collectEvents((cb) => pipeline("automatic-speech-recognition", model_id, { ...DEFAULT_MODEL_OPTIONS, progress_callback: cb }));
 
-        expectValidEventLifecycle(events, model_id, ["config.json", "onnx/encoder_model.onnx", "onnx/decoder_model_merged.onnx", "generation_config.json", "tokenizer.json", "tokenizer_config.json", "preprocessor_config.json"]);
+        const expectedFiles = ["config.json", "onnx/encoder_model.onnx", "onnx/decoder_model_merged.onnx", "generation_config.json", "tokenizer.json", "tokenizer_config.json", "preprocessor_config.json"];
+
+        // Each file should be loaded exactly once: pipeline() must not double-fetch
+        // tokenizer.json/tokenizer_config.json/preprocessor_config.json that the
+        // tokenizer and processor would otherwise each load independently.
+        const initiateCounts = {};
+        for (const e of events.filter((x) => x.status === "initiate")) {
+          initiateCounts[e.file] = (initiateCounts[e.file] ?? 0) + 1;
+        }
+        expect(initiateCounts).toEqual(Object.fromEntries(expectedFiles.map((f) => [f, 1])));
+
+        expectValidEventLifecycle(events, model_id, expectedFiles);
 
         await dispose();
       },

--- a/packages/transformers/tests/progress_callbacks.test.js
+++ b/packages/transformers/tests/progress_callbacks.test.js
@@ -155,11 +155,8 @@ describe("Progress Callbacks", () => {
         // Each file should be loaded exactly once: pipeline() must not double-fetch
         // tokenizer.json/tokenizer_config.json/preprocessor_config.json that the
         // tokenizer and processor would otherwise each load independently.
-        const initiateCounts = {};
-        for (const e of events.filter((x) => x.status === "initiate")) {
-          initiateCounts[e.file] = (initiateCounts[e.file] ?? 0) + 1;
-        }
-        expect(initiateCounts).toEqual(Object.fromEntries(expectedFiles.map((f) => [f, 1])));
+        const initiated = events.filter((e) => e.status === "initiate").map((e) => e.file);
+        expect(initiated.sort()).toEqual([...expectedFiles].sort());
 
         expectValidEventLifecycle(events, model_id, expectedFiles);
 


### PR DESCRIPTION
Whisper pipelines would load tokenizer and processor at the same time, leading to duplicate tokenizer loads (because processor loads tokenizer too). this deduplicates it. this also fixes the non-monotonic file downloading.

Is a follow-up (and improvement) to https://github.com/huggingface/transformers.js/pull/1664, truly fixing https://github.com/huggingface/transformers.js/issues/1663.

The unit test I added currently fails on main, and also fixes this error in CI:
```
Summary of all failing tests
FAIL tests/progress_callbacks.test.js (13.168 s, 104 MB heap size)
  ● Progress Callbacks › Whisper (encoder-decoder) › pipeline('automatic-speech-recognition')

    expect(received).toBeGreaterThanOrEqual(expected)

    Expected: >= 559880
    Received:    342724

      42 |   // 1. loaded should be monotonically non-decreasing
      43 |   for (let i = 1; i < totalEvents.length; i++) {
    > 44 |     expect(totalEvents[i].loaded).toBeGreaterThanOrEqual(totalEvents[i - 1].loaded);
         |                                   ^
      45 |   }
      46 |
```