### PR TITLE
chore(ts): enable noFallthroughCasesInSwitch and annotate intentional fallthrough (#1623)

### DIFF
--- a/packages/transformers/src/utils/image.js
+++ b/packages/transformers/src/utils/image.js
@@ -404,6 +404,7 @@ export class RawImage {
 
             switch (resampleMethod) {
                 case 'box':
+                // @ts-expect-error TS7029 — intentional fallthrough: 'hamming' is unsupported, so we warn, downgrade to 'bilinear', and reuse the shared affine handler below
                 case 'hamming':
                     if (resampleMethod === 'box' || resampleMethod === 'hamming') {
                         logger.warn(

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "types",
     "rootDir": "src",
     "strict": false,
+    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "lib": ["ES2020", "DOM"],
     "outDir": "types",
     "strict": false,
+    "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Part of #1623. Second in the strictness series after #1691 (noImplicitReturns).

Enables `noFallthroughCasesInSwitch` in both tsconfigs. The codebase had 
17 switch statements across 9 files — only one intentional fallthrough 
existed in the entire codebase.

## Changes

| File | What changed |
|------|-------------|
| `tsconfig.json` + `packages/transformers/tsconfig.json` | Flag enabled in both |
| `packages/transformers/src/utils/image.js` | Added `@ts-expect-error TS7029` on the intentional fallthrough in `RawImage.resize()` — `case 'box'`/`case 'hamming'` warn and downgrade to `'bilinear'` before falling through to the shared `img.affine()` block. Runtime behavior unchanged. |

Note: used `@ts-expect-error TS7029` rather than `// falls through` because 
TypeScript does not recognize the latter as a suppression comment 
(that is an ESLint convention). `@ts-expect-error` is self-documenting 
and will fail if the suppression is ever no longer needed.

## Verification

- `pnpm typegen` — zero errors
- `pnpm build` — passes
- `pnpm test` — 1,683 passed, same baseline as #1691