### PR TITLE
chore(ts): enable noImplicitOverride and annotate override methods (#1623)

### DIFF
--- a/packages/transformers/src/generation/logits_process.js
+++ b/packages/transformers/src/generation/logits_process.js
@@ -12,6 +12,7 @@ import { max, log_softmax } from '../utils/maths.js';
  */
 export class LogitsProcessor extends Callable {
     /**
+     * @override
      * Apply the processor to the input logits.
      *
      * @abstract
@@ -29,6 +30,7 @@ export class LogitsProcessor extends Callable {
  */
 export class LogitsWarper extends Callable {
     /**
+     * @override
      * Apply the processor to the input logits.
      *
      * @abstract
@@ -74,6 +76,7 @@ export class LogitsProcessorList extends Callable {
     }
 
     /**
+     * @override
      * Applies all logits processors in the list to a batch of logits, modifying them in-place.
      *
      * @param {bigint[][]} input_ids The input IDs for the language model.
@@ -145,6 +148,7 @@ export class ForcedBOSTokenLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply the BOS token forcing to the logits.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -178,6 +182,7 @@ export class ForcedEOSTokenLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply the processor to input_ids and logits.
      *
      * @param {bigint[][]} input_ids The input ids.
@@ -212,6 +217,7 @@ export class SuppressTokensLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Suppress the specified tokens by setting their logits to -Infinity.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -246,6 +252,7 @@ export class SuppressTokensAtBeginLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply the BOS token forcing to the logits.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -290,6 +297,7 @@ export class WhisperTimeStampLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Modify the logits to handle timestamp tokens.
      * @param {bigint[][]} input_ids The input sequence of tokens.
      * @param {Tensor} logits The logits output by the model.
@@ -420,6 +428,7 @@ export class NoRepeatNGramLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply the no-repeat-ngram processor to the logits.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -461,6 +470,7 @@ export class RepetitionPenaltyLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply the repetition penalty to the logits.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -499,6 +509,7 @@ export class MinLengthLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply logit processor.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -537,6 +548,7 @@ export class MinNewTokensLengthLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply logit processor.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -570,6 +582,7 @@ export class NoBadWordsLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply logit processor.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -632,6 +645,7 @@ export class ClassifierFreeGuidanceLogitsProcessor extends LogitsProcessor {
     }
 
     /**
+     * @override
      * Apply logit processor.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.
@@ -685,6 +699,7 @@ export class TemperatureLogitsWarper extends LogitsWarper {
     }
 
     /**
+     * @override
      * Apply logit warper.
      * @param {bigint[][]} input_ids The input IDs.
      * @param {Tensor} logits The logits.

--- a/packages/transformers/src/generation/logits_sampler.js
+++ b/packages/transformers/src/generation/logits_sampler.js
@@ -23,6 +23,7 @@ export class LogitsSampler extends Callable {
     }
 
     /**
+     * @override
      * Executes the sampler, using the specified logits.
      * @param {Tensor} logits
      * @returns {Promise<[bigint, number][]>}
@@ -107,6 +108,7 @@ export class LogitsSampler extends Callable {
  */
 class GreedySampler extends LogitsSampler {
     /**
+     * @override
      * Sample the maximum probability of a given logits tensor.
      * @param {Tensor} logits
      * @returns {Promise<[bigint, number][]>} An array with a single tuple, containing the index of the maximum value and a meaningless score (since this is a greedy search).
@@ -126,6 +128,7 @@ class GreedySampler extends LogitsSampler {
  */
 class MultinomialSampler extends LogitsSampler {
     /**
+     * @override
      * Sample from the logits.
      * @param {Tensor} logits
      * @returns {Promise<[bigint, number][]>}
@@ -157,6 +160,7 @@ class MultinomialSampler extends LogitsSampler {
  */
 class BeamSearchSampler extends LogitsSampler {
     /**
+     * @override
      * Sample from the logits.
      * @param {Tensor} logits
      * @returns {Promise<[bigint, number][]>}

--- a/packages/transformers/src/generation/stopping_criteria.js
+++ b/packages/transformers/src/generation/stopping_criteria.js
@@ -12,6 +12,7 @@ import { Callable } from '../utils/generic.js';
  */
 export class StoppingCriteria extends Callable {
     /**
+     * @override
      *
      * @param {number[][]} input_ids (`number[][]` of shape `(batch_size, sequence_length)`):
      * Indices of input sequence tokens in the vocabulary.
@@ -58,6 +59,7 @@ export class StoppingCriteriaList extends Callable {
         this.criteria.push(...items);
     }
 
+    /** @override */
     _call(input_ids, scores) {
         const is_done = new Array(input_ids.length).fill(false);
         for (const criterion of this.criteria) {
@@ -90,6 +92,7 @@ export class MaxLengthCriteria extends StoppingCriteria {
         this.max_position_embeddings = max_position_embeddings;
     }
 
+    /** @override */
     _call(input_ids) {
         return input_ids.map((ids) => ids.length >= this.max_length);
     }
@@ -116,6 +119,7 @@ export class EosTokenCriteria extends StoppingCriteria {
     }
 
     /**
+     * @override
      *
      * @param {number[][]} input_ids
      * @param {number[][]} scores
@@ -147,6 +151,7 @@ export class InterruptableStoppingCriteria extends StoppingCriteria {
         this.interrupted = false;
     }
 
+    /** @override */
     _call(input_ids, scores) {
         return new Array(input_ids.length).fill(this.interrupted);
     }

--- a/packages/transformers/src/generation/streamers.js
+++ b/packages/transformers/src/generation/streamers.js
@@ -76,6 +76,7 @@ export class TextStreamer extends BaseStreamer {
     }
 
     /**
+     * @override
      * Receives tokens, decodes them, and prints them to stdout as soon as they form entire words.
      * @param {bigint[][]} value
      */
@@ -136,6 +137,7 @@ export class TextStreamer extends BaseStreamer {
     }
 
     /**
+     * @override
      * Flushes any remaining cache and prints a newline to stdout.
      */
     end() {
@@ -222,6 +224,7 @@ export class WhisperTextStreamer extends TextStreamer {
     }
 
     /**
+     * @override
      * @param {bigint[][]} value
      */
     put(value) {
@@ -251,6 +254,7 @@ export class WhisperTextStreamer extends TextStreamer {
         return super.put(value);
     }
 
+    /** @override */
     end() {
         super.end();
         this.on_finalize?.();

--- a/packages/transformers/src/image_processors_utils.js
+++ b/packages/transformers/src/image_processors_utils.js
@@ -1036,6 +1036,7 @@ export class ImageProcessor extends Callable {
     }
 
     /**
+     * @override
      * Calls the feature extraction process on an array of images,
      * preprocesses each image, and concatenates the resulting
      * features into a single Tensor.

--- a/packages/transformers/src/models/albert/modeling_albert.js
+++ b/packages/transformers/src/models/albert/modeling_albert.js
@@ -5,6 +5,7 @@ export class AlbertPreTrainedModel extends PreTrainedModel {}
 export class AlbertModel extends AlbertPreTrainedModel {}
 export class AlbertForSequenceClassification extends AlbertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -16,6 +17,7 @@ export class AlbertForSequenceClassification extends AlbertPreTrainedModel {
 }
 export class AlbertForQuestionAnswering extends AlbertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -27,6 +29,7 @@ export class AlbertForQuestionAnswering extends AlbertPreTrainedModel {
 }
 export class AlbertForMaskedLM extends AlbertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/albert/tokenization_albert.js
+++ b/packages/transformers/src/models/albert/tokenization_albert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class AlbertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.js
+++ b/packages/transformers/src/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.js
@@ -58,6 +58,7 @@ export class ASTFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor }>} A Promise resolving to an object containing the extracted input features as a Tensor.

--- a/packages/transformers/src/models/auto/modeling_auto.js
+++ b/packages/transformers/src/models/auto/modeling_auto.js
@@ -148,6 +148,7 @@ export class AutoModel extends PretrainedMixin {
     /** @type {Map<string, Object>[]} */
     // @ts-ignore
     static MODEL_CLASS_MAPPINGS = MODEL_CLASS_TYPE_MAPPING.map((x) => x[0]);
+    /** @override */
     static BASE_IF_FAIL = true;
 }
 
@@ -159,6 +160,7 @@ export class AutoModel extends PretrainedMixin {
  * const model = await AutoModelForSequenceClassification.from_pretrained('Xenova/distilbert-base-uncased-finetuned-sst-2-english');
  */
 export class AutoModelForSequenceClassification extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES];
 }
 
@@ -170,6 +172,7 @@ export class AutoModelForSequenceClassification extends PretrainedMixin {
  * const model = await AutoModelForTokenClassification.from_pretrained('Xenova/distilbert-base-multilingual-cased-ner-hrl');
  */
 export class AutoModelForTokenClassification extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES];
 }
 
@@ -181,6 +184,7 @@ export class AutoModelForTokenClassification extends PretrainedMixin {
  * const model = await AutoModelForSeq2SeqLM.from_pretrained('Xenova/t5-small');
  */
 export class AutoModelForSeq2SeqLM extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES];
 }
 
@@ -192,6 +196,7 @@ export class AutoModelForSeq2SeqLM extends PretrainedMixin {
  * const model = await AutoModelForSpeechSeq2Seq.from_pretrained('openai/whisper-tiny.en');
  */
 export class AutoModelForSpeechSeq2Seq extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES];
 }
 
@@ -203,6 +208,7 @@ export class AutoModelForSpeechSeq2Seq extends PretrainedMixin {
  * const model = await AutoModelForTextToSpectrogram.from_pretrained('microsoft/speecht5_tts');
  */
 export class AutoModelForTextToSpectrogram extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES];
 }
 
@@ -214,6 +220,7 @@ export class AutoModelForTextToSpectrogram extends PretrainedMixin {
  * const model = await AutoModelForTextToSpectrogram.from_pretrained('facebook/mms-tts-eng');
  */
 export class AutoModelForTextToWaveform extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES];
 }
 
@@ -225,6 +232,7 @@ export class AutoModelForTextToWaveform extends PretrainedMixin {
  * const model = await AutoModelForCausalLM.from_pretrained('Xenova/gpt2');
  */
 export class AutoModelForCausalLM extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_CAUSAL_LM_MAPPING_NAMES];
 }
 
@@ -236,6 +244,7 @@ export class AutoModelForCausalLM extends PretrainedMixin {
  * const model = await AutoModelForMaskedLM.from_pretrained('Xenova/bert-base-uncased');
  */
 export class AutoModelForMaskedLM extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_MASKED_LM_MAPPING_NAMES];
 }
 
@@ -247,6 +256,7 @@ export class AutoModelForMaskedLM extends PretrainedMixin {
  * const model = await AutoModelForQuestionAnswering.from_pretrained('Xenova/distilbert-base-cased-distilled-squad');
  */
 export class AutoModelForQuestionAnswering extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES];
 }
 
@@ -258,6 +268,7 @@ export class AutoModelForQuestionAnswering extends PretrainedMixin {
  * const model = await AutoModelForVision2Seq.from_pretrained('Xenova/vit-gpt2-image-captioning');
  */
 export class AutoModelForVision2Seq extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES];
 }
 
@@ -269,6 +280,7 @@ export class AutoModelForVision2Seq extends PretrainedMixin {
  * const model = await AutoModelForImageClassification.from_pretrained('Xenova/vit-base-patch16-224');
  */
 export class AutoModelForImageClassification extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING_NAMES];
 }
 
@@ -280,6 +292,7 @@ export class AutoModelForImageClassification extends PretrainedMixin {
  * const model = await AutoModelForImageSegmentation.from_pretrained('Xenova/detr-resnet-50-panoptic');
  */
 export class AutoModelForImageSegmentation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_SEGMENTATION_MAPPING_NAMES];
 }
 
@@ -291,6 +304,7 @@ export class AutoModelForImageSegmentation extends PretrainedMixin {
  * const model = await AutoModelForSemanticSegmentation.from_pretrained('nvidia/segformer-b3-finetuned-cityscapes-1024-1024');
  */
 export class AutoModelForSemanticSegmentation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING_NAMES];
 }
 
@@ -302,6 +316,7 @@ export class AutoModelForSemanticSegmentation extends PretrainedMixin {
  * const model = await AutoModelForUniversalSegmentation.from_pretrained('hf-internal-testing/tiny-random-MaskFormerForInstanceSegmentation');
  */
 export class AutoModelForUniversalSegmentation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_UNIVERSAL_SEGMENTATION_MAPPING_NAMES];
 }
 
@@ -313,10 +328,12 @@ export class AutoModelForUniversalSegmentation extends PretrainedMixin {
  * const model = await AutoModelForObjectDetection.from_pretrained('Xenova/detr-resnet-50');
  */
 export class AutoModelForObjectDetection extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES];
 }
 
 export class AutoModelForZeroShotObjectDetection extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING_NAMES];
 }
 
@@ -328,57 +345,71 @@ export class AutoModelForZeroShotObjectDetection extends PretrainedMixin {
  * const model = await AutoModelForMaskGeneration.from_pretrained('Xenova/sam-vit-base');
  */
 export class AutoModelForMaskGeneration extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_MASK_GENERATION_MAPPING_NAMES];
 }
 
 export class AutoModelForCTC extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_CTC_MAPPING_NAMES];
 }
 
 export class AutoModelForAudioClassification extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES];
 }
 
 export class AutoModelForXVector extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES];
 }
 
 export class AutoModelForAudioFrameClassification extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_AUDIO_FRAME_CLASSIFICATION_MAPPING_NAMES];
 }
 
 export class AutoModelForDocumentQuestionAnswering extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES];
 }
 
 export class AutoModelForImageMatting extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_MATTING_MAPPING_NAMES];
 }
 
 export class AutoModelForImageToImage extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_TO_IMAGE_MAPPING_NAMES];
 }
 
 export class AutoModelForDepthEstimation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_DEPTH_ESTIMATION_MAPPING_NAMES];
 }
 
 export class AutoModelForNormalEstimation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_NORMAL_ESTIMATION_MAPPING_NAMES];
 }
 
 export class AutoModelForPoseEstimation extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_POSE_ESTIMATION_MAPPING_NAMES];
 }
 
 export class AutoModelForImageFeatureExtraction extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_FEATURE_EXTRACTION_MAPPING_NAMES];
 }
 
 export class AutoModelForImageTextToText extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES];
 }
 
 export class AutoModelForAudioTextToText extends PretrainedMixin {
+    /** @override */
     static MODEL_CLASS_MAPPINGS = [MODEL_MAPPINGS.MODEL_FOR_AUDIO_TEXT_TO_TEXT_MAPPING_NAMES];
 }

--- a/packages/transformers/src/models/bart/modeling_bart.js
+++ b/packages/transformers/src/models/bart/modeling_bart.js
@@ -18,6 +18,7 @@ export class BartForConditionalGeneration extends BartPretrainedModel {}
  */
 export class BartForSequenceClassification extends BartPretrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/beit/modeling_beit.js
+++ b/packages/transformers/src/models/beit/modeling_beit.js
@@ -5,6 +5,7 @@ export class BeitPreTrainedModel extends PreTrainedModel {}
 export class BeitModel extends BeitPreTrainedModel {}
 export class BeitForImageClassification extends BeitPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/bert/modeling_bert.js
+++ b/packages/transformers/src/models/bert/modeling_bert.js
@@ -14,6 +14,7 @@ export class BertModel extends BertPreTrainedModel {}
  */
 export class BertForMaskedLM extends BertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -29,6 +30,7 @@ export class BertForMaskedLM extends BertPreTrainedModel {
  */
 export class BertForSequenceClassification extends BertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -44,6 +46,7 @@ export class BertForSequenceClassification extends BertPreTrainedModel {
  */
 export class BertForTokenClassification extends BertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -59,6 +62,7 @@ export class BertForTokenClassification extends BertPreTrainedModel {
  */
 export class BertForQuestionAnswering extends BertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/bert/tokenization_bert.js
+++ b/packages/transformers/src/models/bert/tokenization_bert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class BertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/camembert/modeling_camembert.js
+++ b/packages/transformers/src/models/camembert/modeling_camembert.js
@@ -18,6 +18,7 @@ export class CamembertModel extends CamembertPreTrainedModel {}
  */
 export class CamembertForMaskedLM extends CamembertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class CamembertForMaskedLM extends CamembertPreTrainedModel {
  */
 export class CamembertForSequenceClassification extends CamembertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -48,6 +50,7 @@ export class CamembertForSequenceClassification extends CamembertPreTrainedModel
  */
 export class CamembertForTokenClassification extends CamembertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -63,6 +66,7 @@ export class CamembertForTokenClassification extends CamembertPreTrainedModel {
  */
 export class CamembertForQuestionAnswering extends CamembertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/chatterbox/feature_extraction_chatterbox.js
+++ b/packages/transformers/src/models/chatterbox/feature_extraction_chatterbox.js
@@ -3,6 +3,7 @@ import { Tensor } from '../../utils/tensor.js';
 
 export class ChatterboxFeatureExtractor extends FeatureExtractor {
     /**
+     * @override
      * Asynchronously extracts input values from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor; }>} The extracted input values.

--- a/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
+++ b/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
@@ -6,6 +6,7 @@ const SILENCE_TOKEN = 4299n;
 const START_SPEECH_TOKEN = 6561n;
 
 export class ChatterboxPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         'input_ids',
         'inputs_embeds',
@@ -19,8 +20,10 @@ export class ChatterboxPreTrainedModel extends PreTrainedModel {
         'speaker_features',
         'past_key_values',
     ];
+    /** @override */
     main_input_name = 'input_ids';
 
+    /** @override */
     _return_dict_in_generate_keys = ['audio_tokens', 'speaker_embeddings', 'speaker_features'];
 }
 export class ChatterboxModel extends ChatterboxPreTrainedModel {
@@ -34,6 +37,7 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
         });
     }
 
+    /** @override */
     async forward({
         // Produced by the tokenizer/processor:
         input_ids = null,
@@ -129,6 +133,7 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
         };
     }
 
+    /** @override */
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
         if (!model_inputs.position_ids && this.sessions['embed_tokens'].inputNames.includes('position_ids')) {
             // If position_ids are not provided, we create them on the fly using the position of the START_SPEECH_TOKEN
@@ -160,7 +165,10 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
         return decoder_prepare_inputs_for_generation(this, input_ids, model_inputs, generation_config);
     }
 
-    /** @type {PreTrainedModel['generate']} */
+    /**
+     * @override
+     * @type {PreTrainedModel['generate']}
+     */
     async generate(params) {
         const { sequences, audio_tokens, speaker_embeddings, speaker_features } = /** @type {any} */ (
             await super.generate({

--- a/packages/transformers/src/models/chatterbox/processing_chatterbox.js
+++ b/packages/transformers/src/models/chatterbox/processing_chatterbox.js
@@ -9,6 +9,7 @@ export class ChatterboxProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
 
+    /** @override */
     async _call(text, audio = null) {
         const text_features = this.tokenizer(text);
         const audio_features = audio ? await this.feature_extractor(audio) : {};

--- a/packages/transformers/src/models/clap/feature_extraction_clap.js
+++ b/packages/transformers/src/models/clap/feature_extraction_clap.js
@@ -138,6 +138,7 @@ export class ClapFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_features: Tensor }>} A Promise resolving to an object containing the extracted input features as a Tensor.

--- a/packages/transformers/src/models/clap/modeling_clap.js
+++ b/packages/transformers/src/models/clap/modeling_clap.js
@@ -31,7 +31,10 @@ export class ClapModel extends ClapPreTrainedModel {}
  * ```
  */
 export class ClapTextModelWithProjection extends ClapPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -68,7 +71,10 @@ export class ClapTextModelWithProjection extends ClapPreTrainedModel {
  * ```
  */
 export class ClapAudioModelWithProjection extends ClapPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/clip/modeling_clip.js
+++ b/packages/transformers/src/models/clip/modeling_clip.js
@@ -51,7 +51,10 @@ export class CLIPModel extends CLIPPreTrainedModel {}
  * The text model from CLIP without any head or projection on top.
  */
 export class CLIPTextModel extends CLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -88,7 +91,10 @@ export class CLIPTextModel extends CLIPPreTrainedModel {
  * ```
  */
 export class CLIPTextModelWithProjection extends CLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -102,7 +108,10 @@ export class CLIPTextModelWithProjection extends CLIPPreTrainedModel {
  * The vision model from CLIP without any head or projection on top.
  */
 export class CLIPVisionModel extends CLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -139,7 +148,10 @@ export class CLIPVisionModel extends CLIPPreTrainedModel {
  * ```
  */
 export class CLIPVisionModelWithProjection extends CLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/cohere_asr/feature_extraction_cohere_asr.js
+++ b/packages/transformers/src/models/cohere_asr/feature_extraction_cohere_asr.js
@@ -101,6 +101,7 @@ export class CohereAsrFeatureExtractor extends ParakeetFeatureExtractor {
     }
 
     /**
+     * @override
      * Extracts features from a given audio waveform.
      * @param {Float32Array|Float64Array} audio The audio data.
      * @returns {Promise<{ input_features: import('../../utils/tensor.js').Tensor; attention_mask: import('../../utils/tensor.js').Tensor; }>}

--- a/packages/transformers/src/models/cohere_asr/modeling_cohere_asr.js
+++ b/packages/transformers/src/models/cohere_asr/modeling_cohere_asr.js
@@ -2,7 +2,9 @@ import { PreTrainedModel } from '../modeling_utils.js';
 
 export class CohereAsrPreTrainedModel extends PreTrainedModel {
     requires_attention_mask = false;
+    /** @override */
     main_input_name = 'input_features';
+    /** @override */
     forward_params = ['input_features', 'decoder_input_ids', 'decoder_attention_mask', 'past_key_values'];
 }
 

--- a/packages/transformers/src/models/cohere_asr/processing_cohere_asr.js
+++ b/packages/transformers/src/models/cohere_asr/processing_cohere_asr.js
@@ -7,6 +7,7 @@ const NO_SPACE_LANGUAGES = new Set(['ja', 'zh']);
 export class CohereAsrProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
+    /** @override */
     static uses_processor_config = true;
 
     /**
@@ -45,6 +46,7 @@ export class CohereAsrProcessor extends Processor {
     }
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>}

--- a/packages/transformers/src/models/convbert/modeling_convbert.js
+++ b/packages/transformers/src/models/convbert/modeling_convbert.js
@@ -18,6 +18,7 @@ export class ConvBertModel extends ConvBertPreTrainedModel {}
  */
 export class ConvBertForMaskedLM extends ConvBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class ConvBertForMaskedLM extends ConvBertPreTrainedModel {
  */
 export class ConvBertForSequenceClassification extends ConvBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -49,6 +51,7 @@ export class ConvBertForSequenceClassification extends ConvBertPreTrainedModel {
  */
 export class ConvBertForTokenClassification extends ConvBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -65,6 +68,7 @@ export class ConvBertForTokenClassification extends ConvBertPreTrainedModel {
  */
 export class ConvBertForQuestionAnswering extends ConvBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/convbert/tokenization_convbert.js
+++ b/packages/transformers/src/models/convbert/tokenization_convbert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class ConvBertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/convnext/image_processing_convnext.js
+++ b/packages/transformers/src/models/convnext/image_processing_convnext.js
@@ -11,6 +11,7 @@ export class ConvNextImageProcessor extends ImageProcessor {
         this.crop_pct = this.config.crop_pct ?? 224 / 256;
     }
 
+    /** @override */
     async resize(image) {
         const shortest_edge = this.size?.shortest_edge;
         if (shortest_edge === undefined) {

--- a/packages/transformers/src/models/convnext/modeling_convnext.js
+++ b/packages/transformers/src/models/convnext/modeling_convnext.js
@@ -13,6 +13,7 @@ export class ConvNextModel extends ConvNextPreTrainedModel {}
  */
 export class ConvNextForImageClassification extends ConvNextPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/convnextv2/modeling_convnextv2.js
+++ b/packages/transformers/src/models/convnextv2/modeling_convnextv2.js
@@ -13,6 +13,7 @@ export class ConvNextV2Model extends ConvNextV2PreTrainedModel {}
  */
 export class ConvNextV2ForImageClassification extends ConvNextV2PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/d_fine/modeling_d_fine.js
+++ b/packages/transformers/src/models/d_fine/modeling_d_fine.js
@@ -5,6 +5,7 @@ export class DFinePreTrainedModel extends PreTrainedModel {}
 export class DFineModel extends DFinePreTrainedModel {}
 export class DFineForObjectDetection extends DFinePreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/dac/modeling_dac.js
+++ b/packages/transformers/src/models/dac/modeling_dac.js
@@ -26,7 +26,9 @@ export class DacDecoderOutput extends ModelOutput {
 }
 
 export class DacPreTrainedModel extends PreTrainedModel {
+    /** @override */
     main_input_name = 'input_values';
+    /** @override */
     forward_params = ['input_values'];
 }
 
@@ -55,7 +57,10 @@ export class DacModel extends DacPreTrainedModel {
 }
 
 export class DacEncoderModel extends DacPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -65,7 +70,10 @@ export class DacEncoderModel extends DacPreTrainedModel {
     }
 }
 export class DacDecoderModel extends DacPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/deberta/modeling_deberta.js
+++ b/packages/transformers/src/models/deberta/modeling_deberta.js
@@ -18,6 +18,7 @@ export class DebertaModel extends DebertaPreTrainedModel {}
  */
 export class DebertaForMaskedLM extends DebertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class DebertaForMaskedLM extends DebertaPreTrainedModel {
  */
 export class DebertaForSequenceClassification extends DebertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -48,6 +50,7 @@ export class DebertaForSequenceClassification extends DebertaPreTrainedModel {
  */
 export class DebertaForTokenClassification extends DebertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -64,6 +67,7 @@ export class DebertaForTokenClassification extends DebertaPreTrainedModel {
  */
 export class DebertaForQuestionAnswering extends DebertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/deberta/tokenization_deberta.js
+++ b/packages/transformers/src/models/deberta/tokenization_deberta.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class DebertaTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/deberta_v2/modeling_deberta_v2.js
+++ b/packages/transformers/src/models/deberta_v2/modeling_deberta_v2.js
@@ -18,6 +18,7 @@ export class DebertaV2Model extends DebertaV2PreTrainedModel {}
  */
 export class DebertaV2ForMaskedLM extends DebertaV2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class DebertaV2ForMaskedLM extends DebertaV2PreTrainedModel {
  */
 export class DebertaV2ForSequenceClassification extends DebertaV2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -48,6 +50,7 @@ export class DebertaV2ForSequenceClassification extends DebertaV2PreTrainedModel
  */
 export class DebertaV2ForTokenClassification extends DebertaV2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -64,6 +67,7 @@ export class DebertaV2ForTokenClassification extends DebertaV2PreTrainedModel {
  */
 export class DebertaV2ForQuestionAnswering extends DebertaV2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/deberta_v2/tokenization_deberta_v2.js
+++ b/packages/transformers/src/models/deberta_v2/tokenization_deberta_v2.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class DebertaV2Tokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/deit/modeling_deit.js
+++ b/packages/transformers/src/models/deit/modeling_deit.js
@@ -5,6 +5,7 @@ export class DeiTPreTrainedModel extends PreTrainedModel {}
 export class DeiTModel extends DeiTPreTrainedModel {}
 export class DeiTForImageClassification extends DeiTPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/detr/image_processing_detr.js
+++ b/packages/transformers/src/models/detr/image_processing_detr.js
@@ -15,6 +15,7 @@ import { full } from '../../utils/tensor.js';
 
 export class DetrImageProcessor extends ImageProcessor {
     /**
+     * @override
      * Calls the feature extraction process on an array of images, preprocesses
      * each image, and concatenates the resulting features into a single Tensor.
      * @param {import('../../utils/image.js').RawImage[]} images The image(s) to extract features from.

--- a/packages/transformers/src/models/detr/modeling_detr.js
+++ b/packages/transformers/src/models/detr/modeling_detr.js
@@ -6,6 +6,7 @@ export class DetrPreTrainedModel extends PreTrainedModel {}
 export class DetrModel extends DetrPreTrainedModel {}
 export class DetrForObjectDetection extends DetrPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {
@@ -15,6 +16,7 @@ export class DetrForObjectDetection extends DetrPreTrainedModel {
 
 export class DetrForSegmentation extends DetrPreTrainedModel {
     /**
+     * @override
      * Runs the model with the provided inputs
      * @param {Object} model_inputs Model inputs
      * @returns {Promise<DetrSegmentationOutput>} Object containing segmentation outputs

--- a/packages/transformers/src/models/dinov2/modeling_dinov2.js
+++ b/packages/transformers/src/models/dinov2/modeling_dinov2.js
@@ -13,6 +13,7 @@ export class Dinov2Model extends Dinov2PreTrainedModel {}
  */
 export class Dinov2ForImageClassification extends Dinov2PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/dinov2_with_registers/modeling_dinov2_with_registers.js
+++ b/packages/transformers/src/models/dinov2_with_registers/modeling_dinov2_with_registers.js
@@ -13,6 +13,7 @@ export class Dinov2WithRegistersModel extends Dinov2WithRegistersPreTrainedModel
  */
 export class Dinov2WithRegistersForImageClassification extends Dinov2WithRegistersPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/distilbert/modeling_distilbert.js
+++ b/packages/transformers/src/models/distilbert/modeling_distilbert.js
@@ -14,6 +14,7 @@ export class DistilBertModel extends DistilBertPreTrainedModel {}
  */
 export class DistilBertForSequenceClassification extends DistilBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -29,6 +30,7 @@ export class DistilBertForSequenceClassification extends DistilBertPreTrainedMod
  */
 export class DistilBertForTokenClassification extends DistilBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -44,6 +46,7 @@ export class DistilBertForTokenClassification extends DistilBertPreTrainedModel 
  */
 export class DistilBertForQuestionAnswering extends DistilBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -59,6 +62,7 @@ export class DistilBertForQuestionAnswering extends DistilBertPreTrainedModel {
  */
 export class DistilBertForMaskedLM extends DistilBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/donut/image_processing_donut.js
+++ b/packages/transformers/src/models/donut/image_processing_donut.js
@@ -1,6 +1,7 @@
 import { ImageProcessor } from '../../image_processors_utils.js';
 
 export class DonutImageProcessor extends ImageProcessor {
+    /** @override */
     pad_image(pixelData, imgDims, padSize, options = {}) {
         const [imageHeight, imageWidth, imageChannels] = imgDims;
 

--- a/packages/transformers/src/models/efficientnet/modeling_efficientnet.js
+++ b/packages/transformers/src/models/efficientnet/modeling_efficientnet.js
@@ -13,6 +13,7 @@ export class EfficientNetModel extends EfficientNetPreTrainedModel {}
  */
 export class EfficientNetForImageClassification extends EfficientNetPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/electra/modeling_electra.js
+++ b/packages/transformers/src/models/electra/modeling_electra.js
@@ -20,6 +20,7 @@ export class ElectraModel extends ElectraPreTrainedModel {}
  */
 export class ElectraForMaskedLM extends ElectraPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -35,6 +36,7 @@ export class ElectraForMaskedLM extends ElectraPreTrainedModel {
  */
 export class ElectraForSequenceClassification extends ElectraPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -50,6 +52,7 @@ export class ElectraForSequenceClassification extends ElectraPreTrainedModel {
  */
 export class ElectraForTokenClassification extends ElectraPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -66,6 +69,7 @@ export class ElectraForTokenClassification extends ElectraPreTrainedModel {
  */
 export class ElectraForQuestionAnswering extends ElectraPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/electra/tokenization_electra.js
+++ b/packages/transformers/src/models/electra/tokenization_electra.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class ElectraTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/encodec/feature_extraction_encodec.js
+++ b/packages/transformers/src/models/encodec/feature_extraction_encodec.js
@@ -3,6 +3,7 @@ import { Tensor } from '../../utils/tensor.js';
 
 export class EncodecFeatureExtractor extends FeatureExtractor {
     /**
+     * @override
      * Asynchronously extracts input values from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor; }>} The extracted input values.

--- a/packages/transformers/src/models/esm/modeling_esm.js
+++ b/packages/transformers/src/models/esm/modeling_esm.js
@@ -13,6 +13,7 @@ export class EsmModel extends EsmPreTrainedModel {}
  */
 export class EsmForMaskedLM extends EsmPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -28,6 +29,7 @@ export class EsmForMaskedLM extends EsmPreTrainedModel {
  */
 export class EsmForSequenceClassification extends EsmPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -44,6 +46,7 @@ export class EsmForSequenceClassification extends EsmPreTrainedModel {
  */
 export class EsmForTokenClassification extends EsmPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/eurobert/modeling_eurobert.js
+++ b/packages/transformers/src/models/eurobert/modeling_eurobert.js
@@ -6,6 +6,7 @@ export class EuroBertModel extends EuroBertPreTrainedModel {}
 
 export class EuroBertForMaskedLM extends EuroBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -18,6 +19,7 @@ export class EuroBertForMaskedLM extends EuroBertPreTrainedModel {
 
 export class EuroBertForSequenceClassification extends EuroBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -30,6 +32,7 @@ export class EuroBertForSequenceClassification extends EuroBertPreTrainedModel {
 
 export class EuroBertForTokenClassification extends EuroBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/fastvit/modeling_fastvit.js
+++ b/packages/transformers/src/models/fastvit/modeling_fastvit.js
@@ -5,6 +5,7 @@ export class FastViTPreTrainedModel extends PreTrainedModel {}
 export class FastViTModel extends FastViTPreTrainedModel {}
 export class FastViTForImageClassification extends FastViTPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/florence2/modeling_florence2.js
+++ b/packages/transformers/src/models/florence2/modeling_florence2.js
@@ -2,6 +2,7 @@ import { PreTrainedModel, encoder_forward, decoder_forward } from '../modeling_u
 import { cat, ones } from '../../utils/tensor.js';
 
 export class Florence2PreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         // Encoder inputs
         'input_ids',
@@ -16,6 +17,7 @@ export class Florence2PreTrainedModel extends PreTrainedModel {
         'decoder_attention_mask',
         'past_key_values',
     ];
+    /** @override */
     main_input_name = 'inputs_embeds';
 }
 
@@ -68,6 +70,7 @@ export class Florence2ForConditionalGeneration extends Florence2PreTrainedModel 
         return { inputs_embeds, attention_mask };
     }
 
+    /** @override */
     async forward({
         input_ids,
         pixel_values,

--- a/packages/transformers/src/models/florence2/processing_florence2.js
+++ b/packages/transformers/src/models/florence2/processing_florence2.js
@@ -118,6 +118,7 @@ export class Florence2Processor extends Processor {
 
     // NOTE: images and text are switched from the python version
     // `images` is required, `text` is optional
+    /** @override */
     async _call(images, text = null, kwargs = {}) {
         if (!images && !text) {
             throw new Error('Either text or images must be provided');

--- a/packages/transformers/src/models/gemma3/processing_gemma3.js
+++ b/packages/transformers/src/models/gemma3/processing_gemma3.js
@@ -5,7 +5,9 @@ import { AutoTokenizer } from '../auto/tokenization_auto.js';
 export class Gemma3Processor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static image_processor_class = AutoImageProcessor;
+    /** @override */
     static uses_processor_config = true;
+    /** @override */
     static uses_chat_template_file = true;
 
     constructor(config, components, chat_template) {
@@ -21,6 +23,7 @@ export class Gemma3Processor extends Processor {
     }
 
     /**
+     * @override
      * @param {string|string[]} text
      * @param {import('../../utils/image.js').RawImage|import('../../utils/image.js').RawImage[]} [images]
      * @param {Object} [options]

--- a/packages/transformers/src/models/gemma3n/feature_extraction_gemma3n.js
+++ b/packages/transformers/src/models/gemma3n/feature_extraction_gemma3n.js
@@ -54,6 +54,7 @@ export class Gemma3nAudioFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @param {Object} options Optional parameters for feature extraction.

--- a/packages/transformers/src/models/gemma3n/modeling_gemma3n.js
+++ b/packages/transformers/src/models/gemma3n/modeling_gemma3n.js
@@ -7,6 +7,7 @@ import {
 import { sessionRun } from '../session.js';
 
 export class Gemma3nPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',
@@ -21,6 +22,7 @@ export class Gemma3nPreTrainedModel extends PreTrainedModel {
     ];
 }
 export class Gemma3nForConditionalGeneration extends Gemma3nPreTrainedModel {
+    /** @override */
     async forward({
         // Produced by the tokenizer/processor:
         input_ids = null,

--- a/packages/transformers/src/models/gemma3n/processing_gemma3n.js
+++ b/packages/transformers/src/models/gemma3n/processing_gemma3n.js
@@ -9,7 +9,9 @@ export class Gemma3nProcessor extends Processor {
     static image_processor_class = AutoImageProcessor;
     static feature_extractor_class = AutoFeatureExtractor;
     static tokenizer_class = AutoTokenizer;
+    /** @override */
     static uses_processor_config = true;
+    /** @override */
     static uses_chat_template_file = true;
 
     constructor(config, components, chat_template) {
@@ -45,6 +47,7 @@ export class Gemma3nProcessor extends Processor {
     }
 
     /**
+     * @override
      *
      * @param {string|string[]} text
      * @param {RawImage|RawImage[]|RawImage[][]} images

--- a/packages/transformers/src/models/gemma4/image_processing_gemma4.js
+++ b/packages/transformers/src/models/gemma4/image_processing_gemma4.js
@@ -113,6 +113,7 @@ export class Gemma4ImageProcessor extends Callable {
     }
 
     /**
+     * @override
      * @param {RawImage|RawImage[]} images
      * @returns {Promise<{ pixel_values: Tensor, image_position_ids: Tensor, num_soft_tokens_per_image: number[] }>}
      */

--- a/packages/transformers/src/models/gemma4/modeling_gemma4.js
+++ b/packages/transformers/src/models/gemma4/modeling_gemma4.js
@@ -2,6 +2,7 @@ import { Gemma3nForConditionalGeneration } from '../gemma3n/modeling_gemma3n.js'
 import { sessionRun } from '../session.js';
 
 export class Gemma4ForConditionalGeneration extends Gemma3nForConditionalGeneration {
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',
@@ -16,6 +17,7 @@ export class Gemma4ForConditionalGeneration extends Gemma3nForConditionalGenerat
         'past_key_values',
     ];
 
+    /** @override */
     _encode_vision(kwargs) {
         return sessionRun(this.sessions['vision_encoder'], {
             pixel_values: kwargs.pixel_values,

--- a/packages/transformers/src/models/gemma4/processing_gemma4.js
+++ b/packages/transformers/src/models/gemma4/processing_gemma4.js
@@ -6,7 +6,9 @@ import { PROCESSOR_NAME, CHAT_TEMPLATE_NAME } from '../../utils/constants.js';
 import { getModelJSON, getModelText } from '../../utils/hub.js';
 
 export class Gemma4Processor extends Processor {
+    /** @override */
     static uses_processor_config = true;
+    /** @override */
     static uses_chat_template_file = true;
 
     constructor(config, components, chat_template) {
@@ -25,6 +27,7 @@ export class Gemma4Processor extends Processor {
         this.eoi_token = eoi_token;
     }
 
+    /** @override */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         const [config, tokenizer, chat_template] = await Promise.all([
             getModelJSON(pretrained_model_name_or_path, PROCESSOR_NAME, true, options),
@@ -65,6 +68,7 @@ export class Gemma4Processor extends Processor {
         return Math.min(t, this.audio_seq_length);
     }
 
+    /** @override */
     async _call(text, images = null, audio = null, options = {}) {
         if (typeof text === 'string') {
             text = [text];

--- a/packages/transformers/src/models/glm46v/image_processing_glm46v.js
+++ b/packages/transformers/src/models/glm46v/image_processing_glm46v.js
@@ -2,7 +2,10 @@ import { Qwen2VLImageProcessor } from '../qwen2_vl/image_processing_qwen2_vl.js'
 import { smart_resize } from '../../image_processors_utils.js';
 
 export class Glm46VImageProcessor extends Qwen2VLImageProcessor {
-    /** @type {Qwen2VLImageProcessor['get_resize_output_image_size']} */
+    /**
+     * @override
+     * @type {Qwen2VLImageProcessor['get_resize_output_image_size']}
+     */
     get_resize_output_image_size(image, size) {
         const factor = this.patch_size * this.merge_size;
         // @ts-expect-error ts(2339)

--- a/packages/transformers/src/models/glm46v/processing_glm46v.js
+++ b/packages/transformers/src/models/glm46v/processing_glm46v.js
@@ -1,5 +1,6 @@
 import { Qwen2VLProcessor } from '../qwen2_vl/processing_qwen2_vl.js';
 
 export class Glm46VProcessor extends Qwen2VLProcessor {
+    /** @override */
     static image_token = '<|image|>';
 }

--- a/packages/transformers/src/models/glm_ocr/modeling_glm_ocr.js
+++ b/packages/transformers/src/models/glm_ocr/modeling_glm_ocr.js
@@ -27,6 +27,7 @@ export class GlmOcrForConditionalGeneration extends Qwen2_5_VLForConditionalGene
     }
 
     /**
+     * @override
      * GlmOcr uses mm_token_type_ids-style grouping (image tokens identified by image_token_id)
      * instead of vision_start_token_id scanning used by Qwen2VL.
      * After a vision segment, position advances by max(h, w) / spatial_merge_size.

--- a/packages/transformers/src/models/granite_speech/feature_extraction_granite_speech.js
+++ b/packages/transformers/src/models/granite_speech/feature_extraction_granite_speech.js
@@ -28,6 +28,7 @@ export class GraniteSpeechFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Extract mel spectrogram features from audio, matching the Python GraniteSpeechFeatureExtractor.
      * @param {Float32Array|Float64Array} audio The audio waveform.
      * @returns {Promise<{input_features: Tensor}>}

--- a/packages/transformers/src/models/granite_speech/modeling_granite_speech.js
+++ b/packages/transformers/src/models/granite_speech/modeling_granite_speech.js
@@ -1,5 +1,6 @@
 import { UltravoxModel } from '../ultravox/modeling_ultravox.js';
 
 export class GraniteSpeechForConditionalGeneration extends UltravoxModel {
+    /** @override */
     forward_params = ['input_ids', 'attention_mask', 'input_features', 'past_key_values'];
 }

--- a/packages/transformers/src/models/granite_speech/processing_granite_speech.js
+++ b/packages/transformers/src/models/granite_speech/processing_granite_speech.js
@@ -6,6 +6,7 @@ import { Tensor } from '../../utils/tensor.js';
 export class GraniteSpeechProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
+    /** @override */
     static uses_processor_config = true;
 
     /**
@@ -24,6 +25,7 @@ export class GraniteSpeechProcessor extends Processor {
     }
 
     /**
+     * @override
      * @param {string} text The text input to process.
      * @param {Float32Array} audio The audio input to process.
      */

--- a/packages/transformers/src/models/grounding_dino/image_processing_grounding_dino.js
+++ b/packages/transformers/src/models/grounding_dino/image_processing_grounding_dino.js
@@ -9,6 +9,7 @@ import { ones } from '../../utils/tensor.js';
 
 export class GroundingDinoImageProcessor extends ImageProcessor {
     /**
+     * @override
      * Calls the feature extraction process on an array of images, preprocesses
      * each image, and concatenates the resulting features into a single Tensor.
      * @param {import('../../utils/image.js').RawImage[]} images The image(s) to extract features from.

--- a/packages/transformers/src/models/grounding_dino/processing_grounding_dino.js
+++ b/packages/transformers/src/models/grounding_dino/processing_grounding_dino.js
@@ -31,6 +31,7 @@ export class GroundingDinoProcessor extends Processor {
      * @typedef {import('../../utils/image.js').RawImage} RawImage
      */
     /**
+     * @override
      *
      * @param {RawImage|RawImage[]|RawImage[][]} images
      * @param {string|string[]} text

--- a/packages/transformers/src/models/herbert/tokenization_herbert.js
+++ b/packages/transformers/src/models/herbert/tokenization_herbert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class HerbertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/hiera/modeling_hiera.js
+++ b/packages/transformers/src/models/hiera/modeling_hiera.js
@@ -5,6 +5,7 @@ export class HieraPreTrainedModel extends PreTrainedModel {}
 export class HieraModel extends HieraPreTrainedModel {}
 export class HieraForImageClassification extends HieraPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/hubert/modeling_hubert.js
+++ b/packages/transformers/src/models/hubert/modeling_hubert.js
@@ -38,6 +38,7 @@ export class HubertModel extends Wav2Vec2PreTrainedModel {}
  */
 export class HubertForCTC extends Wav2Vec2PreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -52,6 +53,7 @@ export class HubertForCTC extends Wav2Vec2PreTrainedModel {
  */
 export class HubertForSequenceClassification extends Wav2Vec2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/idefics3/image_processing_idefics3.js
+++ b/packages/transformers/src/models/idefics3/image_processing_idefics3.js
@@ -36,7 +36,10 @@ export class Idefics3ImageProcessor extends ImageProcessor {
         return { height, width };
     }
 
-    /** @param {RawImage|RawImage[]|RawImage[][]} images */
+    /**
+     * @override
+     * @param {RawImage|RawImage[]|RawImage[][]} images
+     */
     async _call(images, { do_image_splitting = null, return_row_col_info = false } = {}) {
         /** @type {RawImage[][]} */
         let batched_2d_images;

--- a/packages/transformers/src/models/idefics3/modeling_idefics3.js
+++ b/packages/transformers/src/models/idefics3/modeling_idefics3.js
@@ -4,6 +4,7 @@ import { LlavaForConditionalGeneration } from '../llava/modeling_llava.js';
  * The Idefics3 model which consists of a vision backbone and a language model.
  */
 export class Idefics3ForConditionalGeneration extends LlavaForConditionalGeneration {
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',

--- a/packages/transformers/src/models/idefics3/processing_idefics3.js
+++ b/packages/transformers/src/models/idefics3/processing_idefics3.js
@@ -70,6 +70,7 @@ function get_image_prompt_string(
 export class Idefics3Processor extends Processor {
     static image_processor_class = AutoImageProcessor;
     static tokenizer_class = AutoTokenizer;
+    /** @override */
     static uses_processor_config = true;
 
     fake_image_token = '<fake_token_around_image>';
@@ -77,6 +78,7 @@ export class Idefics3Processor extends Processor {
     global_img_token = '<global-img>';
 
     /**
+     * @override
      *
      * @param {string|string[]} text
      * @param {RawImage|RawImage[]|RawImage[][]} images

--- a/packages/transformers/src/models/ijepa/modeling_ijepa.js
+++ b/packages/transformers/src/models/ijepa/modeling_ijepa.js
@@ -5,6 +5,7 @@ export class IJepaPreTrainedModel extends PreTrainedModel {}
 export class IJepaModel extends IJepaPreTrainedModel {}
 export class IJepaForImageClassification extends IJepaPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/janus/image_processing_janus.js
+++ b/packages/transformers/src/models/janus/image_processing_janus.js
@@ -14,6 +14,7 @@ export class VLMImageProcessor extends ImageProcessor {
         this.constant_values = this.config.background_color.map((x) => x * this.rescale_factor);
     }
 
+    /** @override */
     pad_image(pixelData, imgDims, padSize, options) {
         return super.pad_image(pixelData, imgDims, padSize, {
             constant_values: this.constant_values,

--- a/packages/transformers/src/models/janus/processing_janus.js
+++ b/packages/transformers/src/models/janus/processing_janus.js
@@ -8,6 +8,7 @@ import { RawImage } from '../../utils/image.js';
 export class VLChatProcessor extends Processor {
     static image_processor_class = AutoImageProcessor;
     static tokenizer_class = AutoTokenizer;
+    /** @override */
     static uses_processor_config = true;
 
     constructor(config, components, chat_template) {
@@ -34,6 +35,7 @@ export class VLChatProcessor extends Processor {
      */
 
     /**
+     * @override
      * @param {MultimodalConversation} conversation The chat messages to process.
      * @param {Object} options Additional options for processing.
      * @param {RawImage|RawImage[]} [options.images] The images to process, if not set in the conversation.

--- a/packages/transformers/src/models/jina_clip/modeling_jina_clip.js
+++ b/packages/transformers/src/models/jina_clip/modeling_jina_clip.js
@@ -4,6 +4,7 @@ import { ones, full } from '../../utils/tensor.js';
 export class JinaCLIPPreTrainedModel extends PreTrainedModel {}
 
 export class JinaCLIPModel extends JinaCLIPPreTrainedModel {
+    /** @override */
     async forward(model_inputs) {
         const missing_text_inputs = !model_inputs.input_ids;
         const missing_image_inputs = !model_inputs.pixel_values;
@@ -43,7 +44,10 @@ export class JinaCLIPModel extends JinaCLIPPreTrainedModel {
 }
 
 export class JinaCLIPTextModel extends JinaCLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -54,7 +58,10 @@ export class JinaCLIPTextModel extends JinaCLIPPreTrainedModel {
 }
 
 export class JinaCLIPVisionModel extends JinaCLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/jina_clip/processing_jina_clip.js
+++ b/packages/transformers/src/models/jina_clip/processing_jina_clip.js
@@ -6,6 +6,7 @@ export class JinaCLIPProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static image_processor_class = AutoImageProcessor;
 
+    /** @override */
     async _call(text = null, images = null, kwargs = {}) {
         if (!text && !images) {
             throw new Error('Either text or images must be provided');

--- a/packages/transformers/src/models/lfm2_vl/modeling_lfm2_vl.js
+++ b/packages/transformers/src/models/lfm2_vl/modeling_lfm2_vl.js
@@ -1,6 +1,7 @@
 import { LlavaForConditionalGeneration } from '../llava/modeling_llava.js';
 
 export class Lfm2VlForConditionalGeneration extends LlavaForConditionalGeneration {
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',

--- a/packages/transformers/src/models/lfm2_vl/processing_lfm2_vl.js
+++ b/packages/transformers/src/models/lfm2_vl/processing_lfm2_vl.js
@@ -11,6 +11,7 @@ export class Lfm2VlProcessor extends Processor {
     static image_processor_class = AutoImageProcessor;
 
     /**
+     * @override
      * @param {RawImage|RawImage[]} images
      * @param {string|string[]|null} [text]
      * @param {Record<string, any>} [kwargs]

--- a/packages/transformers/src/models/llama/tokenization_llama.js
+++ b/packages/transformers/src/models/llama/tokenization_llama.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class LlamaTokenizer extends PreTrainedTokenizer {
+    /** @override */
     padding_side = 'left';
 }

--- a/packages/transformers/src/models/llava/modeling_llava.js
+++ b/packages/transformers/src/models/llava/modeling_llava.js
@@ -1,6 +1,7 @@
 import { PreTrainedModel, default_merge_input_ids_with_image_features } from '../modeling_utils.js';
 
 export class LlavaPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = ['input_ids', 'attention_mask', 'pixel_values', 'position_ids', 'past_key_values'];
 }
 

--- a/packages/transformers/src/models/llava/processing_llava.js
+++ b/packages/transformers/src/models/llava/processing_llava.js
@@ -5,6 +5,7 @@ import { AutoTokenizer } from '../auto/tokenization_auto.js';
 export class LlavaProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static image_processor_class = AutoImageProcessor;
+    /** @override */
     static uses_processor_config = true;
 
     /**
@@ -12,6 +13,7 @@ export class LlavaProcessor extends Processor {
      */
 
     // `images` is required, `text` is optional
+    /** @override */
     async _call(/** @type {RawImage|RawImage[]} */ images, text = null, kwargs = {}) {
         const image_inputs = await this.image_processor(images, kwargs);
 

--- a/packages/transformers/src/models/marian/tokenization_marian.js
+++ b/packages/transformers/src/models/marian/tokenization_marian.js
@@ -25,6 +25,7 @@ export class MarianTokenizer extends PreTrainedTokenizer {
     }
 
     /**
+     * @override
      * Encodes a single text. Overriding this method is necessary since the language codes
      * must be removed before encoding with sentencepiece model.
      * @see https://github.com/huggingface/transformers/blob/12d51db243a00726a548a43cc333390ebae731e3/src/transformers/models/marian/tokenization_marian.py#L204-L213

--- a/packages/transformers/src/models/mbart/modeling_mbart.js
+++ b/packages/transformers/src/models/mbart/modeling_mbart.js
@@ -18,6 +18,7 @@ export class MBartForConditionalGeneration extends MBartPreTrainedModel {}
  */
 export class MBartForSequenceClassification extends MBartPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/mgp_str/modeling_mgp_str.js
+++ b/packages/transformers/src/models/mgp_str/modeling_mgp_str.js
@@ -22,6 +22,7 @@ export class MgpstrPreTrainedModel extends PreTrainedModel {}
  */
 export class MgpstrForSceneTextRecognition extends MgpstrPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mgp_str/processing_mgp_str.js
+++ b/packages/transformers/src/models/mgp_str/processing_mgp_str.js
@@ -139,7 +139,10 @@ export class MgpstrProcessor extends Processor {
             wp_preds,
         };
     }
-    /** @type {typeof Processor.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof Processor.from_pretrained}
+     */
     static async from_pretrained(...args) {
         const base = await super.from_pretrained(...args);
 
@@ -157,6 +160,7 @@ export class MgpstrProcessor extends Processor {
         return base;
     }
 
+    /** @override */
     async _call(images, text = null) {
         const result = await this.image_processor(images);
 

--- a/packages/transformers/src/models/mimi/modeling_mimi.js
+++ b/packages/transformers/src/models/mimi/modeling_mimi.js
@@ -26,7 +26,9 @@ export class MimiDecoderOutput extends ModelOutput {
 }
 
 export class MimiPreTrainedModel extends PreTrainedModel {
+    /** @override */
     main_input_name = 'input_values';
+    /** @override */
     forward_params = ['input_values'];
 }
 
@@ -55,7 +57,10 @@ export class MimiModel extends MimiPreTrainedModel {
 }
 
 export class MimiEncoderModel extends MimiPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -65,7 +70,10 @@ export class MimiEncoderModel extends MimiPreTrainedModel {
     }
 }
 export class MimiDecoderModel extends MimiPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/mobilebert/modeling_mobilebert.js
+++ b/packages/transformers/src/models/mobilebert/modeling_mobilebert.js
@@ -9,6 +9,7 @@ export class MobileBertModel extends MobileBertPreTrainedModel {}
  */
 export class MobileBertForMaskedLM extends MobileBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -24,6 +25,7 @@ export class MobileBertForMaskedLM extends MobileBertPreTrainedModel {
  */
 export class MobileBertForSequenceClassification extends MobileBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -39,6 +41,7 @@ export class MobileBertForSequenceClassification extends MobileBertPreTrainedMod
  */
 export class MobileBertForQuestionAnswering extends MobileBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/mobilebert/tokenization_mobilebert.js
+++ b/packages/transformers/src/models/mobilebert/tokenization_mobilebert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class MobileBertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/mobilenet_v1/modeling_mobilenet_v1.js
+++ b/packages/transformers/src/models/mobilenet_v1/modeling_mobilenet_v1.js
@@ -14,6 +14,7 @@ export class MobileNetV1Model extends MobileNetV1PreTrainedModel {}
  */
 export class MobileNetV1ForImageClassification extends MobileNetV1PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mobilenet_v2/modeling_mobilenet_v2.js
+++ b/packages/transformers/src/models/mobilenet_v2/modeling_mobilenet_v2.js
@@ -14,6 +14,7 @@ export class MobileNetV2Model extends MobileNetV2PreTrainedModel {}
  */
 export class MobileNetV2ForImageClassification extends MobileNetV2PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mobilenet_v3/modeling_mobilenet_v3.js
+++ b/packages/transformers/src/models/mobilenet_v3/modeling_mobilenet_v3.js
@@ -14,6 +14,7 @@ export class MobileNetV3Model extends MobileNetV3PreTrainedModel {}
  */
 export class MobileNetV3ForImageClassification extends MobileNetV3PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mobilenet_v4/modeling_mobilenet_v4.js
+++ b/packages/transformers/src/models/mobilenet_v4/modeling_mobilenet_v4.js
@@ -14,6 +14,7 @@ export class MobileNetV4Model extends MobileNetV4PreTrainedModel {}
  */
 export class MobileNetV4ForImageClassification extends MobileNetV4PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mobilevit/modeling_mobilevit.js
+++ b/packages/transformers/src/models/mobilevit/modeling_mobilevit.js
@@ -5,6 +5,7 @@ export class MobileViTPreTrainedModel extends PreTrainedModel {}
 export class MobileViTModel extends MobileViTPreTrainedModel {}
 export class MobileViTForImageClassification extends MobileViTPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/mobilevitv2/modeling_mobilevitv2.js
+++ b/packages/transformers/src/models/mobilevitv2/modeling_mobilevitv2.js
@@ -5,6 +5,7 @@ export class MobileViTV2PreTrainedModel extends PreTrainedModel {}
 export class MobileViTV2Model extends MobileViTV2PreTrainedModel {}
 export class MobileViTV2ForImageClassification extends MobileViTV2PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -360,6 +360,7 @@ export class PreTrainedModel extends Callable {
     }
 
     /**
+     * @override
      * Runs the model with the provided inputs
      * @param {Object} model_inputs Object containing input tensors
      * @returns {Promise<Object>} Object containing output tensors

--- a/packages/transformers/src/models/modernbert/modeling_modernbert.js
+++ b/packages/transformers/src/models/modernbert/modeling_modernbert.js
@@ -6,6 +6,7 @@ export class ModernBertModel extends ModernBertPreTrainedModel {}
 
 export class ModernBertForMaskedLM extends ModernBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -18,6 +19,7 @@ export class ModernBertForMaskedLM extends ModernBertPreTrainedModel {
 
 export class ModernBertForSequenceClassification extends ModernBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -30,6 +32,7 @@ export class ModernBertForSequenceClassification extends ModernBertPreTrainedMod
 
 export class ModernBertForTokenClassification extends ModernBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/moonshine/feature_extraction_moonshine.js
+++ b/packages/transformers/src/models/moonshine/feature_extraction_moonshine.js
@@ -3,6 +3,7 @@ import { Tensor } from '../../utils/tensor.js';
 
 export class MoonshineFeatureExtractor extends FeatureExtractor {
     /**
+     * @override
      * Asynchronously extracts input values from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor; }>} The extracted input values.

--- a/packages/transformers/src/models/moonshine/modeling_moonshine.js
+++ b/packages/transformers/src/models/moonshine/modeling_moonshine.js
@@ -2,7 +2,9 @@ import { PreTrainedModel } from '../modeling_utils.js';
 
 export class MoonshinePreTrainedModel extends PreTrainedModel {
     requires_attention_mask = false;
+    /** @override */
     main_input_name = 'input_values';
+    /** @override */
     forward_params = ['input_values', 'decoder_input_ids', 'past_key_values'];
 }
 

--- a/packages/transformers/src/models/moonshine/processing_moonshine.js
+++ b/packages/transformers/src/models/moonshine/processing_moonshine.js
@@ -10,6 +10,7 @@ export class MoonshineProcessor extends Processor {
     static feature_extractor_class = AutoFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/mpnet/modeling_mpnet.js
+++ b/packages/transformers/src/models/mpnet/modeling_mpnet.js
@@ -18,6 +18,7 @@ export class MPNetModel extends MPNetPreTrainedModel {}
  */
 export class MPNetForMaskedLM extends MPNetPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class MPNetForMaskedLM extends MPNetPreTrainedModel {
  */
 export class MPNetForSequenceClassification extends MPNetPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -48,6 +50,7 @@ export class MPNetForSequenceClassification extends MPNetPreTrainedModel {
  */
 export class MPNetForTokenClassification extends MPNetPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -63,6 +66,7 @@ export class MPNetForTokenClassification extends MPNetPreTrainedModel {
  */
 export class MPNetForQuestionAnswering extends MPNetPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
+++ b/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
@@ -6,6 +6,7 @@ import { Tensor, cat, full, full_like } from '../../utils/tensor.js';
 
 export class MultiModalityPreTrainedModel extends PreTrainedModel {}
 export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
+    /** @override */
     forward_params = [
         // prepare_inputs_embeds
         'input_ids',
@@ -29,6 +30,7 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
         this._generation_mode = 'text';
     }
 
+    /** @override */
     async forward(model_inputs) {
         const mode = this._generation_mode ?? 'text';
 
@@ -70,6 +72,7 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
         };
     }
 
+    /** @override */
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
         const has_past_key_values = !!model_inputs.past_key_values;
 
@@ -116,6 +119,7 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
     }
 
     /**
+     * @override
      * @param {import('../../generation/parameters.js').GenerationFunctionParameters} options
      */
     async generate(options) {

--- a/packages/transformers/src/models/musicgen/modeling_musicgen.js
+++ b/packages/transformers/src/models/musicgen/modeling_musicgen.js
@@ -51,6 +51,7 @@ export class MusicgenForCausalLM extends MusicgenPreTrainedModel {}
  */
 export class MusicgenForConditionalGeneration extends PreTrainedModel {
     // NOTE: not MusicgenPreTrainedModel
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',
@@ -94,6 +95,7 @@ export class MusicgenForConditionalGeneration extends PreTrainedModel {
         return new Tensor(outputs.type, outputs.data.slice(0, newDataSize), [batch_size, num_codebooks, inferred]);
     }
 
+    /** @override */
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
         // @ts-expect-error TS2339
         const pad_token_id = BigInt(this.config.decoder.pad_token_id);
@@ -119,6 +121,7 @@ export class MusicgenForConditionalGeneration extends PreTrainedModel {
     }
 
     /**
+     * @override
      * Generates sequences of token ids for models with a language modeling head.
      * @param {import('../../generation/parameters.js').GenerationFunctionParameters} options
      * @returns {Promise<ModelOutput|Tensor>} The output of the model, which can contain the generated token ids, attentions, and scores.

--- a/packages/transformers/src/models/neobert/modeling_neobert.js
+++ b/packages/transformers/src/models/neobert/modeling_neobert.js
@@ -11,6 +11,7 @@ export class NeoBertModel extends NeoBertPreTrainedModel {}
 
 export class NeoBertForMaskedLM extends NeoBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -23,6 +24,7 @@ export class NeoBertForMaskedLM extends NeoBertPreTrainedModel {
 
 export class NeoBertForSequenceClassification extends NeoBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -35,6 +37,7 @@ export class NeoBertForSequenceClassification extends NeoBertPreTrainedModel {
 
 export class NeoBertForTokenClassification extends NeoBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -47,6 +50,7 @@ export class NeoBertForTokenClassification extends NeoBertPreTrainedModel {
 
 export class NeoBertForQuestionAnswering extends NeoBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/openai_privacy_filter/modeling_openai_privacy_filter.js
+++ b/packages/transformers/src/models/openai_privacy_filter/modeling_openai_privacy_filter.js
@@ -6,6 +6,7 @@ export class OpenAIPrivacyFilterModel extends OpenAIPrivacyFilterPreTrainedModel
 
 export class OpenAIPrivacyFilterForTokenClassification extends OpenAIPrivacyFilterPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/paligemma/processing_paligemma.js
+++ b/packages/transformers/src/models/paligemma/processing_paligemma.js
@@ -12,6 +12,7 @@ function build_string_from_input(prompt, bos_token, image_seq_len, image_token, 
 export class PaliGemmaProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static image_processor_class = AutoImageProcessor;
+    /** @override */
     static uses_processor_config = false;
 
     /**
@@ -19,6 +20,7 @@ export class PaliGemmaProcessor extends Processor {
      */
 
     // `images` is required, `text` is optional
+    /** @override */
     async _call(/** @type {RawImage|RawImage[]} */ images, text = null, kwargs = {}) {
         if (!text) {
             logger.warn(

--- a/packages/transformers/src/models/parakeet/feature_extraction_parakeet.js
+++ b/packages/transformers/src/models/parakeet/feature_extraction_parakeet.js
@@ -65,6 +65,7 @@ export class ParakeetFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_features: Tensor; attention_mask: Tensor; }>} A Promise resolving to an object containing the extracted input features as a Tensor.

--- a/packages/transformers/src/models/parakeet/modeling_parakeet.js
+++ b/packages/transformers/src/models/parakeet/modeling_parakeet.js
@@ -5,6 +5,7 @@ import { Tensor } from '../../utils/tensor.js';
 export class ParakeetPreTrainedModel extends PreTrainedModel {}
 export class ParakeetForCTC extends ParakeetPreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]

--- a/packages/transformers/src/models/phi3_v/image_processing_phi3_v.js
+++ b/packages/transformers/src/models/phi3_v/image_processing_phi3_v.js
@@ -28,7 +28,10 @@ export class Phi3VImageProcessor extends ImageProcessor {
         );
     }
 
-    /** @type {ImageProcessor['get_resize_output_image_size']} */
+    /**
+     * @override
+     * @type {ImageProcessor['get_resize_output_image_size']}
+     */
     get_resize_output_image_size(image, size) {
         const hd_num = this._num_crops;
         const [width, height] = image.size;
@@ -49,7 +52,10 @@ export class Phi3VImageProcessor extends ImageProcessor {
         return [new_w, new_h];
     }
 
-    /** @type {ImageProcessor['pad_image']} */
+    /**
+     * @override
+     * @type {ImageProcessor['pad_image']}
+     */
     pad_image(pixelData, imgDims, padSize, options = {}) {
         // Phi3V uses a custom padding strategy:
         // - Pad to a multiple of 336
@@ -72,6 +78,7 @@ export class Phi3VImageProcessor extends ImageProcessor {
         );
     }
 
+    /** @override */
     async _call(images, { num_crops = null } = {}) {
         // @ts-expect-error
         this._num_crops = num_crops ??= this.config.num_crops;

--- a/packages/transformers/src/models/phi3_v/modeling_phi3_v.js
+++ b/packages/transformers/src/models/phi3_v/modeling_phi3_v.js
@@ -3,6 +3,7 @@ import { sessionRun } from '../session.js';
 import { Tensor } from '../../utils/tensor.js';
 
 export class Phi3VPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         'input_ids',
         'inputs_embeds',
@@ -14,6 +15,7 @@ export class Phi3VPreTrainedModel extends PreTrainedModel {
     ];
 }
 export class Phi3VForCausalLM extends Phi3VPreTrainedModel {
+    /** @override */
     async forward({
         // Produced by the tokenizer/processor:
         input_ids = null,

--- a/packages/transformers/src/models/phi3_v/processing_phi3_v.js
+++ b/packages/transformers/src/models/phi3_v/processing_phi3_v.js
@@ -11,6 +11,7 @@ export class Phi3VProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
 
     /**
+     * @override
      *
      * @param {string|string[]} text
      * @param {RawImage|RawImage[]} images

--- a/packages/transformers/src/models/pixtral/image_processing_pixtral.js
+++ b/packages/transformers/src/models/pixtral/image_processing_pixtral.js
@@ -1,7 +1,10 @@
 import { ImageProcessor } from '../../image_processors_utils.js';
 
 export class PixtralImageProcessor extends ImageProcessor {
-    /** @type {ImageProcessor['get_resize_output_image_size']} */
+    /**
+     * @override
+     * @type {ImageProcessor['get_resize_output_image_size']}
+     */
     get_resize_output_image_size(image, size) {
         const { longest_edge } = size;
         if (longest_edge === undefined) {

--- a/packages/transformers/src/models/pixtral/processing_pixtral.js
+++ b/packages/transformers/src/models/pixtral/processing_pixtral.js
@@ -5,6 +5,7 @@ import { AutoTokenizer } from '../auto/tokenization_auto.js';
 export class PixtralProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static image_processor_class = AutoImageProcessor;
+    /** @override */
     static uses_processor_config = true;
 
     /**
@@ -12,6 +13,7 @@ export class PixtralProcessor extends Processor {
      */
 
     // `images` is required, `text` is optional
+    /** @override */
     async _call(/** @type {RawImage|RawImage[]} */ images, text = null, kwargs = {}) {
         const image_inputs = await this.image_processor(images, kwargs);
 

--- a/packages/transformers/src/models/pvt/modeling_pvt.js
+++ b/packages/transformers/src/models/pvt/modeling_pvt.js
@@ -5,6 +5,7 @@ export class PvtPreTrainedModel extends PreTrainedModel {}
 export class PvtModel extends PvtPreTrainedModel {}
 export class PvtForImageClassification extends PvtPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/pyannote/feature_extraction_pyannote.js
+++ b/packages/transformers/src/models/pyannote/feature_extraction_pyannote.js
@@ -4,6 +4,7 @@ import { max, softmax } from '../../utils/maths.js';
 
 export class PyAnnoteFeatureExtractor extends FeatureExtractor {
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor; }>} The extracted input features.

--- a/packages/transformers/src/models/pyannote/modeling_pyannote.js
+++ b/packages/transformers/src/models/pyannote/modeling_pyannote.js
@@ -67,6 +67,7 @@ export class PyAnnoteModel extends PyAnnotePreTrainedModel {}
  */
 export class PyAnnoteForAudioFrameClassification extends PyAnnotePreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<TokenClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/pyannote/processing_pyannote.js
+++ b/packages/transformers/src/models/pyannote/processing_pyannote.js
@@ -5,6 +5,7 @@ export class PyAnnoteProcessor extends Processor {
     static feature_extractor_class = PyAnnoteFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/qwen2_5_vl/modeling_qwen2_5_vl.js
+++ b/packages/transformers/src/models/qwen2_5_vl/modeling_qwen2_5_vl.js
@@ -1,9 +1,11 @@
 import { Qwen2VLForConditionalGeneration, Qwen2VLForCausalLM } from '../qwen2_vl/modeling_qwen2_vl.js';
 
 export class Qwen2_5_VLForConditionalGeneration extends Qwen2VLForConditionalGeneration {
+    /** @override */
     image_grid_thw_name = 'image_grid_thw';
 }
 
 export class Qwen2_5_VLForCausalLM extends Qwen2VLForCausalLM {
+    /** @override */
     image_grid_thw_name = 'image_grid_thw';
 }

--- a/packages/transformers/src/models/qwen2_vl/image_processing_qwen2_vl.js
+++ b/packages/transformers/src/models/qwen2_vl/image_processing_qwen2_vl.js
@@ -10,12 +10,16 @@ export class Qwen2VLImageProcessor extends ImageProcessor {
         this.merge_size = config.merge_size;
     }
 
-    /** @type {ImageProcessor['get_resize_output_image_size']} */
+    /**
+     * @override
+     * @type {ImageProcessor['get_resize_output_image_size']}
+     */
     get_resize_output_image_size(image, size) {
         const factor = this.patch_size * this.merge_size;
         return smart_resize(image.height, image.width, factor, this.min_pixels, this.max_pixels);
     }
 
+    /** @override */
     async _call(images, ...args) {
         const { pixel_values, original_sizes, reshaped_input_sizes } = await super._call(images, ...args);
 

--- a/packages/transformers/src/models/qwen2_vl/modeling_qwen2_vl.js
+++ b/packages/transformers/src/models/qwen2_vl/modeling_qwen2_vl.js
@@ -9,6 +9,7 @@ import { stack, Tensor, ones_like, zeros } from '../../utils/tensor.js';
 import { max } from '../../utils/maths.js';
 
 export class Qwen2VLPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         // Text inputs
         'input_ids',
@@ -271,6 +272,7 @@ export class Qwen2VLForConditionalGeneration extends Qwen2VLPreTrainedModel {
         }
     }
 
+    /** @override */
     async encode_image({ pixel_values, image_grid_thw }) {
         const features = (
             await sessionRun(this.sessions['vision_encoder'], {
@@ -289,6 +291,7 @@ export class Qwen2VLForConditionalGeneration extends Qwen2VLPreTrainedModel {
         });
     }
 
+    /** @override */
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
         setNumLogitsToKeep(this, model_inputs, 1n);
 

--- a/packages/transformers/src/models/qwen2_vl/processing_qwen2_vl.js
+++ b/packages/transformers/src/models/qwen2_vl/processing_qwen2_vl.js
@@ -9,6 +9,7 @@ export class Qwen2VLProcessor extends Processor {
     static image_token = '<|image_pad|>';
 
     /**
+     * @override
      *
      * @param {string|string[]} text
      * @param {RawImage|RawImage[]} images

--- a/packages/transformers/src/models/resnet/modeling_resnet.js
+++ b/packages/transformers/src/models/resnet/modeling_resnet.js
@@ -16,6 +16,7 @@ export class ResNetModel extends ResNetPreTrainedModel {}
  */
 export class ResNetForImageClassification extends ResNetPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/rf_detr/modeling_rf_detr.js
+++ b/packages/transformers/src/models/rf_detr/modeling_rf_detr.js
@@ -5,6 +5,7 @@ export class RFDetrPreTrainedModel extends PreTrainedModel {}
 export class RFDetrModel extends RFDetrPreTrainedModel {}
 export class RFDetrForObjectDetection extends RFDetrPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/roberta/modeling_roberta.js
+++ b/packages/transformers/src/models/roberta/modeling_roberta.js
@@ -14,6 +14,7 @@ export class RobertaModel extends RobertaPreTrainedModel {}
  */
 export class RobertaForMaskedLM extends RobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -29,6 +30,7 @@ export class RobertaForMaskedLM extends RobertaPreTrainedModel {
  */
 export class RobertaForSequenceClassification extends RobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -44,6 +46,7 @@ export class RobertaForSequenceClassification extends RobertaPreTrainedModel {
  */
 export class RobertaForTokenClassification extends RobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -59,6 +62,7 @@ export class RobertaForTokenClassification extends RobertaPreTrainedModel {
  */
 export class RobertaForQuestionAnswering extends RobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/roformer/modeling_roformer.js
+++ b/packages/transformers/src/models/roformer/modeling_roformer.js
@@ -18,6 +18,7 @@ export class RoFormerModel extends RoFormerPreTrainedModel {}
  */
 export class RoFormerForMaskedLM extends RoFormerPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class RoFormerForMaskedLM extends RoFormerPreTrainedModel {
  */
 export class RoFormerForSequenceClassification extends RoFormerPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -49,6 +51,7 @@ export class RoFormerForSequenceClassification extends RoFormerPreTrainedModel {
  */
 export class RoFormerForTokenClassification extends RoFormerPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -65,6 +68,7 @@ export class RoFormerForTokenClassification extends RoFormerPreTrainedModel {
  */
 export class RoFormerForQuestionAnswering extends RoFormerPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/roformer/tokenization_roformer.js
+++ b/packages/transformers/src/models/roformer/tokenization_roformer.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class RoFormerTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/rt_detr/modeling_rt_detr.js
+++ b/packages/transformers/src/models/rt_detr/modeling_rt_detr.js
@@ -6,6 +6,7 @@ export class RTDetrPreTrainedModel extends PreTrainedModel {}
 export class RTDetrModel extends RTDetrPreTrainedModel {}
 export class RTDetrForObjectDetection extends RTDetrPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/rt_detr_v2/modeling_rt_detr_v2.js
+++ b/packages/transformers/src/models/rt_detr_v2/modeling_rt_detr_v2.js
@@ -5,6 +5,7 @@ export class RTDetrV2PreTrainedModel extends PreTrainedModel {}
 export class RTDetrV2Model extends RTDetrV2PreTrainedModel {}
 export class RTDetrV2ForObjectDetection extends RTDetrV2PreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/sam/image_processing_sam.js
+++ b/packages/transformers/src/models/sam/image_processing_sam.js
@@ -86,6 +86,7 @@ export class SamImageProcessor extends ImageProcessor {
         return new Tensor('int64', input_labels.flat(Infinity).map(BigInt), shape);
     }
     /**
+     * @override
      * @param {any[]} images The URL(s) of the image(s) to extract features from.
      * @param {Object} [options] Additional options for the processor.
      * @param {any} [options.input_points=null] A 3D or 4D array, representing the input points provided by the user.

--- a/packages/transformers/src/models/sam/modeling_sam.js
+++ b/packages/transformers/src/models/sam/modeling_sam.js
@@ -97,6 +97,7 @@ export class SamModel extends SamPreTrainedModel {
      */
 
     /**
+     * @override
      * @param {SamModelInputs} model_inputs Object containing the model inputs.
      * @returns {Promise<Object>} The output of the model.
      */
@@ -135,6 +136,7 @@ export class SamModel extends SamPreTrainedModel {
     }
 
     /**
+     * @override
      * Runs the model with the provided inputs
      * @param {Object} model_inputs Model inputs
      * @returns {Promise<SamImageSegmentationOutput>} Object containing segmentation outputs

--- a/packages/transformers/src/models/sam/processing_sam.js
+++ b/packages/transformers/src/models/sam/processing_sam.js
@@ -4,6 +4,7 @@ import { AutoImageProcessor } from '../auto/image_processing_auto.js';
 export class SamProcessor extends Processor {
     static image_processor_class = AutoImageProcessor;
 
+    /** @override */
     async _call(...args) {
         return await this.image_processor(...args);
     }

--- a/packages/transformers/src/models/sam2/modeling_sam2.js
+++ b/packages/transformers/src/models/sam2/modeling_sam2.js
@@ -39,6 +39,7 @@ export class Sam2Model extends Sam2PreTrainedModel {
         return await encoder_forward(this, { pixel_values });
     }
 
+    /** @override */
     async forward(model_inputs) {
         // @ts-expect-error ts(2339)
         const { num_feature_levels } = this.config.vision_config;
@@ -83,6 +84,7 @@ export class Sam2Model extends Sam2PreTrainedModel {
     }
 
     /**
+     * @override
      * Runs the model with the provided inputs
      * @param {Object} model_inputs Model inputs
      * @returns {Promise<Sam2ImageSegmentationOutput>} Object containing segmentation outputs

--- a/packages/transformers/src/models/seamless_m4t/feature_extraction_seamless_m4t.js
+++ b/packages/transformers/src/models/seamless_m4t/feature_extraction_seamless_m4t.js
@@ -60,6 +60,7 @@ export class SeamlessM4TFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @param {Object} options Optional parameters for feature extraction.

--- a/packages/transformers/src/models/siglip/modeling_siglip.js
+++ b/packages/transformers/src/models/siglip/modeling_siglip.js
@@ -75,7 +75,10 @@ export class SiglipModel extends SiglipPreTrainedModel {}
  * ```
  */
 export class SiglipTextModel extends SiglipPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -112,7 +115,10 @@ export class SiglipTextModel extends SiglipPreTrainedModel {
  * ```
  */
 export class SiglipVisionModel extends CLIPPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/snac/modeling_snac.js
+++ b/packages/transformers/src/models/snac/modeling_snac.js
@@ -3,7 +3,9 @@ import { sessionRun } from '../session.js';
 import { Tensor } from '../../utils/tensor.js';
 
 export class SnacPreTrainedModel extends PreTrainedModel {
+    /** @override */
     main_input_name = 'input_values';
+    /** @override */
     forward_params = ['input_values'];
 }
 
@@ -32,7 +34,10 @@ export class SnacModel extends SnacPreTrainedModel {
 }
 
 export class SnacEncoderModel extends SnacPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,
@@ -42,7 +47,10 @@ export class SnacEncoderModel extends SnacPreTrainedModel {
     }
 }
 export class SnacDecoderModel extends SnacPreTrainedModel {
-    /** @type {typeof PreTrainedModel.from_pretrained} */
+    /**
+     * @override
+     * @type {typeof PreTrainedModel.from_pretrained}
+     */
     static async from_pretrained(pretrained_model_name_or_path, options = {}) {
         return super.from_pretrained(pretrained_model_name_or_path, {
             ...options,

--- a/packages/transformers/src/models/speecht5/modeling_speecht5.js
+++ b/packages/transformers/src/models/speecht5/modeling_speecht5.js
@@ -160,5 +160,6 @@ export class SpeechT5ForTextToSpeech extends SpeechT5PreTrainedModel {
  * See [SpeechT5ForSpeechToText](./models#module_models.SpeechT5ForSpeechToText) for example usage.
  */
 export class SpeechT5HifiGan extends PreTrainedModel {
+    /** @override */
     main_input_name = 'spectrogram';
 }

--- a/packages/transformers/src/models/speecht5/processing_speecht5.js
+++ b/packages/transformers/src/models/speecht5/processing_speecht5.js
@@ -7,6 +7,7 @@ export class SpeechT5Processor extends Processor {
     static feature_extractor_class = AutoFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given input.
      * @param {any} input The input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/squeezebert/modeling_squeezebert.js
+++ b/packages/transformers/src/models/squeezebert/modeling_squeezebert.js
@@ -5,6 +5,7 @@ export class SqueezeBertPreTrainedModel extends PreTrainedModel {}
 export class SqueezeBertModel extends SqueezeBertPreTrainedModel {}
 export class SqueezeBertForMaskedLM extends SqueezeBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -16,6 +17,7 @@ export class SqueezeBertForMaskedLM extends SqueezeBertPreTrainedModel {
 }
 export class SqueezeBertForSequenceClassification extends SqueezeBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -27,6 +29,7 @@ export class SqueezeBertForSequenceClassification extends SqueezeBertPreTrainedM
 }
 export class SqueezeBertForQuestionAnswering extends SqueezeBertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/squeezebert/tokenization_squeezebert.js
+++ b/packages/transformers/src/models/squeezebert/tokenization_squeezebert.js
@@ -1,5 +1,6 @@
 import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 
 export class SqueezeBertTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 }

--- a/packages/transformers/src/models/swin/modeling_swin.js
+++ b/packages/transformers/src/models/swin/modeling_swin.js
@@ -5,6 +5,7 @@ export class SwinPreTrainedModel extends PreTrainedModel {}
 export class SwinModel extends SwinPreTrainedModel {}
 export class SwinForImageClassification extends SwinPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/swin2sr/image_processing_swin2sr.js
+++ b/packages/transformers/src/models/swin2sr/image_processing_swin2sr.js
@@ -1,6 +1,7 @@
 import { ImageProcessor } from '../../image_processors_utils.js';
 
 export class Swin2SRImageProcessor extends ImageProcessor {
+    /** @override */
     pad_image(pixelData, imgDims, padSize, options = {}) {
         // NOTE: In this case, `padSize` represents the size of the sliding window for the local attention.
         // In other words, the image is padded so that its width and height are multiples of `padSize`.

--- a/packages/transformers/src/models/t5/modeling_t5.js
+++ b/packages/transformers/src/models/t5/modeling_t5.js
@@ -1,6 +1,7 @@
 import { PreTrainedModel } from '../modeling_utils.js';
 
 export class T5PreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = [
         'input_ids',
         'attention_mask',

--- a/packages/transformers/src/models/table_transformer/modeling_table_transformer.js
+++ b/packages/transformers/src/models/table_transformer/modeling_table_transformer.js
@@ -15,6 +15,7 @@ export class TableTransformerModel extends TableTransformerPreTrainedModel {}
  */
 export class TableTransformerForObjectDetection extends TableTransformerPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/ultravox/modeling_ultravox.js
+++ b/packages/transformers/src/models/ultravox/modeling_ultravox.js
@@ -1,6 +1,7 @@
 import { PreTrainedModel, default_merge_input_ids_with_audio_features } from '../modeling_utils.js';
 
 export class UltravoxPreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = ['input_ids', 'attention_mask', 'position_ids', 'audio_values', 'past_key_values'];
 }
 

--- a/packages/transformers/src/models/ultravox/processing_ultravox.js
+++ b/packages/transformers/src/models/ultravox/processing_ultravox.js
@@ -8,9 +8,11 @@ import { Processor } from '../../processing_utils.js';
 export class UltravoxProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
+    /** @override */
     static uses_processor_config = true;
 
     /**
+     * @override
      * @param {string} text The text input to process.
      * @param {Float32Array} audio The audio input to process.
      */

--- a/packages/transformers/src/models/unispeech/modeling_unispeech.js
+++ b/packages/transformers/src/models/unispeech/modeling_unispeech.js
@@ -14,6 +14,7 @@ export class UniSpeechModel extends UniSpeechPreTrainedModel {}
  */
 export class UniSpeechForCTC extends UniSpeechPreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -28,6 +29,7 @@ export class UniSpeechForCTC extends UniSpeechPreTrainedModel {
  */
 export class UniSpeechForSequenceClassification extends UniSpeechPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/unispeech_sat/modeling_unispeech_sat.js
+++ b/packages/transformers/src/models/unispeech_sat/modeling_unispeech_sat.js
@@ -14,6 +14,7 @@ export class UniSpeechSatModel extends UniSpeechSatPreTrainedModel {}
  */
 export class UniSpeechSatForCTC extends UniSpeechSatPreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -28,6 +29,7 @@ export class UniSpeechSatForCTC extends UniSpeechSatPreTrainedModel {
  */
 export class UniSpeechSatForSequenceClassification extends UniSpeechSatPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.
@@ -42,6 +44,7 @@ export class UniSpeechSatForSequenceClassification extends UniSpeechSatPreTraine
  */
 export class UniSpeechSatForAudioFrameClassification extends UniSpeechSatPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<TokenClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/vision_encoder_decoder/modeling_vision_encoder_decoder.js
+++ b/packages/transformers/src/models/vision_encoder_decoder/modeling_vision_encoder_decoder.js
@@ -4,7 +4,9 @@ import { PreTrainedModel } from '../modeling_utils.js';
  * Vision Encoder-Decoder model based on OpenAI's GPT architecture for image captioning and other vision tasks
  */
 export class VisionEncoderDecoderModel extends PreTrainedModel {
+    /** @override */
     main_input_name = 'pixel_values';
+    /** @override */
     forward_params = [
         // Encoder inputs
         'pixel_values',

--- a/packages/transformers/src/models/vit/modeling_vit.js
+++ b/packages/transformers/src/models/vit/modeling_vit.js
@@ -5,6 +5,7 @@ export class ViTPreTrainedModel extends PreTrainedModel {}
 export class ViTModel extends ViTPreTrainedModel {}
 export class ViTForImageClassification extends ViTPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/vit_msn/modeling_vit_msn.js
+++ b/packages/transformers/src/models/vit_msn/modeling_vit_msn.js
@@ -5,6 +5,7 @@ export class ViTMSNPreTrainedModel extends PreTrainedModel {}
 export class ViTMSNModel extends ViTMSNPreTrainedModel {}
 export class ViTMSNForImageClassification extends ViTMSNPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/vitmatte/image_processing_vitmatte.js
+++ b/packages/transformers/src/models/vitmatte/image_processing_vitmatte.js
@@ -4,6 +4,7 @@ import { stack, cat } from '../../utils/tensor.js';
 
 export class VitMatteImageProcessor extends ImageProcessor {
     /**
+     * @override
      * Calls the feature extraction process on an array of images, preprocesses
      * each image, and concatenates the resulting features into a single Tensor.
      * @param {import("../../utils/image.js").RawImage[]} images The image(s) to extract features from.

--- a/packages/transformers/src/models/vitmatte/modeling_vitmatte.js
+++ b/packages/transformers/src/models/vitmatte/modeling_vitmatte.js
@@ -56,6 +56,7 @@ export class VitMattePreTrainedModel extends PreTrainedModel {}
  */
 export class VitMatteForImageMatting extends VitMattePreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/models/vits/modeling_vits.js
+++ b/packages/transformers/src/models/vits/modeling_vits.js
@@ -50,6 +50,7 @@ export class VitsPreTrainedModel extends PreTrainedModel {}
  */
 export class VitsModel extends VitsPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<VitsModelOutput>} The outputs for the VITS model.

--- a/packages/transformers/src/models/voxtral/processing_voxtral.js
+++ b/packages/transformers/src/models/voxtral/processing_voxtral.js
@@ -27,9 +27,11 @@ function chunk(audio, n_samples) {
 export class VoxtralProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
+    /** @override */
     static uses_processor_config = false;
 
     /**
+     * @override
      * @param {string} text The text input to process.
      * @param {Float32Array|Float32Array[]} audio The audio input(s) to process.
      */

--- a/packages/transformers/src/models/voxtral_realtime/feature_extraction_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/feature_extraction_voxtral_realtime.js
@@ -53,6 +53,7 @@ export class VoxtralRealtimeFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Extract mel spectrogram features from audio.
      * @param {Float32Array|Float64Array} audio The audio data.
      * @param {Object} [options]

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -192,6 +192,7 @@ class AudioExhaustedCriteria extends StoppingCriteria {
         super();
         this._s = enc_state;
     }
+    /** @override */
     _call(input_ids) {
         const done = this._s.stream_exhausted && this._s.audio_embed_queue.length === 0;
         return input_ids.map(() => done);
@@ -199,10 +200,12 @@ class AudioExhaustedCriteria extends StoppingCriteria {
 }
 
 export class VoxtralRealtimePreTrainedModel extends PreTrainedModel {
+    /** @override */
     forward_params = ['input_ids', 'attention_mask', 'position_ids', 'past_key_values'];
 }
 
 export class VoxtralRealtimeForConditionalGeneration extends VoxtralRealtimePreTrainedModel {
+    /** @override */
     async forward({ input_ids, past_key_values, ...kwargs }) {
         const current_len = input_ids.dims[1];
 
@@ -225,6 +228,7 @@ export class VoxtralRealtimeForConditionalGeneration extends VoxtralRealtimePreT
         return await sessionRun(session, fixed);
     }
 
+    /** @override */
     async generate({ input_features, stopping_criteria: userStoppingCriteria, ...kwargs }) {
         if (!input_features) {
             throw new Error('input_features (generator/iterable) must be provided');

--- a/packages/transformers/src/models/voxtral_realtime/processing_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/processing_voxtral_realtime.js
@@ -16,6 +16,7 @@ const STREAMING_PAD_TOKEN_ID = 32;
 export class VoxtralRealtimeProcessor extends Processor {
     static tokenizer_class = AutoTokenizer;
     static feature_extractor_class = AutoFeatureExtractor;
+    /** @override */
     static uses_processor_config = false;
 
     /** Number of mel frames in the first audio chunk. */
@@ -51,6 +52,7 @@ export class VoxtralRealtimeProcessor extends Processor {
     }
 
     /**
+     * @override
      * Process audio input for VoxtralRealtime.
      *
      * In streaming mode with `is_first_audio_chunk=true`, the audio is left-padded

--- a/packages/transformers/src/models/wav2vec2/feature_extraction_wav2vec2.js
+++ b/packages/transformers/src/models/wav2vec2/feature_extraction_wav2vec2.js
@@ -15,6 +15,7 @@ export class Wav2Vec2FeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_values: Tensor; attention_mask: Tensor }>} A Promise resolving to an object containing the extracted input features and attention mask as Tensors.

--- a/packages/transformers/src/models/wav2vec2/modeling_wav2vec2.js
+++ b/packages/transformers/src/models/wav2vec2/modeling_wav2vec2.js
@@ -34,6 +34,7 @@ export class Wav2Vec2Model extends Wav2Vec2PreTrainedModel {}
 
 export class Wav2Vec2ForCTC extends Wav2Vec2PreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -45,6 +46,7 @@ export class Wav2Vec2ForCTC extends Wav2Vec2PreTrainedModel {
 
 export class Wav2Vec2ForSequenceClassification extends Wav2Vec2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.
@@ -59,6 +61,7 @@ export class Wav2Vec2ForSequenceClassification extends Wav2Vec2PreTrainedModel {
  */
 export class Wav2Vec2ForAudioFrameClassification extends Wav2Vec2PreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<TokenClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/wav2vec2/processing_wav2vec2.js
+++ b/packages/transformers/src/models/wav2vec2/processing_wav2vec2.js
@@ -7,6 +7,7 @@ export class Wav2Vec2Processor extends Processor {
     static feature_extractor_class = AutoFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/wav2vec2_bert/modeling_wav2vec2_bert.js
+++ b/packages/transformers/src/models/wav2vec2_bert/modeling_wav2vec2_bert.js
@@ -14,6 +14,7 @@ export class Wav2Vec2BertModel extends Wav2Vec2BertPreTrainedModel {}
  */
 export class Wav2Vec2BertForCTC extends Wav2Vec2BertPreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_features Float values of input mel-spectrogram.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -28,6 +29,7 @@ export class Wav2Vec2BertForCTC extends Wav2Vec2BertPreTrainedModel {
  */
 export class Wav2Vec2BertForSequenceClassification extends Wav2Vec2BertPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.js
+++ b/packages/transformers/src/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.js
@@ -7,6 +7,7 @@ export class Wav2Vec2ProcessorWithLM extends Processor {
     static feature_extractor_class = AutoFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/wavlm/modeling_wavlm.js
+++ b/packages/transformers/src/models/wavlm/modeling_wavlm.js
@@ -56,6 +56,7 @@ export class WavLMModel extends WavLMPreTrainedModel {}
  */
 export class WavLMForCTC extends WavLMPreTrainedModel {
     /**
+     * @override
      * @param {Object} model_inputs
      * @param {Tensor} model_inputs.input_values Float values of input raw speech waveform.
      * @param {Tensor} model_inputs.attention_mask Mask to avoid performing convolution and attention on padding token indices. Mask values selected in [0, 1]
@@ -70,6 +71,7 @@ export class WavLMForCTC extends WavLMPreTrainedModel {
  */
 export class WavLMForSequenceClassification extends WavLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<SequenceClassifierOutput>} An object containing the model's output logits for sequence classification.
@@ -113,6 +115,7 @@ export class WavLMForSequenceClassification extends WavLMPreTrainedModel {
  */
 export class WavLMForXVector extends WavLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<XVectorOutput>} An object containing the model's output logits and speaker embeddings.
@@ -161,6 +164,7 @@ export class WavLMForXVector extends WavLMPreTrainedModel {
  */
 export class WavLMForAudioFrameClassification extends WavLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
      * @returns {Promise<TokenClassifierOutput>} An object containing the model's output logits for sequence classification.

--- a/packages/transformers/src/models/wespeaker/feature_extraction_wespeaker.js
+++ b/packages/transformers/src/models/wespeaker/feature_extraction_wespeaker.js
@@ -58,6 +58,7 @@ export class WeSpeakerFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_features: Tensor }>} A Promise resolving to an object containing the extracted input features as a Tensor.

--- a/packages/transformers/src/models/whisper/feature_extraction_whisper.js
+++ b/packages/transformers/src/models/whisper/feature_extraction_whisper.js
@@ -47,6 +47,7 @@ export class WhisperFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * @override
      * Asynchronously extracts features from a given audio using the provided configuration.
      * @param {Float32Array|Float64Array} audio The audio data as a Float32Array/Float64Array.
      * @returns {Promise<{ input_features: Tensor }>} A Promise resolving to an object containing the extracted input features as a Tensor.

--- a/packages/transformers/src/models/whisper/modeling_whisper.js
+++ b/packages/transformers/src/models/whisper/modeling_whisper.js
@@ -15,7 +15,9 @@ import { logger } from '../../utils/logger.js';
 
 export class WhisperPreTrainedModel extends PreTrainedModel {
     requires_attention_mask = false;
+    /** @override */
     main_input_name = 'input_features';
+    /** @override */
     forward_params = [
         'input_features',
         'attention_mask',
@@ -34,6 +36,7 @@ export class WhisperModel extends WhisperPreTrainedModel {}
  * WhisperForConditionalGeneration class for generating conditional outputs from Whisper models.
  */
 export class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
+    /** @override */
     _prepare_generation_config(generation_config, kwargs) {
         return /** @type {WhisperGenerationConfig} */ (
             super._prepare_generation_config(generation_config, kwargs, WhisperGenerationConfig)
@@ -98,6 +101,7 @@ export class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
     }
 
     /**
+     * @override
      * Transcribes or translates log-mel input features to a sequence of auto-regressively generated token ids.
      * @param {import('./generation_whisper.js').WhisperGenerationFunctionParameters} options
      * @returns {Promise<ModelOutput|Tensor>} The output of the model, which can contain the generated token ids, attentions, and scores.

--- a/packages/transformers/src/models/whisper/processing_whisper.js
+++ b/packages/transformers/src/models/whisper/processing_whisper.js
@@ -10,6 +10,7 @@ export class WhisperProcessor extends Processor {
     static feature_extractor_class = AutoFeatureExtractor;
 
     /**
+     * @override
      * Calls the feature_extractor function with the given audio input.
      * @param {any} audio The audio input to extract features from.
      * @returns {Promise<any>} A Promise that resolves with the extracted features.

--- a/packages/transformers/src/models/whisper/tokenization_whisper.js
+++ b/packages/transformers/src/models/whisper/tokenization_whisper.js
@@ -508,7 +508,10 @@ export class WhisperTokenizer extends PreTrainedTokenizer {
         return this.mergePunctuations(words, word_tokens, token_indices, prepend_punctionations, append_punctuations);
     }
 
-    /** @type {PreTrainedTokenizer['decode']} */
+    /**
+     * @override
+     * @type {PreTrainedTokenizer['decode']}
+     */
     decode(token_ids, decode_args) {
         let text;
         // @ts-ignore

--- a/packages/transformers/src/models/xlm/modeling_xlm.js
+++ b/packages/transformers/src/models/xlm/modeling_xlm.js
@@ -18,6 +18,7 @@ export class XLMModel extends XLMPreTrainedModel {}
  */
 export class XLMWithLMHeadModel extends XLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -33,6 +34,7 @@ export class XLMWithLMHeadModel extends XLMPreTrainedModel {
  */
 export class XLMForSequenceClassification extends XLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -48,6 +50,7 @@ export class XLMForSequenceClassification extends XLMPreTrainedModel {
  */
 export class XLMForTokenClassification extends XLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -63,6 +66,7 @@ export class XLMForTokenClassification extends XLMPreTrainedModel {
  */
 export class XLMForQuestionAnswering extends XLMPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/xlm/tokenization_xlm.js
+++ b/packages/transformers/src/models/xlm/tokenization_xlm.js
@@ -2,6 +2,7 @@ import { PreTrainedTokenizer } from '../../tokenization_utils.js';
 import { logger } from '../../utils/logger.js';
 
 export class XLMTokenizer extends PreTrainedTokenizer {
+    /** @override */
     return_token_type_ids = true;
 
     constructor(tokenizerJSON, tokenizerConfig) {

--- a/packages/transformers/src/models/xlm_roberta/modeling_xlm_roberta.js
+++ b/packages/transformers/src/models/xlm_roberta/modeling_xlm_roberta.js
@@ -14,6 +14,7 @@ export class XLMRobertaModel extends XLMRobertaPreTrainedModel {}
  */
 export class XLMRobertaForMaskedLM extends XLMRobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -29,6 +30,7 @@ export class XLMRobertaForMaskedLM extends XLMRobertaPreTrainedModel {
  */
 export class XLMRobertaForSequenceClassification extends XLMRobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -44,6 +46,7 @@ export class XLMRobertaForSequenceClassification extends XLMRobertaPreTrainedMod
  */
 export class XLMRobertaForTokenClassification extends XLMRobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.
@@ -59,6 +62,7 @@ export class XLMRobertaForTokenClassification extends XLMRobertaPreTrainedModel 
  */
 export class XLMRobertaForQuestionAnswering extends XLMRobertaPreTrainedModel {
     /**
+     * @override
      * Calls the model on new inputs.
      *
      * @param {Object} model_inputs The inputs to the model.

--- a/packages/transformers/src/models/yolos/modeling_yolos.js
+++ b/packages/transformers/src/models/yolos/modeling_yolos.js
@@ -6,6 +6,7 @@ export class YolosPreTrainedModel extends PreTrainedModel {}
 export class YolosModel extends YolosPreTrainedModel {}
 export class YolosForObjectDetection extends YolosPreTrainedModel {
     /**
+     * @override
      * @param {any} model_inputs
      */
     async _call(model_inputs) {

--- a/packages/transformers/src/processing_utils.js
+++ b/packages/transformers/src/processing_utils.js
@@ -109,6 +109,7 @@ export class Processor extends Callable {
     }
 
     /**
+     * @override
      * Calls the feature_extractor function with the given input.
      * @param {any} input The input to extract features from.
      * @param {...any} args Additional arguments.

--- a/packages/transformers/src/utils/core.js
+++ b/packages/transformers/src/utils/core.js
@@ -115,6 +115,7 @@ export class DefaultProgressCallback extends Callable {
     }
 
     /**
+     * @override
      * @param {ProgressInfo} info
      */
     _call(info) {

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "types",
     "rootDir": "src",
     "strict": false,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "lib": ["ES2020", "DOM"],
     "outDir": "types",
     "strict": false,
+    "noImplicitOverride": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Part of #1623. Third in the strictness series after 
#1691 (noImplicitReturns) and #1692 (noFallthroughCasesInSwitch).

Enables `noImplicitOverride` in both tsconfigs. TypeScript flagged 
355 sites across 173 source files where a method overrides a parent 
class method without an explicit marker.

## Changes

| Category | Detail |
|----------|--------|
| `tsconfig.json` + `packages/transformers/tsconfig.json` | Flag enabled in both |
| 173 source files | `@override` JSDoc tag added to 355 methods |

### How `@override` was placed

The repo already uses this convention in 
`models/gemma4/feature_extraction_gemma4.js` — this PR follows 
the same pattern throughout:

**Existing multi-line JSDoc (223 sites)** — tag inserted as first line:
```js
/**
 * @override
 * @param {bigint[][]} input_ids
 */
_call(input_ids, logits) { ... }
```

**No existing JSDoc (132 sites)** — minimal one-liner added:
```js
/** @override */
_call(input_ids, logits) { ... }
```

**Existing single-line JSDoc (25 sites)** — expanded to multi-line:
```js
/**
 * @override
 * @type {ImageProcessor['get_resize_output_image_size']}
 */
get_resize_output_image_size(image, size) { ... }
```

No method bodies, logic, or formatting changed anywhere.

## Verification

- `pnpm typegen` — 355 TS4114 errors before, 0 after
- `pnpm build` — passes
- `pnpm format:check` — identical to baseline (652 pre-existing failures, none introduced by this PR)
- `pnpm test` — same baseline as prior PRs in this series