### PR TITLE
Add classifier-free guidance support for Chatterbox (fixes multilingual) + MinPLogitsWarper

### DIFF
--- a/packages/transformers/src/generation/configuration_utils.js
+++ b/packages/transformers/src/generation/configuration_utils.js
@@ -119,6 +119,14 @@ export class GenerationConfig {
     top_p = 1.0;
 
     /**
+     * Minimum token probability, which will be scaled by the probability of the most likely token.
+     * It must be a value between 0 and 1. Typical values are in the 0.01-0.2 range, comparably selective as setting `top_p` in the 0.99-0.8 range (use the opposite of normal `top_p` values).
+     * @type {number}
+     * @default null
+     */
+    min_p = null;
+
+    /**
      * Local typicality measures how similar the conditional probability of predicting a target token next is to the expected conditional probability of predicting a random token next, given the partial text already generated.
      * If set to float < 1, the smallest set of the most locally typical tokens with probabilities that add up to `typical_p` or higher are kept for generation.
      * See [this paper](https://huggingface.co/papers/2202.00666) for more details.

--- a/packages/transformers/src/generation/logits_process.js
+++ b/packages/transformers/src/generation/logits_process.js
@@ -749,3 +749,72 @@ export class TopKLogitsWarper extends LogitsWarper {
         this.filter_value = filter_value;
     }
 }
+
+/**
+ * [`LogitsWarper`] that performs min-p, i.e. keeping all tokens that are above a minimum probability, scaled by the
+ * probability of the most likely token. As a result, the filter becomes more aggressive in the presence of
+ * high-probability tokens, which is a sign of a confident output that we shouldn't deviate from.
+ * Often used together with [`TemperatureLogitsWarper`]. Used as an alternative to [`TopPLogitsWarper`] and
+ * [`TopKLogitsWarper`].
+ */
+export class MinPLogitsWarper extends LogitsWarper {
+    /**
+     * Create a `MinPLogitsWarper`.
+     * @param {number} min_p Minimum token probability, which will be scaled by the probability of the most likely
+     * token. It must be a value between 0 and 1. Typical values are in the 0.01-0.2 range.
+     * @param {Object} options Additional options for the min-p filtering.
+     * @param {number} [options.filter_value=-Infinity] All filtered values will be set to this float value.
+     * @param {number} [options.min_tokens_to_keep=1] Minimum number of tokens that cannot be filtered.
+     */
+    constructor(min_p, { filter_value = -Infinity, min_tokens_to_keep = 1 } = {}) {
+        super();
+        if (typeof min_p !== 'number' || min_p < 0 || min_p > 1.0) {
+            throw new Error(`\`min_p\` must be a float in the [0, 1] interval, but is ${min_p}`);
+        }
+        if (!Number.isInteger(min_tokens_to_keep) || min_tokens_to_keep < 1) {
+            throw new Error(`\`min_tokens_to_keep\` must be a positive integer, but is ${min_tokens_to_keep}`);
+        }
+        this.min_p = min_p;
+        this.filter_value = filter_value;
+        this.min_tokens_to_keep = min_tokens_to_keep;
+    }
+
+    /**
+     * Apply logit warper.
+     * @param {bigint[][]} input_ids The input IDs.
+     * @param {Tensor} logits The logits.
+     * @returns {Tensor} The processed logits.
+     */
+    _call(input_ids, logits) {
+        const vocab_size = logits.dims.at(-1);
+        const batch_size = logits.data.length / vocab_size;
+        const data = /** @type {Float32Array} */ (logits.data);
+        const log_min_p = Math.log(this.min_p);
+        for (let b = 0; b < batch_size; ++b) {
+            const offset = b * vocab_size;
+
+            // Since softmax is monotonic and shift-invariant, `prob < min_p * max_prob`
+            // is equivalent to `logit < max_logit + log(min_p)`, so the probabilities
+            // never need to be materialized.
+            let max_logit = -Infinity;
+            for (let i = 0; i < vocab_size; ++i) {
+                const v = data[offset + i];
+                if (v > max_logit) max_logit = v;
+            }
+            let threshold = max_logit + log_min_p;
+
+            if (this.min_tokens_to_keep > 1) {
+                // Lower the threshold if needed so that at least `min_tokens_to_keep` tokens survive.
+                const sorted = Array.from(data.subarray(offset, offset + vocab_size)).sort((a, b) => b - a);
+                threshold = Math.min(threshold, sorted[Math.min(this.min_tokens_to_keep, vocab_size) - 1]);
+            }
+
+            for (let i = 0; i < vocab_size; ++i) {
+                if (data[offset + i] < threshold) {
+                    data[offset + i] = this.filter_value;
+                }
+            }
+        }
+        return logits;
+    }
+}

--- a/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
+++ b/packages/transformers/src/models/chatterbox/modeling_chatterbox.js
@@ -90,6 +90,42 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
 
             ({ inputs_embeds } = await sessionRun(this.sessions['embed_tokens'], embed_model_inputs));
 
+            // Classifier-free guidance (CFG): the reference PyTorch implementation
+            // (resemble-ai/chatterbox, `T3.inference`) always generates with
+            // `cfg_weight=0.5`, running a batch of two sequences: the conditional
+            // input and an unconditional copy whose *text* token embeddings are
+            // zeroed (`text_emb[1].zero_()`) — speaker conditioning, exaggeration
+            // and speech tokens are shared between the two rows. The multilingual
+            // checkpoint produces unintelligible vocalizations without it.
+            // Enabled by setting `guidance_scale` (= 1 + cfg_weight, i.e. 1.5 for
+            // parity with the python defaults) to a value > 1. The two rows are
+            // recombined by `ClassifierFreeGuidanceLogitsProcessor`, so the
+            // batch size visible to `generate()` remains 1.
+            const use_cfg = generation_config?.guidance_scale > 1;
+            if (use_cfg) {
+                if (input_ids.dims[0] !== 1) {
+                    throw new Error('Classifier-free guidance is only supported for a batch size of 1.');
+                }
+                if (past_key_values && inputs_embeds.dims[1] === 1) {
+                    // Generation step: the sampled speech token is fed to both rows.
+                    inputs_embeds = cat([inputs_embeds, inputs_embeds], 0);
+                } else {
+                    // Prefill: zero out the text token embeddings of the unconditional row.
+                    const ids = input_ids.data;
+                    const hidden_size = inputs_embeds.dims.at(-1);
+                    const unconditional = inputs_embeds.data.slice();
+                    for (let i = 0; i < ids.length; ++i) {
+                        if (ids[i] < START_SPEECH_TOKEN) {
+                            unconditional.fill(0, i * hidden_size, (i + 1) * hidden_size);
+                        }
+                    }
+                    inputs_embeds = cat(
+                        [inputs_embeds, new Tensor(inputs_embeds.type, unconditional, inputs_embeds.dims)],
+                        0,
+                    );
+                }
+            }
+
             if (audio_features && audio_tokens && speaker_embeddings && speaker_features) {
                 // Use pre-computed speech encoder outputs
                 speech_encoder_outputs = { audio_features, audio_tokens, speaker_embeddings, speaker_features };
@@ -98,8 +134,16 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
             if (speech_encoder_outputs || audio_values) {
                 speech_encoder_outputs ??= await this.encode_speech(audio_values);
 
-                // Update LLM inputs
-                inputs_embeds = cat([speech_encoder_outputs.audio_features, inputs_embeds], 1);
+                // Update LLM inputs. With CFG enabled, the speaker conditioning is
+                // shared by (i.e. repeated for) the conditional and unconditional rows.
+                let cond_features = speech_encoder_outputs.audio_features;
+                if (cond_features.dims[0] !== inputs_embeds.dims[0]) {
+                    cond_features = cat(
+                        Array.from({ length: inputs_embeds.dims[0] }, () => cond_features),
+                        0,
+                    );
+                }
+                inputs_embeds = cat([cond_features, inputs_embeds], 1);
                 attention_mask = ones([inputs_embeds.dims[0], inputs_embeds.dims[1]]);
             } else {
                 const target_length = inputs_embeds.dims[1];
@@ -130,6 +174,9 @@ export class ChatterboxModel extends ChatterboxPreTrainedModel {
     }
 
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
+        // Forward the generation config to `forward`, which needs `guidance_scale`
+        // to decide whether to build the classifier-free guidance batch.
+        model_inputs.generation_config = generation_config;
         if (!model_inputs.position_ids && this.sessions['embed_tokens'].inputNames.includes('position_ids')) {
             // If position_ids are not provided, we create them on the fly using the position of the START_SPEECH_TOKEN
             if (model_inputs.input_ids.dims[1] === 1) {

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -29,6 +29,7 @@ import {
     MinLengthLogitsProcessor,
     MinNewTokensLengthLogitsProcessor,
     TemperatureLogitsWarper,
+    MinPLogitsWarper,
     ClassifierFreeGuidanceLogitsProcessor,
 } from '../generation/logits_process.js';
 import { GenerationConfig } from '../generation/configuration_utils.js';
@@ -402,6 +403,14 @@ export class PreTrainedModel extends Callable {
     ) {
         const processors = new LogitsProcessorList();
 
+        // Classifier-free guidance must run FIRST so that the conditional and
+        // unconditional batches are combined back into a single batch before any
+        // other processor (e.g. repetition penalty) is applied — matching the
+        // processor ordering of the python `transformers` library.
+        if (generation_config.guidance_scale !== null && generation_config.guidance_scale > 1) {
+            processors.push(new ClassifierFreeGuidanceLogitsProcessor(generation_config.guidance_scale));
+        }
+
         // if (generation_config.diversity_penalty !== null && generation_config.diversity_penalty > 0.0) {
         //     processors.push(new HammingDiversityLogitsProcessor(
         //         generation_config.diversity_penalty,
@@ -513,11 +522,6 @@ export class PreTrainedModel extends Callable {
         //     processors.push(new ForceTokensLogitsProcessor(generation_config.forced_decoder_ids));
         // }
 
-        // 8. prepare batched CFG externally
-        if (generation_config.guidance_scale !== null && generation_config.guidance_scale > 1) {
-            processors.push(new ClassifierFreeGuidanceLogitsProcessor(generation_config.guidance_scale));
-        }
-
         if (generation_config.temperature === 0 && generation_config.do_sample) {
             logger.warn(
                 '`do_sample` changed to false because `temperature: 0` implies greedy sampling (always selecting the most likely token), which is incompatible with `do_sample: true`.',
@@ -536,6 +540,9 @@ export class PreTrainedModel extends Callable {
             // if (generation_config.top_p !== null && generation_config.top_p < 1.0) {
             //     processors.push(new TopPLogitsWarper(generation_config.top_p));
             // }
+            if (generation_config.min_p !== null && generation_config.min_p > 0) {
+                processors.push(new MinPLogitsWarper(generation_config.min_p));
+            }
         }
 
         if (logits_processor !== null) {

--- a/packages/transformers/tests/utils/logits_process.test.js
+++ b/packages/transformers/tests/utils/logits_process.test.js
@@ -2,6 +2,12 @@ import {
   // Pipelines
   pipeline,
   TextGenerationPipeline,
+
+  // Logits processors
+  MinPLogitsWarper,
+
+  // Other
+  Tensor,
 } from "../../src/transformers.js";
 
 import { init } from "../init.js";
@@ -108,5 +114,35 @@ describe("Logits Processors", () => {
     afterAll(async () => {
       await pipe?.dispose();
     }, MAX_MODEL_DISPOSE_TIME);
+  });
+});
+
+describe("MinPLogitsWarper", () => {
+  it("filters tokens whose probability is below min_p times the top probability", () => {
+    // Probabilities: [0.5, 0.25, 0.1, 0.01] (up to normalization)
+    const logits = new Tensor("float32", new Float32Array([0.5, 0.25, 0.1, 0.01].map(Math.log)), [1, 4]);
+    const warper = new MinPLogitsWarper(0.3);
+    const data = Array.from(warper([[]], logits).data);
+    expect(data[0]).toBeCloseTo(Math.log(0.5)); // ratio 1.0  >= 0.3 -> kept
+    expect(data[1]).toBeCloseTo(Math.log(0.25)); // ratio 0.5 >= 0.3 -> kept
+    expect(data[2]).toBe(-Infinity); // ratio 0.2  < 0.3 -> filtered
+    expect(data[3]).toBe(-Infinity); // ratio 0.02 < 0.3 -> filtered
+  });
+
+  it("keeps at least min_tokens_to_keep tokens", () => {
+    const logits = new Tensor("float32", new Float32Array([0, -10, -20, -30]), [1, 4]);
+    const warper = new MinPLogitsWarper(0.5, { min_tokens_to_keep: 3 });
+    const data = Array.from(warper([[]], logits).data);
+    expect(data.filter((x) => x !== -Infinity)).toHaveLength(3);
+  });
+
+  it("processes each batch row independently", () => {
+    const logits = new Tensor("float32", new Float32Array([0.5, 0.01, 0.01, 0.5].map(Math.log)), [2, 2]);
+    const warper = new MinPLogitsWarper(0.3);
+    const data = Array.from(warper([[], []], logits).data);
+    expect(data[0]).toBeCloseTo(Math.log(0.5));
+    expect(data[1]).toBe(-Infinity);
+    expect(data[2]).toBe(-Infinity);
+    expect(data[3]).toBeCloseTo(Math.log(0.5));
   });
 });


### PR DESCRIPTION
Fixes #1656

### TL;DR
The Chatterbox **multilingual** checkpoint was thought to be unsupported ("requires special setup"). After a full investigation (ONNX graph diffing against the English export, tokenizer comparison, and step-by-step replication of the reference PyTorch sampling loop), it turns out the architecture is already fully supported by the existing `ChatterboxModel` — the missing piece in the library is **classifier-free guidance (CFG)**, which the reference implementation ([resemble-ai/chatterbox `T3.inference`](https://github.com/resemble-ai/chatterbox/blob/master/src/chatterbox/models/t3/t3.py)) always applies with `cfg_weight=0.5`. Without CFG the multilingual model only produces short unintelligible vocalizations followed by an early EOS; with it, it produces correct cloned speech (validated in-browser on WebGPU in French and German with a 10s reference voice).

### Changes
1. **`ChatterboxModel`: CFG support, enabled via `guidance_scale`** (= `1 + cfg_weight`, i.e. `1.5` for parity with the python defaults). When `guidance_scale > 1`, `forward` internally runs a batch of two sequences — the conditional input and an unconditional copy whose *text token* embeddings are zeroed (matching `text_emb[1].zero_()` in the reference implementation; speaker conditioning, exaggeration and speech tokens are shared between the two rows). The two rows are recombined by the existing `ClassifierFreeGuidanceLogitsProcessor`, so the batch size visible to `generate()` stays 1. Opt-in: no behavior change when `guidance_scale` is unset.
2. **Processor ordering: move `ClassifierFreeGuidanceLogitsProcessor` to the front of the list**, matching the python `transformers` ordering — the cond/uncond logits must be combined back into a single batch *before* any other processor (e.g. repetition penalty) runs.
3. **Add `MinPLogitsWarper` + the `min_p` generation option** (full implementation incl. `min_tokens_to_keep`, with unit tests). The official Chatterbox sampling parameters use `min_p=0.05`.

### Usage (multilingual)
```js
const waveform = await model.generate({
    ...inputs, ...speaker_data, exaggeration: 0.5,
    max_new_tokens: 1000,
    do_sample: true, temperature: 0.8, top_k: 0, top_p: 1.0,
    min_p: 0.05, repetition_penalty: 1.2,
    guidance_scale: 1.5, // 1 + cfg_weight(0.5) — required for the multilingual checkpoint
});
```

### Note on the multilingual model files (for anyone reproducing)
There is currently no official ONNX repo with complete configs for the multilingual checkpoint. The community mirror's `tokenizer.json` has a broken `post_processor` (its `TemplateProcessing` special tokens are referenced without brackets — `"BOS"`, `"EOS"`, `"START_SPEECH"`, `"EXAGGERATION"` — which don't exist in the vocab, so all five special tokens encode to `[UNK]`). The correct template, identical to the working English export, is: `[EXAGGERATION](6563) [START](255) …text… [STOP](0) [START_SPEECH](6561) [START_SPEECH](6561)`. Happy to help fix/publish corrected model files if useful.

### Validation
- In-browser (WebGPU, Chrome/macOS): multilingual checkpoint + this PR's build → intelligible cloned speech in **French** and **German** from a 10.7s reference (previously: 0.5s of breath noise, RMS ≈ 0.0003 → now ≈ 5–6s of speech, RMS ≈ 0.08). English checkpoint unchanged.
- `pnpm build` ✓ (incl. typegen), `pnpm format:check` ✓, `logits_process` test suite ✓ (incl. 3 new `MinPLogitsWarper` unit tests).
