### PR TITLE
chore(ts): enable noImplicitReturns and add explicit returns (#1623)

### DIFF
--- a/packages/transformers/src/models/marian/tokenization_marian.js
+++ b/packages/transformers/src/models/marian/tokenization_marian.js
@@ -52,5 +52,6 @@ export class MarianTokenizer extends PreTrainedTokenizer {
             }
             return mergeArrays([language], super._encode_text(text));
         }
+        return undefined;
     }
 }

--- a/packages/transformers/src/utils/core.js
+++ b/packages/transformers/src/utils/core.js
@@ -273,6 +273,7 @@ export function pick(o, props) {
             if (o[prop] !== undefined) {
                 return { [prop]: o[prop] };
             }
+            return undefined;
         }),
     );
 }

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "types",
     "rootDir": "src",
     "strict": false,
+    "noImplicitReturns": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "lib": ["ES2020", "DOM"],
     "outDir": "types",
     "strict": false,
+    "noImplicitReturns": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Part of #1623.

Enables `noImplicitReturns` in both tsconfigs and fixes the two functions that were missing explicit returns. Turned out the codebase was already pretty clean for this flag — only two sites needed fixing.

## Changes

| File | What changed |
|------|-------------|
| `tsconfig.json` + `packages/transformers/tsconfig.json` | Flag enabled in both to keep IDE and build checks in sync |
| `packages/transformers/src/models/marian/tokenization_marian.js` | Added `return undefined;` at the end of `_encode_text` where a code path fell through |
| `packages/transformers/src/utils/core.js` | Same fix for the arrow callback inside `pick` |

## Verification

- `pnpm typegen` — zero TS7030 errors
- `pnpm build` — passes
- `pnpm test` — 1,683 passed. The 48 `beforeAll` timeouts are HF Hub download failures that reproduce identically on unmodified `main` — not from this PR

## Notes

No runtime behavior change. Both additions are on paths that already implicitly returned `undefined`. Confirmed with a sanity scan that the only JS lines added across the whole diff are the two return statements.

Used `return undefined;` instead of bare `return;` because TypeScript requires it when the inferred return type isn't `void`. Same thing at runtime.