### PR TITLE
fix(backends/onnx): fall back to next execution provider on init failure

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -286,15 +286,57 @@ async function ensureWasmLoaded() {
 export async function createInferenceSession(buffer_or_path, session_options, session_config) {
     await ensureWasmLoaded();
     const logSeverityLevel = getOnnxLogSeverityLevel(env.logLevel ?? LogLevel.WARNING);
-    const load = () =>
+    const load = (executionProviders) =>
         InferenceSession.create(buffer_or_path, {
             // Set default log severity level, but allow overriding through session options
             logSeverityLevel,
             ...session_options,
+            ...(executionProviders !== undefined && { executionProviders }),
         });
-    const session = await (apis.IS_WEB_ENV ? (webInitChain = webInitChain.then(load)) : load());
+
+    // When more than one execution provider has been requested (typically via
+    // `device: 'auto'`), fall back to the remaining providers if the first one
+    // fails to initialize. The common case is CUDA on Linux x64: ORT lists
+    // CUDA as a supported backend even when the CUDA shared library isn't
+    // installed on the host, so `auto` would otherwise fail hard with
+    // "Failed to load shared library" instead of falling through to CPU
+    // (see #1642). When the caller explicitly requested a single provider
+    // we don't second-guess them — the error propagates as before.
+    if (
+        !apis.IS_WEB_ENV &&
+        Array.isArray(session_options.executionProviders) &&
+        session_options.executionProviders.length > 1
+    ) {
+        let providers = session_options.executionProviders.slice();
+        let lastError;
+        while (providers.length > 0) {
+            try {
+                const session = await load(providers);
+                session.config = session_config;
+                return session;
+            } catch (error) {
+                lastError = error;
+                if (providers.length === 1) break;
+                logger.warn(
+                    `Execution provider "${providerName(providers[0])}" failed to initialize: ${error?.message ?? error}. Falling back to ${providers.slice(1).map(providerName).join(', ')}.`,
+                );
+                providers = providers.slice(1);
+            }
+        }
+        throw lastError;
+    }
+
+    const session = await (apis.IS_WEB_ENV ? (webInitChain = webInitChain.then(() => load())) : load());
     session.config = session_config;
     return session;
+}
+
+/**
+ * @param {string | { name: string }} provider
+ * @returns {string}
+ */
+function providerName(provider) {
+    return typeof provider === 'string' ? provider : provider.name;
 }
 
 /**


### PR DESCRIPTION
## Summary

When `device: 'auto'` is requested in Node, [`deviceToExecutionProviders`](packages/transformers/src/backends/onnx.js) returns the full supported-device list (e.g. `['cuda', 'webgpu', 'cpu']` on Linux x64). ONNX Runtime treats that list as load-or-fail per provider — so on a Linux x64 host **without the CUDA shared library installed**, session creation fails hard with:

```
OrtSessionOptionsAppendExecutionProvider_Cuda: Failed to load shared library
  at new OnnxruntimeSessionHandler (node_modules/onnxruntime-node/lib/backend)
```

…instead of falling through to the next provider in the list. Users without CUDA can't use the SDK at all in `auto` mode (#1642).

## Fix

Make `createInferenceSession` retry with the remaining providers when the first one fails to initialise.

```diff
+    if (
+        !apis.IS_WEB_ENV &&
+        Array.isArray(session_options.executionProviders) &&
+        session_options.executionProviders.length > 1
+    ) {
+        let providers = session_options.executionProviders.slice();
+        let lastError;
+        while (providers.length > 0) {
+            try {
+                const session = await load(providers);
+                session.config = session_config;
+                return session;
+            } catch (error) {
+                lastError = error;
+                if (providers.length === 1) break;
+                logger.warn(
+                    `Execution provider \"${providerName(providers[0])}\" failed to initialize: ${error?.message ?? error}. Falling back to ${providers.slice(1).map(providerName).join(', ')}.`,
+                );
+                providers = providers.slice(1);
+            }
+        }
+        throw lastError;
+    }
```

Three properties worth calling out:

1. **Only retries when more than one provider was requested.** If a caller explicitly asks for a single provider (`device: 'cuda'`), the error propagates as before — we don't second-guess deliberate intent.
2. **Web path is untouched.** The web path (WASM + WebGPU) keeps its existing `webInitChain` chain semantics — the fallback only applies in Node, where the multi-provider list is what triggers the original bug.
3. **Visibility.** Each fallback emits a `logger.warn` so silent degradation is observable in logs.

The change generalises beyond CUDA — the same pattern naturally handles transient or missing-driver failures for DirectML on Windows, CoreML on macOS, or WebGPU when the runtime is unavailable.

## Test plan

- [x] `pnpm -C packages/transformers build` — clean (CJS + ESM + types)
- [x] `pnpm format:check` — clean
- [ ] No dedicated unit test added — the failure mode requires runtime mocking of ONNX session creation against specific error strings, which doesn't slot cleanly into the existing test suite. Happy to add one if you'd like to suggest a pattern that fits.

Fixes #1642