### PR TITLE
fix: respect TypedArray byteOffset and byteLength in RawAudio.toBlob()

### DIFF
--- a/packages/transformers/src/utils/audio.js
+++ b/packages/transformers/src/utils/audio.js
@@ -813,7 +813,7 @@ function encodeWAV(chunks, rate) {
     /* data chunk length */
     view.setUint32(40, totalLength * 4, true);
 
-    return new Blob([buffer, ...chunks.map((chunk) => /** @type {ArrayBuffer} */ (chunk.buffer))], {
+    return new Blob([buffer, ...chunks.map((c) => new Uint8Array(c.buffer, c.byteOffset, c.byteLength))], {
         type: 'audio/wav',
     });
 }


### PR DESCRIPTION
## Summary

Fixes `RawAudio.toBlob()` producing malformed WAV files when audio chunks are TypedArray subarrays with non-zero `byteOffset`.

## Root Cause

The `encodeWAV` method uses `chunk.buffer` to get the raw binary data from each audio chunk. However, for TypedArray subarrays (created via `.subarray()` or `.slice()` in streaming contexts), `.buffer` returns the **entire backing `ArrayBuffer`** regardless of the view's offset and length. This causes the WAV blob to contain extra bytes from outside the actual audio data, creating a length mismatch with the WAV header.

## Fix

Replace `chunk.buffer` with `new Uint8Array(c.buffer, c.byteOffset, c.byteLength)` to correctly extract only the relevant portion of the backing buffer, respecting the TypedArray view's offset and length.

**Before:**
\`\`\`js
return new Blob([buffer, ...chunks.map((chunk) => chunk.buffer)], { type: 'audio/wav' });
\`\`\`

**After:**
\`\`\`js
return new Blob([buffer, ...chunks.map((c) => new Uint8Array(c.buffer, c.byteOffset, c.byteLength))], { type: 'audio/wav' });
\`\`\`

## Impact

Fixes silent audio corruption in TTS pipelines that use streaming output, where audio chunks are subarrays of a larger buffer. The WAV header length fields are computed correctly from `chunk.length` (number of elements), but the old `chunk.buffer` could include padding bytes outside the view's range, causing the actual data payload to mismatch the declared lengths.

Fixes #1704