### PR TITLE
Respect HF_ENDPOINT for env.remoteHost

### DIFF
--- a/packages/transformers/src/env.js
+++ b/packages/transformers/src/env.js
@@ -257,7 +257,10 @@ export const env = {
     },
     /////////////////// Model settings ///////////////////
     allowRemoteModels: true,
-    remoteHost: 'https://huggingface.co/',
+    remoteHost:
+        typeof process !== 'undefined'
+            ? (process.env?.HF_ENDPOINT ?? 'https://huggingface.co/')
+            : 'https://huggingface.co/',
     remotePathTemplate: '{model}/resolve/{revision}/',
 
     allowLocalModels: !(IS_BROWSER_ENV || IS_WEBWORKER_ENV || IS_DENO_WEB_RUNTIME), // Default to true for non-web environments, false for web environments

--- a/packages/transformers/tests/env.test.js
+++ b/packages/transformers/tests/env.test.js
@@ -1,0 +1,28 @@
+import { spawnSync } from "child_process";
+
+const ENV_MODULE_URL = new URL("../src/env.js", import.meta.url).href;
+
+function readRemoteHost(env) {
+  const code = `import { env } from ${JSON.stringify(ENV_MODULE_URL)}; process.stdout.write(env.remoteHost);`;
+  const result = spawnSync("node", ["--input-type=module", "-e", code], { env });
+
+  expect(result.stderr.toString()).toEqual("");
+  expect(result.status).toEqual(0);
+
+  return result.stdout.toString();
+}
+
+describe("env", () => {
+  it("defaults remoteHost to the Hugging Face Hub", async () => {
+    const env = { ...process.env };
+    delete env.HF_ENDPOINT;
+
+    expect(readRemoteHost(env)).toBe("https://huggingface.co/");
+  });
+
+  it("uses HF_ENDPOINT as the default remoteHost when set", async () => {
+    const env = { ...process.env, HF_ENDPOINT: "https://hf.example.com/" };
+
+    expect(readRemoteHost(env)).toBe("https://hf.example.com/");
+  });
+});


### PR DESCRIPTION
## Background

Some enterprise deployments route Hugging Face traffic through an internal proxy or self-hosted Hub, for example to allow only approved models. Today, Transformers.js initializes `env.remoteHost` to `https://huggingface.co/`, so Node.js users targeting those deployments need to override `env.remoteHost` manually in code.

## Change

This changes the default to read `process.env.HF_ENDPOINT` when present, and fall back to `https://huggingface.co/` otherwise. This follows the existing environment variable pattern used for Hub auth tokens while preserving the current default behavior.

## Tests

Adds a focused `env.test.js` covering both the fallback and `HF_ENDPOINT` cases.