### PR TITLE
[Fix] RawAudio.toBlob() ignores TypedArray byteOffset/length (#1704)

### DIFF
--- a/packages/transformers/src/utils/audio.js
+++ b/packages/transformers/src/utils/audio.js
@@ -813,7 +813,7 @@ function encodeWAV(chunks, rate) {
     /* data chunk length */
     view.setUint32(40, totalLength * 4, true);
 
-    return new Blob([buffer, ...chunks.map((chunk) => /** @type {ArrayBuffer} */ (chunk.buffer))], {
+    return new Blob([buffer, ...chunks.map((chunk) => new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))], {
         type: 'audio/wav',
     });
 }

--- a/packages/transformers/src/utils/audio.js
+++ b/packages/transformers/src/utils/audio.js
@@ -813,9 +813,18 @@ function encodeWAV(chunks, rate) {
     /* data chunk length */
     view.setUint32(40, totalLength * 4, true);
 
-    return new Blob([buffer, ...chunks.map((chunk) => new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))], {
-        type: 'audio/wav',
-    });
+    // SharedArrayBuffer cannot back a BlobPart, so only ArrayBuffer-backed chunks get a zero-copy view.
+    return new Blob(
+        [
+            buffer,
+            ...chunks.map((chunk) =>
+                chunk.buffer instanceof ArrayBuffer
+                    ? new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+                    : chunk.slice(),
+            ),
+        ],
+        { type: 'audio/wav' },
+    );
 }
 
 function writeString(view, offset, string) {

--- a/packages/transformers/tests/utils/audio.test.js
+++ b/packages/transformers/tests/utils/audio.test.js
@@ -127,6 +127,31 @@ describe("Audio utilities", () => {
       expect(blob.type).toBe("audio/wav");
       expect(blob.size).toBe(4044); // 44 header + 4000 data
     });
+
+    it("should convert to Blob (WAV) from a non-zero-offset subarray view", async () => {
+      // Regression test for https://github.com/huggingface/transformers.js/issues/1704:
+      // the WAV payload must reflect the view's byteOffset/byteLength,
+      // not the start of its backing buffer.
+      const sampling_rate = 16000;
+      const backing = new Float32Array([-1, -0.5, -0.25, 0.125, 0.25, 0.5, 1]);
+      const view = backing.subarray(3); // byteOffset = 12 bytes, 4 samples
+
+      const blob = new RawAudio(view, sampling_rate).toBlob();
+
+      // 44-byte WAV header + only the view's bytes (4 samples * 4 bytes)
+      expect(blob.size).toBe(44 + view.byteLength);
+
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      const header = new DataView(bytes.buffer);
+
+      // "data" chunk length must match the view's size
+      expect(header.getUint32(40, true)).toBe(view.byteLength);
+
+      // Payload samples must come from the selected view, not the start of the backing buffer
+      const payload = new Float32Array(bytes.buffer, 44, view.length);
+      expect(Array.from(payload)).toEqual(Array.from(view));
+      expect(payload[0]).toBe(0.125); // backing[3]; would be -1 if the buffer start leaked in
+    });
   });
 
   describe("spectrogram", () => {


### PR DESCRIPTION
## Motivation

`RawAudio.toBlob()` produces a WAV whose audio is wrong (e.g. leading silence / only the first N samples) when the audio is a `TypedArray` view with a non-zero `byteOffset` or a length shorter than its backing buffer — anything coming from `Float32Array.subarray(...)`, for example (#1704).

## Root cause

In `packages/transformers/src/utils/audio.js`, `encodeWAV()` writes the WAV data-chunk size from each view's length (`chunk.length`), but builds the `Blob` payload from `chunk.buffer` — the entire underlying `ArrayBuffer`, ignoring the view's `byteOffset`/`byteLength`. Header and payload then disagree, and decoders honor the header, reading the wrong window of samples.

## Modifications

`packages/transformers/src/utils/audio.js` (`encodeWAV`): build the payload from `Uint8Array` views that respect each chunk's `byteOffset`/`byteLength`, instead of passing the whole `chunk.buffer`.

## Duplicate-check

- Track A — `gh api 'repos/huggingface/transformers.js/pulls?state=open&per_page=100' --paginate` grepped for `1704` → no open PR references it.
- Track B — issue #1704 has no comments and no in-progress claim.
