### PR TITLE
refactor(cos): use singular requestFileHandle() instead of requestFileHandles()

### DIFF
--- a/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
+++ b/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
@@ -57,9 +57,13 @@ export class CrossOriginStorage {
             return undefined;
         }
         try {
-            const [handle] = await navigator.crossOriginStorage.requestFileHandles([makeHashDescriptor(hashValue)]);
+            const handle = await navigator.crossOriginStorage.requestFileHandle(makeHashDescriptor(hashValue));
             const blob = await handle.getFile();
-            return new Response(blob);
+            return new Response(blob, {
+                headers: {
+                    'Content-Length': String(blob.size),
+                },
+            });
         } catch {
             return undefined;
         }
@@ -106,7 +110,7 @@ export class CrossOriginStorage {
      * @returns {Promise<void>}
      */
     _storeBlobInCOS = async (blob, hashHex) => {
-        const [handle] = await navigator.crossOriginStorage.requestFileHandles([makeHashDescriptor(hashHex)], {
+        const handle = await navigator.crossOriginStorage.requestFileHandle(makeHashDescriptor(hashHex), {
             create: true,
         });
         const writableStream = await handle.createWritable();

--- a/packages/transformers/src/utils/cache/cross-origin-storage.d.ts
+++ b/packages/transformers/src/utils/cache/cross-origin-storage.d.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Represents the dictionary for hash algorithms and values.
+ * Represents the dictionary for hash algorithm and value.
  */
 interface CrossOriginStorageRequestFileHandleHash {
     value: string;
@@ -13,7 +13,7 @@ interface CrossOriginStorageRequestFileHandleHash {
 }
 
 /**
- * Represents the options for requesting file handles.
+ * Represents the options for requesting a file handle.
  */
 interface CrossOriginStorageRequestFileHandleOptions {
     create?: boolean;
@@ -24,10 +24,10 @@ interface CrossOriginStorageRequestFileHandleOptions {
  * [SecureContext]
  */
 interface CrossOriginStorageManager {
-    requestFileHandles(
-        hashes: CrossOriginStorageRequestFileHandleHash[],
+    requestFileHandle(
+        hash: CrossOriginStorageRequestFileHandleHash,
         options?: CrossOriginStorageRequestFileHandleOptions,
-    ): Promise<FileSystemFileHandle[]>;
+    ): Promise<FileSystemFileHandle>;
 }
 
 /**


### PR DESCRIPTION
Switches from the deprecated plural `requestFileHandles([hash])` to the new singular `requestFileHandle(hash)` API, which returns a `FileSystemFileHandle` directly rather than a single-element array. Also updates the bundled type definitions to match.

The rename was adopted in the COS spec after a survey of all known real-world implementations found that every call site passed a single-element array and immediately destructured it to one handle — no implementation ever used the plural form as intended.

FYI @nico-martin @xenova — as the author and reviewer of the original COS PR (#1549).

See https://github.com/WICG/cross-origin-storage/issues/61 for details.