### PR TITLE
feat(hub): resume interrupted model downloads via HTTP Range (Node)

### DIFF
--- a/packages/transformers/src/utils/cache.js
+++ b/packages/transformers/src/utils/cache.js
@@ -4,6 +4,19 @@ import { logger } from './logger.js';
 import { CrossOriginStorage } from './cache/CrossOriginStorageCache.js';
 
 /**
+ * Describes a partial download that can be continued with an HTTP `Range` request.
+ *
+ * NOTE: this is a named typedef rather than an inline object type because jsdoc
+ * cannot parse an object literal nested inside a generic (`Promise<{...}>`),
+ * which breaks the API documentation build.
+ *
+ * @typedef {Object} ResumeInfo
+ * @property {number} size Bytes already written to disk for this request.
+ * @property {string|null} etag The validator the partial was started against, if the server sent one.
+ * @property {number} total The full size of the file being downloaded.
+ */
+
+/**
  * @typedef {Object} CacheInterface
  * @property {(request: string) => Promise<Response|import('./hub/FileResponse.js').FileResponse|undefined|string>} match
  * Checks if a request is in the cache and returns the cached response if found.
@@ -11,7 +24,7 @@ import { CrossOriginStorage } from './cache/CrossOriginStorageCache.js';
  * Adds a response to the cache.
  * @property {(request: string) => Promise<boolean>} [delete]
  * Deletes a request from the cache. Returns true if deleted, false otherwise.
- * @property {(request: string) => Promise<{size: number, etag: string|null, total: number}|undefined>} [reserveResume]
+ * @property {(request: string) => Promise<ResumeInfo|undefined>} [reserveResume]
  * Optional. Claims a request's partial download and reports it (size on disk, its etag, and expected total) so the
  * caller can continue it with an HTTP `Range`/`If-Range` request. Returns undefined when there is nothing to resume
  * or another writer holds the key, in which case the caller must issue an ordinary full request. Implementations that

--- a/packages/transformers/src/utils/cache.js
+++ b/packages/transformers/src/utils/cache.js
@@ -11,6 +11,9 @@ import { CrossOriginStorage } from './cache/CrossOriginStorageCache.js';
  * Adds a response to the cache.
  * @property {(request: string) => Promise<boolean>} [delete]
  * Deletes a request from the cache. Returns true if deleted, false otherwise.
+ * @property {(request: string) => Promise<{size: number, etag: string|null, total: number}|undefined>} [getResumeInfo]
+ * Optional. Reports a resumable partial download for a request (size on disk, its etag, and expected total),
+ * enabling the caller to continue an interrupted download via an HTTP `Range` request.
  */
 
 /**

--- a/packages/transformers/src/utils/cache.js
+++ b/packages/transformers/src/utils/cache.js
@@ -11,9 +11,14 @@ import { CrossOriginStorage } from './cache/CrossOriginStorageCache.js';
  * Adds a response to the cache.
  * @property {(request: string) => Promise<boolean>} [delete]
  * Deletes a request from the cache. Returns true if deleted, false otherwise.
- * @property {(request: string) => Promise<{size: number, etag: string|null, total: number}|undefined>} [getResumeInfo]
- * Optional. Reports a resumable partial download for a request (size on disk, its etag, and expected total),
- * enabling the caller to continue an interrupted download via an HTTP `Range` request.
+ * @property {(request: string) => Promise<{size: number, etag: string|null, total: number}|undefined>} [reserveResume]
+ * Optional. Claims a request's partial download and reports it (size on disk, its etag, and expected total) so the
+ * caller can continue it with an HTTP `Range`/`If-Range` request. Returns undefined when there is nothing to resume
+ * or another writer holds the key, in which case the caller must issue an ordinary full request. Implementations that
+ * provide this must also provide `releaseResume`, and callers must not send `Range` for a key they did not reserve.
+ * @property {(request: string) => Promise<void>} [releaseResume]
+ * Optional. Releases a reservation taken by `reserveResume` when the caller does not go on to `put` the response.
+ * A matching `put` releases the reservation itself. Releasing an absent reservation is a no-op.
  */
 
 /**

--- a/packages/transformers/src/utils/cache.js
+++ b/packages/transformers/src/utils/cache.js
@@ -23,7 +23,8 @@ import { CrossOriginStorage } from './cache/CrossOriginStorageCache.js';
  * @property {(request: string, response: Response, progress_callback?: (data: {progress: number, loaded: number, total: number}) => void) => Promise<void>} put
  * Adds a response to the cache.
  * @property {(request: string) => Promise<boolean>} [delete]
- * Deletes a request from the cache. Returns true if deleted, false otherwise.
+ * Deletes a request from the cache. Returns true if deleted, false otherwise. Implementations that support resuming
+ * must also discard any partial download held for the request, so a later call cannot resume onto deleted bytes.
  * @property {(request: string) => Promise<ResumeInfo|undefined>} [reserveResume]
  * Optional. Claims a request's partial download and reports it (size on disk, its etag, and expected total) so the
  * caller can continue it with an HTTP `Range`/`If-Range` request. Returns undefined when there is nothing to resume

--- a/packages/transformers/src/utils/cache/FileCache.js
+++ b/packages/transformers/src/utils/cache/FileCache.js
@@ -28,20 +28,29 @@ const LOCK_ABANDONED_MS = 60 * 60 * 1000;
  * Destroy a write stream and wait until its file descriptor is actually
  * released. Used on the error paths, where the stream is still open over a
  * partial or temp file that is about to be unlinked or handed to another
- * writer. A no-op when the stream is absent or already closed.
+ * writer.
+ *
+ * The early-out tests `closed`, not `destroyed`: `destroyed` is set
+ * synchronously when teardown *begins*, so a stream already destroyed by an
+ * auto-destroy on error can still be holding its descriptor. `closed` flips
+ * with the `close` event, which is emitted once the descriptor is gone.
  *
  * @param {import('node:fs').WriteStream | undefined} stream
  * @returns {Promise<void>}
  */
 function destroyStream(stream) {
-    if (!stream || stream.destroyed) {
+    if (!stream || stream.closed) {
         return Promise.resolve();
     }
     return new Promise((resolve) => {
-        // `close` fires once the fd is gone, whether the teardown itself
-        // succeeded or not — either way there is nothing further to wait for.
+        // `close` fires whether the teardown itself succeeded or not — either
+        // way there is nothing further to wait for.
         stream.once('close', resolve);
-        stream.destroy();
+        // An already-destroyed stream is mid-teardown; destroying it again is
+        // pointless, but its pending `close` is still worth waiting for.
+        if (!stream.destroyed) {
+            stream.destroy();
+        }
     });
 }
 
@@ -586,6 +595,12 @@ export class FileCache {
      * request resumes onto — reviving bytes the caller asked to delete — and a
      * lock sitting in the way of the next writer.
      *
+     * An in-flight download by another writer is left alone: its lock, partial
+     * and sidecar are that writer's working set, and removing them would let a
+     * third writer take the same key and write concurrently. The completed
+     * file is still removed in that case — it is the entry the caller asked to
+     * delete, and it is not what the other writer is holding.
+     *
      * @param {string} request
      * @returns {Promise<boolean>} A Promise that resolves to `true` if a cache
      * entry (the completed file or a partial download) was deleted, `false`
@@ -595,10 +610,12 @@ export class FileCache {
     async delete(request) {
         const filePath = path.join(this.path, request);
         const incompletePath = filePath + '.incomplete';
+        const lockPath = incompletePath + '.lock';
 
         // Drop our own reservation first, so the lock is removed by the writer
         // that owns it and its heartbeat stops — rather than unlinking a path a
-        // live timer would keep touching.
+        // live timer would keep touching. This also means the check below only
+        // ever considers a lock belonging to somebody else.
         await this.releaseResume(request);
 
         const unlink = (target) =>
@@ -607,11 +624,18 @@ export class FileCache {
                 () => false,
             );
 
+        // Absent, stale-with-a-dead-owner, or stamped by this process: all
+        // report abandoned, and are ours to clear. Anything else is a writer
+        // actively downloading right now.
+        if (!(await this.#isLockAbandoned(lockPath))) {
+            return unlink(filePath);
+        }
+
         const [fileDeleted, partialDeleted] = await Promise.all([
             unlink(filePath),
             unlink(incompletePath),
             unlink(incompletePath + '.json'),
-            unlink(incompletePath + '.lock'),
+            unlink(lockPath),
         ]);
 
         return fileDeleted || partialDeleted;

--- a/packages/transformers/src/utils/cache/FileCache.js
+++ b/packages/transformers/src/utils/cache/FileCache.js
@@ -8,9 +8,19 @@ import { apis } from '../../env.js';
 // Create a dedicated random instance for generating unique temporary file names
 const rng = new Random();
 
+// How long a `.incomplete.lock` may sit before another writer treats it as
+// stale (a previous run crashed without releasing it). Well above any realistic
+// single-chunk write, but low enough that a resume is not blocked forever.
+const LOCK_STALE_MS = 10 * 60 * 1000;
+
 /**
  * File system cache implementation that implements the CacheInterface.
  * Provides `match` and `put` methods compatible with the Web Cache API.
+ *
+ * Large downloads are streamed to a deterministic `<key>.incomplete` file with
+ * a small sidecar recording the server `ETag` and expected size. If a download
+ * is interrupted the partial is kept, so a later attempt can send a `Range`
+ * request (see `getResumeInfo`) and continue instead of starting from byte 0.
  */
 export class FileCache {
     /**
@@ -38,6 +48,36 @@ export class FileCache {
     }
 
     /**
+     * Report whether a resumable partial download exists for `request`.
+     * Returns `{ size, etag, total }` when a `.incomplete` file and its sidecar
+     * are present and internally consistent, otherwise `undefined`. Callers use
+     * this to send a `Range`/`If-Range` request and continue the download.
+     * @param {string} request
+     * @returns {Promise<{size: number, etag: string|null, total: number} | undefined>}
+     */
+    async getResumeInfo(request) {
+        const incompletePath = path.join(this.path, request) + '.incomplete';
+        const sidecarPath = incompletePath + '.json';
+        try {
+            const [stat, sidecarRaw] = await Promise.all([
+                fs.promises.stat(incompletePath),
+                fs.promises.readFile(sidecarPath, 'utf-8'),
+            ]);
+            const sidecar = JSON.parse(sidecarRaw);
+            const total = typeof sidecar.total === 'number' ? sidecar.total : 0;
+            // Only resume when there is something to resume and we have not
+            // somehow written past the expected size. Anything inconsistent
+            // falls through to a clean restart.
+            if (stat.size > 0 && (total === 0 || stat.size < total)) {
+                return { size: stat.size, etag: sidecar.etag ?? null, total };
+            }
+        } catch {
+            // No partial, no sidecar, or unreadable — nothing to resume.
+        }
+        return undefined;
+    }
+
+    /**
      * Adds the given response to the cache.
      * @param {string} request
      * @param {Response} response
@@ -47,21 +87,45 @@ export class FileCache {
      */
     async put(request, response, progress_callback = undefined) {
         const filePath = path.join(this.path, request);
+        await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
 
-        // Include both PID and a random suffix so that concurrent put() call within the same process
-        // (e.g., multiple pipelines loading the same file in parallel) each get their own temp file
-        // and don't corrupt each other's writes.
-        const id = apis.IS_PROCESS_AVAILABLE ? process.pid : Date.now();
-        const randomSuffix = rng._int32().toString(36);
-        const tmpPath = filePath + `.tmp.${id}.${randomSuffix}`;
+        const incompletePath = filePath + '.incomplete';
+        const sidecarPath = incompletePath + '.json';
+        const lockPath = incompletePath + '.lock';
+
+        // Claim the deterministic partial for this key. If another writer (this
+        // or another process) already holds it, fall back to the legacy
+        // random-suffix temp path: correct and non-resumable, but it never
+        // corrupts the shared partial — preserving the previous concurrency
+        // guarantee for parallel loads of the same file.
+        const locked = await this.#acquireLock(lockPath);
+        if (!locked) {
+            return this.#putUniqueTemp(filePath, response, progress_callback);
+        }
+
+        // A 206 (Partial Content) means the server honored our Range request and
+        // we append to the existing partial. Anything else (200) is a fresh
+        // download: discard any stale partial and start over.
+        const resuming = response.status === 206;
+        const total = this.#expectedTotal(response, resuming);
+
+        let loaded = 0;
+        if (resuming) {
+            try {
+                loaded = (await fs.promises.stat(incompletePath)).size;
+            } catch {
+                loaded = 0;
+            }
+        }
 
         try {
-            const contentLength = response.headers.get('Content-Length');
-            const total = parseInt(contentLength ?? '0');
-            let loaded = 0;
+            // Record the etag + expected total up front so an interrupted write
+            // still leaves a sidecar the next attempt can validate against.
+            await fs.promises.writeFile(sidecarPath, JSON.stringify({ etag: response.headers.get('etag'), total }));
 
-            await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
-            const fileStream = fs.createWriteStream(tmpPath);
+            const fileStream = fs.createWriteStream(incompletePath, {
+                flags: resuming ? 'a' : 'w',
+            });
             const reader = response.body.getReader();
 
             while (true) {
@@ -71,13 +135,7 @@ export class FileCache {
                 }
 
                 await new Promise((resolve, reject) => {
-                    fileStream.write(value, (err) => {
-                        if (err) {
-                            reject(err);
-                            return;
-                        }
-                        resolve();
-                    });
+                    fileStream.write(value, (err) => (err ? reject(err) : resolve()));
                 });
 
                 loaded += value.length;
@@ -90,16 +148,121 @@ export class FileCache {
                 fileStream.close((err) => (err ? reject(err) : resolve()));
             });
 
-            // Atomically move the completed temp file to the final path so that
-            // concurrent readers (other processes or other in-process calls)
-            // never observe a partially-written file.
+            // Guard against a truncated body: if we know the expected size and
+            // fell short, keep the partial so the next call can resume rather
+            // than promoting an incomplete file to the final path.
+            if (total && loaded < total) {
+                throw new Error(`Incomplete download for "${request}": got ${loaded} of ${total} bytes.`);
+            }
+
+            // Atomically publish the completed file and drop the sidecar.
+            await fs.promises.rename(incompletePath, filePath);
+            await fs.promises.unlink(sidecarPath).catch(() => {});
+        } catch (error) {
+            // Intentionally keep `.incomplete` + sidecar on failure so a later
+            // attempt can resume from here. Only the lock is released (finally).
+            throw error;
+        } finally {
+            await fs.promises.unlink(lockPath).catch(() => {});
+        }
+    }
+
+    /**
+     * Legacy write path: stream to a unique temp file and atomically rename.
+     * Used when the deterministic partial is already locked by a concurrent
+     * writer, so this call must not touch the shared `.incomplete` file.
+     * @param {string} filePath
+     * @param {Response} response
+     * @param {((data: {progress: number, loaded: number, total: number}) => void) | undefined} progress_callback
+     * @returns {Promise<void>}
+     */
+    async #putUniqueTemp(filePath, response, progress_callback) {
+        const id = apis.IS_PROCESS_AVAILABLE ? process.pid : Date.now();
+        const randomSuffix = rng._int32().toString(36);
+        const tmpPath = filePath + `.tmp.${id}.${randomSuffix}`;
+
+        try {
+            const total = parseInt(response.headers.get('Content-Length') ?? '0');
+            let loaded = 0;
+
+            const fileStream = fs.createWriteStream(tmpPath);
+            const reader = response.body.getReader();
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) {
+                    break;
+                }
+
+                await new Promise((resolve, reject) => {
+                    fileStream.write(value, (err) => (err ? reject(err) : resolve()));
+                });
+
+                loaded += value.length;
+                const progress = total ? (loaded / total) * 100 : 0;
+
+                progress_callback?.({ progress, loaded, total });
+            }
+
+            await new Promise((resolve, reject) => {
+                fileStream.close((err) => (err ? reject(err) : resolve()));
+            });
+
             await fs.promises.rename(tmpPath, filePath);
         } catch (error) {
-            // Clean up the temp file if an error occurred during download
             try {
                 await fs.promises.unlink(tmpPath);
             } catch {}
             throw error;
+        }
+    }
+
+    /**
+     * Total expected file size. For a 206 response it is read from the
+     * `Content-Range: bytes start-end/total` header; for a fresh 200 from
+     * `Content-Length`. Returns 0 when the size is unknown.
+     * @param {Response} response
+     * @param {boolean} resuming
+     * @returns {number}
+     */
+    #expectedTotal(response, resuming) {
+        if (resuming) {
+            const contentRange = response.headers.get('Content-Range');
+            const match = contentRange && /\/(\d+)\s*$/.exec(contentRange);
+            if (match) {
+                return parseInt(match[1], 10);
+            }
+        }
+        return parseInt(response.headers.get('Content-Length') ?? '0', 10) || 0;
+    }
+
+    /**
+     * Acquire the per-key write lock via an exclusive create (`wx`). If a lock
+     * already exists but is older than `LOCK_STALE_MS`, it is treated as
+     * abandoned by a crashed writer and stolen.
+     * @param {string} lockPath
+     * @returns {Promise<boolean>}
+     */
+    async #acquireLock(lockPath) {
+        try {
+            const fd = await fs.promises.open(lockPath, 'wx');
+            await fd.close();
+            return true;
+        } catch (e) {
+            if (e.code !== 'EEXIST') {
+                return false;
+            }
+            // Steal a stale lock left behind by a crashed process.
+            try {
+                const stat = await fs.promises.stat(lockPath);
+                if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+                    await fs.promises.unlink(lockPath).catch(() => {});
+                    const fd = await fs.promises.open(lockPath, 'wx');
+                    await fd.close();
+                    return true;
+                }
+            } catch {}
+            return false;
         }
     }
 

--- a/packages/transformers/src/utils/cache/FileCache.js
+++ b/packages/transformers/src/utils/cache/FileCache.js
@@ -25,6 +25,27 @@ const LOCK_STALE_MS = 5 * 60 * 1000;
 const LOCK_ABANDONED_MS = 60 * 60 * 1000;
 
 /**
+ * Destroy a write stream and wait until its file descriptor is actually
+ * released. Used on the error paths, where the stream is still open over a
+ * partial or temp file that is about to be unlinked or handed to another
+ * writer. A no-op when the stream is absent or already closed.
+ *
+ * @param {import('node:fs').WriteStream | undefined} stream
+ * @returns {Promise<void>}
+ */
+function destroyStream(stream) {
+    if (!stream || stream.destroyed) {
+        return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+        // `close` fires once the fd is gone, whether the teardown itself
+        // succeeded or not — either way there is nothing further to wait for.
+        stream.once('close', resolve);
+        stream.destroy();
+    });
+}
+
+/**
  * File system cache implementation that implements the CacheInterface.
  * Provides `match` and `put` methods compatible with the Web Cache API.
  *
@@ -192,6 +213,8 @@ export class FileCache {
             return this.#putUniqueTemp(filePath, response, progress_callback);
         }
 
+        /** @type {import('node:fs').WriteStream | undefined} */
+        let fileStream;
         try {
             let loaded = 0;
             let total;
@@ -217,9 +240,13 @@ export class FileCache {
                 await fs.promises.writeFile(sidecarPath, JSON.stringify({ etag: response.headers.get('etag'), total }));
             }
 
-            const fileStream = fs.createWriteStream(incompletePath, {
+            fileStream = fs.createWriteStream(incompletePath, {
                 flags: resuming ? 'a' : 'w',
             });
+            // Write failures are surfaced through the `write`/`close` callbacks
+            // below. Without a listener the same failure also reaches the
+            // process as an unhandled `error` event.
+            fileStream.on('error', () => {});
             const reader = response.body.getReader();
 
             while (true) {
@@ -238,14 +265,27 @@ export class FileCache {
                 progress_callback?.({ progress, loaded, total });
             }
 
+            const stream = fileStream;
             await new Promise((resolve, reject) => {
-                fileStream.close((err) => (err ? reject(err) : resolve()));
+                stream.close((err) => (err ? reject(err) : resolve()));
             });
+            // Closed cleanly, so `finally` has nothing left to tear down.
+            fileStream = undefined;
 
-            // Guard against a truncated body: if we know the expected size and
-            // fell short, keep the partial so the next call can resume rather
-            // than promoting an incomplete file to the final path.
-            if (total && loaded < total) {
+            // The body must match the size we were promised, exactly. Falling
+            // short keeps the partial so the next call can resume; an oversized
+            // body is a broken server or a changed file, and cannot be resumed
+            // onto (the partial now runs past `total`), so it is discarded and
+            // the next attempt starts clean. Neither case is ever published.
+            if (total && loaded !== total) {
+                if (loaded > total) {
+                    await fs.promises.unlink(incompletePath).catch(() => {});
+                    await fs.promises.unlink(sidecarPath).catch(() => {});
+                    throw new Error(
+                        `Oversized download for "${request}": got ${loaded} bytes but expected ${total}. ` +
+                            `Discarded the partial; retry from scratch.`,
+                    );
+                }
                 throw new Error(`Incomplete download for "${request}": got ${loaded} of ${total} bytes.`);
             }
 
@@ -253,6 +293,13 @@ export class FileCache {
             await fs.promises.rename(incompletePath, filePath);
             await fs.promises.unlink(sidecarPath).catch(() => {});
         } finally {
+            // A reader, writer, or progress-callback error leaves the stream
+            // open on the partial. Tear it down *before* the reservation is
+            // released, so the next writer — which may be another process
+            // taking this key the moment the lock disappears — never finds a
+            // file we are still holding open.
+            await destroyStream(fileStream);
+
             // `.incomplete` + sidecar are intentionally kept on failure so a
             // later attempt can resume from here. Only the lock is released.
             await this.releaseResume(request);
@@ -357,11 +404,14 @@ export class FileCache {
         const randomSuffix = rng._int32().toString(36);
         const tmpPath = filePath + `.tmp.${id}.${randomSuffix}`;
 
+        /** @type {import('node:fs').WriteStream | undefined} */
+        let fileStream;
         try {
             const total = parseInt(response.headers.get('Content-Length') ?? '0');
             let loaded = 0;
 
-            const fileStream = fs.createWriteStream(tmpPath);
+            fileStream = fs.createWriteStream(tmpPath);
+            fileStream.on('error', () => {});
             const reader = response.body.getReader();
 
             while (true) {
@@ -380,16 +430,28 @@ export class FileCache {
                 progress_callback?.({ progress, loaded, total });
             }
 
+            const stream = fileStream;
             await new Promise((resolve, reject) => {
-                fileStream.close((err) => (err ? reject(err) : resolve()));
+                stream.close((err) => (err ? reject(err) : resolve()));
             });
+            fileStream = undefined;
 
-            if (total && loaded < total) {
-                throw new Error(`Incomplete download for "${filePath}": got ${loaded} of ${total} bytes.`);
+            // This path renames onto the final file, so the body must match the
+            // declared size exactly — an oversized one is no safer to publish
+            // than a truncated one.
+            if (total && loaded !== total) {
+                throw new Error(
+                    loaded > total
+                        ? `Oversized download for "${filePath}": got ${loaded} bytes but expected ${total}.`
+                        : `Incomplete download for "${filePath}": got ${loaded} of ${total} bytes.`,
+                );
             }
 
             await fs.promises.rename(tmpPath, filePath);
         } catch (error) {
+            // Close the stream before unlinking: an open handle makes the
+            // removal fail outright on Windows and leaves the temp file behind.
+            await destroyStream(fileStream);
             try {
                 await fs.promises.unlink(tmpPath);
             } catch {}
@@ -516,20 +578,43 @@ export class FileCache {
     }
 
     /**
-     * Deletes the cache entry for the given request.
+     * Deletes the cache entry for the given request, including anything an
+     * interrupted resumable download left behind: the `.incomplete` partial,
+     * its sidecar, and the write lock.
+     *
+     * Removing only the completed file would leave a partial that a later
+     * request resumes onto — reviving bytes the caller asked to delete — and a
+     * lock sitting in the way of the next writer.
+     *
      * @param {string} request
-     * @returns {Promise<boolean>} A Promise that resolves to `true` if the cache entry was deleted, `false` otherwise.
+     * @returns {Promise<boolean>} A Promise that resolves to `true` if a cache
+     * entry (the completed file or a partial download) was deleted, `false`
+     * otherwise. A leftover sidecar or lock is cleaned up either way, but on
+     * its own does not count as an entry.
      */
     async delete(request) {
-        let filePath = path.join(this.path, request);
+        const filePath = path.join(this.path, request);
+        const incompletePath = filePath + '.incomplete';
 
-        try {
-            await fs.promises.unlink(filePath);
-            return true;
-        } catch (error) {
-            // File doesn't exist or couldn't be deleted
-            return false;
-        }
+        // Drop our own reservation first, so the lock is removed by the writer
+        // that owns it and its heartbeat stops — rather than unlinking a path a
+        // live timer would keep touching.
+        await this.releaseResume(request);
+
+        const unlink = (target) =>
+            fs.promises.unlink(target).then(
+                () => true,
+                () => false,
+            );
+
+        const [fileDeleted, partialDeleted] = await Promise.all([
+            unlink(filePath),
+            unlink(incompletePath),
+            unlink(incompletePath + '.json'),
+            unlink(incompletePath + '.lock'),
+        ]);
+
+        return fileDeleted || partialDeleted;
     }
 
     // TODO add the rest?

--- a/packages/transformers/src/utils/cache/FileCache.js
+++ b/packages/transformers/src/utils/cache/FileCache.js
@@ -85,7 +85,7 @@ export class FileCache {
      * `releaseResume` if the caller abandons the download.
      *
      * @param {string} request
-     * @returns {Promise<{size: number, etag: string|null, total: number} | undefined>}
+     * @returns {Promise<import('../cache.js').ResumeInfo | undefined>}
      */
     async reserveResume(request) {
         const incompletePath = path.join(this.path, request) + '.incomplete';

--- a/packages/transformers/src/utils/cache/FileCache.js
+++ b/packages/transformers/src/utils/cache/FileCache.js
@@ -8,10 +8,21 @@ import { apis } from '../../env.js';
 // Create a dedicated random instance for generating unique temporary file names
 const rng = new Random();
 
-// How long a `.incomplete.lock` may sit before another writer treats it as
-// stale (a previous run crashed without releasing it). Well above any realistic
-// single-chunk write, but low enough that a resume is not blocked forever.
-const LOCK_STALE_MS = 10 * 60 * 1000;
+// Distinguishes this process from any other lock holder. A pid alone is not
+// enough: on a shared/network cache directory the same pid can exist on a
+// different machine, and we must not read that as "our own writer is alive".
+const INSTANCE_ID = rng._int32().toString(36);
+
+// A live writer refreshes its lock on this interval, so a lock that has not
+// been touched for `LOCK_STALE_MS` belongs to a writer that is gone — not to a
+// slow download. The heartbeat is what makes the staleness check safe.
+const LOCK_HEARTBEAT_MS = 30 * 1000;
+const LOCK_STALE_MS = 5 * 60 * 1000;
+
+// Absolute ceiling. Reached only when the lock looks stale but its owner claims
+// a pid that still resolves, which on a shared cache directory may be an
+// unrelated process on another host. Prevents a permanent deadlock.
+const LOCK_ABANDONED_MS = 60 * 60 * 1000;
 
 /**
  * File system cache implementation that implements the CacheInterface.
@@ -20,9 +31,21 @@ const LOCK_STALE_MS = 10 * 60 * 1000;
  * Large downloads are streamed to a deterministic `<key>.incomplete` file with
  * a small sidecar recording the server `ETag` and expected size. If a download
  * is interrupted the partial is kept, so a later attempt can send a `Range`
- * request (see `getResumeInfo`) and continue instead of starting from byte 0.
+ * request and continue instead of starting from byte 0.
+ *
+ * Resuming is coordinated by a per-key lock that is taken *before* the request
+ * is issued (see `reserveResume`). A caller may only send `Range` for a key it
+ * has reserved, which means a partial response can never reach a writer that
+ * does not own the corresponding partial file.
  */
 export class FileCache {
+    /**
+     * Locks held by this instance, keyed by request. Populated by
+     * `reserveResume` and consumed by `put`/`releaseResume`.
+     * @type {Map<string, {lockPath: string, timer: any}>}
+     */
+    #reservations = new Map();
+
     /**
      * Instantiate a `FileCache` object.
      * @param {string} path
@@ -48,16 +71,27 @@ export class FileCache {
     }
 
     /**
-     * Report whether a resumable partial download exists for `request`.
-     * Returns `{ size, etag, total }` when a `.incomplete` file and its sidecar
-     * are present and internally consistent, otherwise `undefined`. Callers use
-     * this to send a `Range`/`If-Range` request and continue the download.
+     * Reserve a resumable partial download for `request`.
+     *
+     * Takes the per-key write lock and, only if a consistent partial exists,
+     * reports `{ size, etag, total }` so the caller can continue the download
+     * with a `Range`/`If-Range` request. Returns `undefined` when there is
+     * nothing to resume or another writer holds the key, in which case the
+     * caller must perform an ordinary full request.
+     *
+     * Taking the lock here (rather than in `put`) is what guarantees a `206`
+     * is only ever produced by the writer that owns the partial it continues.
+     * A successful reservation is released by the matching `put`, or by
+     * `releaseResume` if the caller abandons the download.
+     *
      * @param {string} request
      * @returns {Promise<{size: number, etag: string|null, total: number} | undefined>}
      */
-    async getResumeInfo(request) {
+    async reserveResume(request) {
         const incompletePath = path.join(this.path, request) + '.incomplete';
         const sidecarPath = incompletePath + '.json';
+
+        let info;
         try {
             const [stat, sidecarRaw] = await Promise.all([
                 fs.promises.stat(incompletePath),
@@ -68,17 +102,62 @@ export class FileCache {
             // Only resume when there is something to resume and we have not
             // somehow written past the expected size. Anything inconsistent
             // falls through to a clean restart.
-            if (stat.size > 0 && (total === 0 || stat.size < total)) {
-                return { size: stat.size, etag: sidecar.etag ?? null, total };
+            if (stat.size > 0 && total > 0 && stat.size < total) {
+                info = { size: stat.size, etag: sidecar.etag ?? null, total };
             }
         } catch {
             // No partial, no sidecar, or unreadable — nothing to resume.
         }
-        return undefined;
+        if (!info) {
+            return undefined;
+        }
+
+        // Only claim the lock once we know a resume is actually possible, so a
+        // pointless reservation never blocks another writer.
+        if (!(await this.#acquireLock(request))) {
+            return undefined;
+        }
+
+        // Re-check under the lock: another writer may have completed or reset
+        // the partial between the stat above and the lock being granted.
+        try {
+            const stat = await fs.promises.stat(incompletePath);
+            if (stat.size !== info.size) {
+                await this.releaseResume(request);
+                return undefined;
+            }
+        } catch {
+            await this.releaseResume(request);
+            return undefined;
+        }
+
+        return info;
+    }
+
+    /**
+     * Release a reservation taken by `reserveResume` without writing anything.
+     * Safe to call when no reservation is held.
+     * @param {string} request
+     * @returns {Promise<void>}
+     */
+    async releaseResume(request) {
+        const reservation = this.#reservations.get(request);
+        if (!reservation) {
+            return;
+        }
+        this.#reservations.delete(request);
+        clearInterval(reservation.timer);
+        await fs.promises.unlink(reservation.lockPath).catch(() => {});
     }
 
     /**
      * Adds the given response to the cache.
+     *
+     * A `206 Partial Content` response is only accepted when this instance
+     * holds a reservation for `request` (see `reserveResume`) and the
+     * `Content-Range` header lines up exactly with the partial on disk;
+     * otherwise the write is refused rather than risking a corrupt entry.
+     *
      * @param {string} request
      * @param {Response} response
      * @param {(data: {progress: number, loaded: number, total: number}) => void} [progress_callback] Optional.
@@ -91,37 +170,52 @@ export class FileCache {
 
         const incompletePath = filePath + '.incomplete';
         const sidecarPath = incompletePath + '.json';
-        const lockPath = incompletePath + '.lock';
+        const resuming = response.status === 206;
 
-        // Claim the deterministic partial for this key. If another writer (this
-        // or another process) already holds it, fall back to the legacy
-        // random-suffix temp path: correct and non-resumable, but it never
-        // corrupts the shared partial — preserving the previous concurrency
+        // A partial response is only meaningful to the writer that owns the
+        // partial it continues. Without a reservation we have no such partial,
+        // so writing this body anywhere would publish a fragment as a whole
+        // file. Refuse instead — the caller must retry without `Range`.
+        const reserved = this.#reservations.has(request);
+        if (resuming && !reserved) {
+            throw new Error(
+                `Refusing to cache a partial (206) response for "${request}" without a resume reservation. ` +
+                    `Retry the request without a \`Range\` header.`,
+            );
+        }
+
+        // Not resuming and no reservation: fall back to the legacy
+        // random-suffix temp path. Correct and non-resumable, but it never
+        // touches the shared partial — preserving the previous concurrency
         // guarantee for parallel loads of the same file.
-        const locked = await this.#acquireLock(lockPath);
-        if (!locked) {
+        if (!reserved && !(await this.#acquireLock(request))) {
             return this.#putUniqueTemp(filePath, response, progress_callback);
         }
 
-        // A 206 (Partial Content) means the server honored our Range request and
-        // we append to the existing partial. Anything else (200) is a fresh
-        // download: discard any stale partial and start over.
-        const resuming = response.status === 206;
-        const total = this.#expectedTotal(response, resuming);
-
-        let loaded = 0;
-        if (resuming) {
-            try {
-                loaded = (await fs.promises.stat(incompletePath)).size;
-            } catch {
-                loaded = 0;
-            }
-        }
-
         try {
+            let loaded = 0;
+            let total;
+
+            if (resuming) {
+                const partialSize = await fs.promises.stat(incompletePath).then(
+                    (s) => s.size,
+                    () => 0,
+                );
+                const range = await this.#validateContentRange(response, request, partialSize, sidecarPath);
+                loaded = range.start;
+                total = range.total;
+            } else {
+                // A fresh download supersedes any partial we were holding.
+                total = parseInt(response.headers.get('Content-Length') ?? '0', 10) || 0;
+            }
+
             // Record the etag + expected total up front so an interrupted write
-            // still leaves a sidecar the next attempt can validate against.
-            await fs.promises.writeFile(sidecarPath, JSON.stringify({ etag: response.headers.get('etag'), total }));
+            // still leaves a sidecar the next attempt can validate against. On a
+            // 206 the validator is the one we resumed against, not the (absent)
+            // ETag of the partial response.
+            if (!resuming) {
+                await fs.promises.writeFile(sidecarPath, JSON.stringify({ etag: response.headers.get('etag'), total }));
+            }
 
             const fileStream = fs.createWriteStream(incompletePath, {
                 flags: resuming ? 'a' : 'w',
@@ -158,13 +252,85 @@ export class FileCache {
             // Atomically publish the completed file and drop the sidecar.
             await fs.promises.rename(incompletePath, filePath);
             await fs.promises.unlink(sidecarPath).catch(() => {});
-        } catch (error) {
-            // Intentionally keep `.incomplete` + sidecar on failure so a later
-            // attempt can resume from here. Only the lock is released (finally).
-            throw error;
         } finally {
-            await fs.promises.unlink(lockPath).catch(() => {});
+            // `.incomplete` + sidecar are intentionally kept on failure so a
+            // later attempt can resume from here. Only the lock is released.
+            await this.releaseResume(request);
         }
+    }
+
+    /**
+     * Validate a `206` response against the partial on disk.
+     *
+     * Every component of `Content-Range: bytes <start>-<end>/<total>` is
+     * checked: the range must begin exactly where the partial ends (no gap and
+     * no overlap), its length must agree with `Content-Length`, and its total
+     * must match what the sidecar recorded. Unsatisfied (`bytes *`/`<total>`)
+     * and suffix (`bytes -500/1234`) forms are rejected outright — neither can
+     * be appended safely.
+     *
+     * A mismatch means our assumptions about the partial no longer hold, so it
+     * is discarded and the caller restarts from byte 0 rather than resuming
+     * onto data that may belong to a different revision of the file.
+     *
+     * @param {Response} response
+     * @param {string} request
+     * @param {number} partialSize
+     * @param {string} sidecarPath
+     * @returns {Promise<{start: number, end: number, total: number}>}
+     */
+    async #validateContentRange(response, request, partialSize, sidecarPath) {
+        const raw = response.headers.get('Content-Range');
+        const match = /^\s*bytes\s+(\d+)-(\d+)\/(\d+)\s*$/.exec(raw ?? '');
+
+        const reject = async (reason) => {
+            const incompletePath = sidecarPath.replace(/\.json$/, '');
+            await fs.promises.unlink(incompletePath).catch(() => {});
+            await fs.promises.unlink(sidecarPath).catch(() => {});
+            return new Error(`Cannot resume "${request}": ${reason}. Discarded the partial; retry from scratch.`);
+        };
+
+        if (!match) {
+            throw await reject(`unusable Content-Range "${raw ?? '<missing>'}"`);
+        }
+
+        const start = parseInt(match[1], 10);
+        const end = parseInt(match[2], 10);
+        const total = parseInt(match[3], 10);
+
+        if (end < start || end >= total) {
+            throw await reject(`inconsistent Content-Range "${raw}"`);
+        }
+        if (start !== partialSize) {
+            throw await reject(
+                `server resumed at byte ${start} but the partial holds ${partialSize} bytes ` +
+                    `(${start > partialSize ? 'gap' : 'overlap'})`,
+            );
+        }
+
+        const contentLength = response.headers.get('Content-Length');
+        if (contentLength !== null) {
+            const expected = end - start + 1;
+            const declared = parseInt(contentLength, 10);
+            if (declared !== expected) {
+                throw await reject(`Content-Length ${declared} does not match Content-Range span ${expected}`);
+            }
+        }
+
+        try {
+            const sidecar = JSON.parse(await fs.promises.readFile(sidecarPath, 'utf-8'));
+            if (typeof sidecar.total === 'number' && sidecar.total > 0 && sidecar.total !== total) {
+                throw await reject(`total size changed from ${sidecar.total} to ${total}`);
+            }
+        } catch (e) {
+            if (e instanceof Error && e.message.startsWith('Cannot resume')) {
+                throw e;
+            }
+            // An unreadable sidecar is not fatal: the Content-Range checks above
+            // already pin the append to the right offset.
+        }
+
+        return { start, end, total };
     }
 
     /**
@@ -177,6 +343,16 @@ export class FileCache {
      * @returns {Promise<void>}
      */
     async #putUniqueTemp(filePath, response, progress_callback) {
+        // This path renames whatever it writes onto the final file, so it must
+        // only ever see a complete body. A partial response reaching here would
+        // publish a fragment as the whole file.
+        if (response.status !== 200) {
+            throw new Error(
+                `Refusing to cache a ${response.status} response as a complete file for "${filePath}". ` +
+                    `Only a full 200 response can be written by the fallback path.`,
+            );
+        }
+
         const id = apis.IS_PROCESS_AVAILABLE ? process.pid : Date.now();
         const randomSuffix = rng._int32().toString(36);
         const tmpPath = filePath + `.tmp.${id}.${randomSuffix}`;
@@ -208,6 +384,10 @@ export class FileCache {
                 fileStream.close((err) => (err ? reject(err) : resolve()));
             });
 
+            if (total && loaded < total) {
+                throw new Error(`Incomplete download for "${filePath}": got ${loaded} of ${total} bytes.`);
+            }
+
             await fs.promises.rename(tmpPath, filePath);
         } catch (error) {
             try {
@@ -218,51 +398,120 @@ export class FileCache {
     }
 
     /**
-     * Total expected file size. For a 206 response it is read from the
-     * `Content-Range: bytes start-end/total` header; for a fresh 200 from
-     * `Content-Length`. Returns 0 when the size is unknown.
-     * @param {Response} response
-     * @param {boolean} resuming
-     * @returns {number}
+     * Acquire the per-key write lock via an exclusive create (`wx`), recording
+     * the owner so its liveness can be checked later. While held, the lock is
+     * refreshed on an interval — an untouched lock therefore means an absent
+     * writer, never a slow one.
+     *
+     * An existing lock is only taken over when it has gone stale *and* its
+     * owner is demonstrably gone, or when it has sat untouched long enough that
+     * it must be treated as abandoned regardless.
+     *
+     * @param {string} request
+     * @returns {Promise<boolean>}
      */
-    #expectedTotal(response, resuming) {
-        if (resuming) {
-            const contentRange = response.headers.get('Content-Range');
-            const match = contentRange && /\/(\d+)\s*$/.exec(contentRange);
-            if (match) {
-                return parseInt(match[1], 10);
+    async #acquireLock(request) {
+        const lockPath = path.join(this.path, request) + '.incomplete.lock';
+
+        if (!(await this.#writeLockFile(lockPath))) {
+            if (!(await this.#isLockAbandoned(lockPath))) {
+                return false;
+            }
+            await fs.promises.unlink(lockPath).catch(() => {});
+            if (!(await this.#writeLockFile(lockPath))) {
+                // Another writer won the race for the abandoned lock.
+                return false;
             }
         }
-        return parseInt(response.headers.get('Content-Length') ?? '0', 10) || 0;
+
+        // Keep the lock warm for as long as we hold it, so other writers can
+        // tell an in-progress download from a crashed one.
+        const timer = setInterval(() => {
+            const now = new Date();
+            fs.promises.utimes(lockPath, now, now).catch(() => {});
+        }, LOCK_HEARTBEAT_MS);
+        timer.unref?.();
+
+        this.#reservations.set(request, { lockPath, timer });
+        return true;
     }
 
     /**
-     * Acquire the per-key write lock via an exclusive create (`wx`). If a lock
-     * already exists but is older than `LOCK_STALE_MS`, it is treated as
-     * abandoned by a crashed writer and stolen.
+     * Exclusively create `lockPath` and stamp it with this writer's identity.
+     * @param {string} lockPath
+     * @returns {Promise<boolean>} Whether the lock was created.
+     */
+    async #writeLockFile(lockPath) {
+        try {
+            const handle = await fs.promises.open(lockPath, 'wx');
+            try {
+                await handle.writeFile(
+                    JSON.stringify({
+                        instance: INSTANCE_ID,
+                        pid: apis.IS_PROCESS_AVAILABLE ? process.pid : null,
+                        startedAt: Date.now(),
+                    }),
+                );
+            } finally {
+                await handle.close();
+            }
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Whether an existing lock may be taken over. True only when the lock has
+     * not been refreshed for `LOCK_STALE_MS` and its owning process is gone, or
+     * when it has sat untouched for `LOCK_ABANDONED_MS` and must be reclaimed
+     * to avoid deadlocking on an owner we cannot verify.
      * @param {string} lockPath
      * @returns {Promise<boolean>}
      */
-    async #acquireLock(lockPath) {
+    async #isLockAbandoned(lockPath) {
+        let age;
         try {
-            const fd = await fs.promises.open(lockPath, 'wx');
-            await fd.close();
+            age = Date.now() - (await fs.promises.stat(lockPath)).mtimeMs;
+        } catch {
+            // The lock vanished — treat it as gone so the caller retries.
             return true;
-        } catch (e) {
-            if (e.code !== 'EEXIST') {
-                return false;
-            }
-            // Steal a stale lock left behind by a crashed process.
-            try {
-                const stat = await fs.promises.stat(lockPath);
-                if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-                    await fs.promises.unlink(lockPath).catch(() => {});
-                    const fd = await fs.promises.open(lockPath, 'wx');
-                    await fd.close();
-                    return true;
-                }
-            } catch {}
+        }
+
+        if (age < LOCK_STALE_MS) {
+            // Refreshed recently: a writer is actively downloading. Leave it be.
             return false;
+        }
+        if (age >= LOCK_ABANDONED_MS) {
+            return true;
+        }
+
+        let owner;
+        try {
+            owner = JSON.parse(await fs.promises.readFile(lockPath, 'utf-8'));
+        } catch {
+            // Unreadable or truncated (e.g. a writer died mid-create): stale.
+            return true;
+        }
+
+        // A lock stamped by this process but no longer tracked belongs to a
+        // reservation we already released; reclaiming it is safe.
+        if (owner?.instance === INSTANCE_ID) {
+            return true;
+        }
+        if (!apis.IS_PROCESS_AVAILABLE || typeof owner?.pid !== 'number') {
+            return true;
+        }
+
+        try {
+            // Signal 0 performs the permission/existence check without sending.
+            process.kill(owner.pid, 0);
+            // The pid resolves, but on a shared cache directory it may belong to
+            // an unrelated process on another host. Wait for the hard ceiling.
+            return false;
+        } catch (e) {
+            // ESRCH: no such process. EPERM: alive but owned by another user.
+            return e?.code === 'ESRCH';
         }
     }
 

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -276,6 +276,12 @@ export async function loadResourceFile(
     // Whether to cache the final response in the end.
     let toCacheResponse = false;
 
+    // Cache key whose partial we hold a resume reservation for, if any. The
+    // matching `put` releases it; every path that skips the write must release
+    // it explicitly so the key is not blocked for the next writer.
+    /** @type {string|undefined} */
+    let reservedKey;
+
     /** @type {Response|import('./hub/FileResponse.js').FileResponse|undefined|string} */
     let response;
 
@@ -342,22 +348,41 @@ export async function loadResourceFile(
             // partial for this key. This only applies to the streaming path
             // (`IS_NODE_ENV && return_path`), where the body is written straight to
             // disk; on the buffered path a 206 would yield only the trailing bytes.
-            // `Range` asks the CDN to continue from the last byte we have; `If-Range`
-            // makes the server fall back to a full 200 if the file changed upstream.
+            //
+            // The reservation claims the partial before the request goes out, so a
+            // `Range` is only ever sent by the writer that owns the bytes it
+            // continues. If the key is already being written, or there is nothing to
+            // resume, we fall through to an ordinary full download.
             let resumeHeaders;
-            if (apis.IS_NODE_ENV && return_path && cache && typeof cache.getResumeInfo === 'function') {
-                const resume = await cache.getResumeInfo(proposedCacheKey);
-                if (resume && resume.size > 0) {
-                    resumeHeaders = { Range: `bytes=${resume.size}-` };
+            if (apis.IS_NODE_ENV && return_path && cache && typeof cache.reserveResume === 'function') {
+                const resume = await cache.reserveResume(proposedCacheKey);
+                if (resume) {
+                    reservedKey = proposedCacheKey;
+                    // Never resume without a validator: a bare `Range` lets the
+                    // server serve bytes from a revision we did not start with,
+                    // splicing two versions into one file. `If-Range` makes the
+                    // server return a full 200 instead if the file changed, and
+                    // without an ETag to pin we restart from byte 0 outright.
                     if (resume.etag) {
-                        resumeHeaders['If-Range'] = resume.etag;
+                        resumeHeaders = {
+                            Range: `bytes=${resume.size}-`,
+                            'If-Range': resume.etag,
+                        };
                     }
                 }
             }
-            response = await getFile(remoteURL, resumeHeaders);
+
+            try {
+                response = await getFile(remoteURL, resumeHeaders);
+            } catch (e) {
+                // Nothing was written; hand the key back to the next writer.
+                if (reservedKey !== undefined) await cache.releaseResume(reservedKey);
+                throw e;
+            }
 
             // 200 (full download) and 206 (resumed partial) are both success.
             if (response.status !== 200 && response.status !== 206) {
+                if (reservedKey !== undefined) await cache.releaseResume(reservedKey);
                 return handleError(response.status, remoteURL, fatal);
             }
 
@@ -448,14 +473,22 @@ export async function loadResourceFile(
         result = buffer;
     }
 
-    if (
-        // Only cache web responses
-        // i.e., do not cache FileResponses (prevents duplication)
-        toCacheResponse &&
-        cacheKey &&
-        typeof response !== 'string'
-    ) {
-        await storeCachedResource(path_or_repo_id, filename, cache, cacheKey, response, result, options);
+    try {
+        if (
+            // Only cache web responses
+            // i.e., do not cache FileResponses (prevents duplication)
+            toCacheResponse &&
+            cacheKey &&
+            typeof response !== 'string'
+        ) {
+            await storeCachedResource(path_or_repo_id, filename, cache, cacheKey, response, result, options);
+        }
+    } finally {
+        // `put` releases the reservation itself, but it is skipped whenever the
+        // response is not cached — including when another writer finished the
+        // file while this one was downloading. Releasing here covers those
+        // paths; it is a no-op once the reservation is already gone.
+        if (reservedKey !== undefined) await cache.releaseResume(reservedKey);
     }
 
     // In Node.js with return_path, the buffer read is skipped so no progress

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -62,9 +62,11 @@ export { MAX_EXTERNAL_DATA_CHUNKS } from './hub/constants.js';
  * Helper function to get a file, using either the Fetch API or FileSystem API.
  *
  * @param {URL|string} urlOrPath The URL/path of the file to get.
+ * @param {Record<string, string>} [extraHeaders] Additional request headers to merge
+ * on top of the default fetch headers (e.g. `Range`/`If-Range` for resuming a download).
  * @returns {Promise<FileResponse|Response>} A promise that resolves to a FileResponse object (if the file is retrieved using the FileSystem API), or a Response object (if the file is retrieved using the Fetch API).
  */
-export async function getFile(urlOrPath) {
+export async function getFile(urlOrPath, extraHeaders = undefined) {
     if (env.useFS && !isValidUrl(urlOrPath, ['http:', 'https:', 'blob:'])) {
         return new FileResponse(
             urlOrPath instanceof URL
@@ -74,9 +76,13 @@ export async function getFile(urlOrPath) {
                 : urlOrPath,
         );
     } else {
-        return env.fetch(urlOrPath, {
-            headers: getFetchHeaders(urlOrPath),
-        });
+        const headers = getFetchHeaders(urlOrPath);
+        if (extraHeaders) {
+            for (const [key, value] of Object.entries(extraHeaders)) {
+                headers.set(key, value);
+            }
+        }
+        return env.fetch(urlOrPath, { headers });
     }
 }
 
@@ -330,10 +336,28 @@ export async function loadResourceFile(
                 );
             }
 
-            // File not found locally, so we try to download it from the remote server
-            response = await getFile(remoteURL);
+            // File not found locally, so we try to download it from the remote server.
+            //
+            // Resume an interrupted download when the Node file cache still holds a
+            // partial for this key. This only applies to the streaming path
+            // (`IS_NODE_ENV && return_path`), where the body is written straight to
+            // disk; on the buffered path a 206 would yield only the trailing bytes.
+            // `Range` asks the CDN to continue from the last byte we have; `If-Range`
+            // makes the server fall back to a full 200 if the file changed upstream.
+            let resumeHeaders;
+            if (apis.IS_NODE_ENV && return_path && cache && typeof cache.getResumeInfo === 'function') {
+                const resume = await cache.getResumeInfo(proposedCacheKey);
+                if (resume && resume.size > 0) {
+                    resumeHeaders = { Range: `bytes=${resume.size}-` };
+                    if (resume.etag) {
+                        resumeHeaders['If-Range'] = resume.etag;
+                    }
+                }
+            }
+            response = await getFile(remoteURL, resumeHeaders);
 
-            if (response.status !== 200) {
+            // 200 (full download) and 206 (resumed partial) are both success.
+            if (response.status !== 200 && response.status !== 206) {
                 return handleError(response.status, remoteURL, fatal);
             }
 
@@ -346,7 +370,7 @@ export async function loadResourceFile(
             cache && // 1. A caching system is available
             typeof Response !== 'undefined' && // 2. `Response` is defined (i.e., we are in a browser-like environment)
             response instanceof Response && // 3. result is a `Response` object (i.e., not a `FileResponse`)
-            response.status === 200; // 4. request was successful (status code 200)
+            (response.status === 200 || response.status === 206); // 4. request was successful (200 full, or 206 resumed)
     }
 
     // Start downloading

--- a/packages/transformers/tests/utils/file_cache.test.js
+++ b/packages/transformers/tests/utils/file_cache.test.js
@@ -1,4 +1,6 @@
+import { jest } from "@jest/globals";
 import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -397,6 +399,61 @@ describe("FileCache resumable downloads", () => {
       expect(fs.existsSync(p(key))).toBe(false);
     });
 
+    it("waits for a stream that is already mid-teardown", async () => {
+      const key = "mid-teardown.onnx";
+
+      // A stream whose teardown is slow enough to observe. A real fs stream
+      // closes its descriptor within the very next event-loop turn, so the
+      // gap this guards is invisible against one — the `destroyed`-vs-`closed`
+      // distinction is real but only shows up under load.
+      const CLOSE_MS = 250;
+      const events = new EventEmitter();
+      const stream = {
+        destroyed: false,
+        closed: false,
+        on: (...args) => (events.on(...args), stream),
+        once: (...args) => (events.once(...args), stream),
+        write: (_chunk, cb) => (cb(null), true),
+        close: (cb) => {
+          stream.destroy();
+          events.once("close", () => cb(null));
+        },
+        destroy: () => {
+          if (!stream.destroyed) {
+            stream.destroyed = true;
+            // `destroyed` flips now; the descriptor is only released later.
+            setTimeout(() => {
+              stream.closed = true;
+              events.emit("close");
+            }, CLOSE_MS);
+          }
+          return stream;
+        },
+      };
+
+      const spy = jest.spyOn(fs, "createWriteStream").mockImplementation(() => stream);
+      try {
+        const response = streamingResponse([bytes("0123"), bytes("456789")], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } });
+
+        await expect(
+          cache.put(key, response, () => {
+            stream.destroy();
+            expect(stream.destroyed).toBe(true);
+            expect(stream.closed).toBe(false);
+            throw new Error("callback blew up");
+          }),
+        ).rejects.toThrow(/callback blew up/);
+      } finally {
+        spy.mockRestore();
+      }
+
+      // `put` must not have returned while the descriptor was still open:
+      // the moment it does, the lock is gone and the next writer may open the
+      // same partial.
+      expect(stream.closed).toBe(true);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+    });
+
     it("cleans up the temp file when the fallback path fails", async () => {
       const key = "fallback-error.onnx";
       seedPartial(key, "0123", { etag: '"v1"', total: 10 });
@@ -461,10 +518,60 @@ describe("FileCache resumable downloads", () => {
       // `clear_cache` falls back to a second key when `delete` returns false,
       // so a stray lock must not masquerade as a real entry...
       const key = "lock-only.onnx";
-      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 0);
+      seedLock(key, { instance: "other", pid: await deadPid(), startedAt: Date.now() }, 10 * 60 * 1000);
 
       expect(await cache.delete(key)).toBe(false);
       // ...but it is still swept up.
+      expect(fs.readdirSync(dir)).toEqual([]);
+    });
+
+    it("leaves an active writer's lock, partial and sidecar alone", async () => {
+      const key = "in-flight.onnx";
+      fs.writeFileSync(p(key), "an older copy");
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      // Freshly refreshed by a live owner: somebody is downloading right now.
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 0);
+
+      // The completed file is what the caller asked to delete, so it goes...
+      expect(await cache.delete(key)).toBe(true);
+      expect(fs.existsSync(p(key))).toBe(false);
+
+      // ...but taking the lock away would let a third writer acquire the same
+      // key and write concurrently with the one already streaming into it.
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(true);
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+      expect(fs.existsSync(p(key + ".incomplete.json"))).toBe(true);
+
+      // And the key is still not available to anyone else.
+      expect(await cache.reserveResume(key)).toBeUndefined();
+    });
+
+    it("clears a stale writer's artifacts once its owner is gone", async () => {
+      const key = "crashed.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      seedLock(key, { instance: "other", pid: await deadPid(), startedAt: Date.now() }, 10 * 60 * 1000);
+
+      expect(await cache.delete(key)).toBe(true);
+      expect(fs.readdirSync(dir)).toEqual([]);
+    });
+
+    it("clears a lock this instance stamped but no longer tracks", async () => {
+      const key = "our-stale.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+
+      // Let the cache stamp a lock with its own instance id, then put it back
+      // on disk untracked and aged — what a crashed reservation of ours looks
+      // like. Its pid is alive (it is us), so only the instance check can tell
+      // that reclaiming it is safe.
+      expect(await cache.reserveResume(key)).toBeDefined();
+      const lockPath = p(key + ".incomplete.lock");
+      const stamped = fs.readFileSync(lockPath, "utf-8");
+      await cache.releaseResume(key);
+      fs.writeFileSync(lockPath, stamped);
+      const when = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(lockPath, when, when);
+
+      expect(await cache.delete(key)).toBe(true);
       expect(fs.readdirSync(dir)).toEqual([]);
     });
   });

--- a/packages/transformers/tests/utils/file_cache.test.js
+++ b/packages/transformers/tests/utils/file_cache.test.js
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { FileCache } from "../../src/utils/cache/FileCache.js";
+
+/**
+ * Build a streaming `Response` from an array of `Uint8Array` chunks.
+ * @param {Uint8Array[]} chunks
+ * @param {{status?: number, headers?: Record<string,string>}} [init]
+ */
+function streamingResponse(chunks, { status = 200, headers = {} } = {}) {
+  let i = 0;
+  const body = new ReadableStream({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(chunks[i++]);
+    },
+  });
+  return new Response(body, { status, headers });
+}
+
+const bytes = (str) => new TextEncoder().encode(str);
+
+describe("FileCache resumable downloads", () => {
+  let dir;
+  let cache;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "tjs-filecache-"));
+    cache = new FileCache(dir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("getResumeInfo returns undefined when there is no partial", async () => {
+    expect(await cache.getResumeInfo("model.onnx")).toBeUndefined();
+  });
+
+  it("writes a full 200 response and leaves no partial artifacts", async () => {
+    const content = "hello world";
+    await cache.put(
+      "model.onnx",
+      streamingResponse([bytes(content)], {
+        status: 200,
+        headers: { "Content-Length": String(content.length), etag: '"abc"' },
+      }),
+    );
+
+    expect(fs.readFileSync(path.join(dir, "model.onnx"), "utf-8")).toBe(content);
+    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete.json"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete.lock"))).toBe(false);
+  });
+
+  it("keeps the partial and sidecar when the body is truncated", async () => {
+    const key = "big.onnx";
+    // Server promises 10 bytes but only delivers 4.
+    await expect(
+      cache.put(
+        key,
+        streamingResponse([bytes("0123")], {
+          status: 200,
+          headers: { "Content-Length": "10", etag: '"v1"' },
+        }),
+      ),
+    ).rejects.toThrow(/Incomplete download/);
+
+    // Final file must NOT be published; partial + sidecar remain for resume.
+    expect(fs.existsSync(path.join(dir, key))).toBe(false);
+    expect(fs.readFileSync(path.join(dir, key + ".incomplete"), "utf-8")).toBe("0123");
+    expect(fs.existsSync(path.join(dir, key + ".incomplete.lock"))).toBe(false);
+
+    const resume = await cache.getResumeInfo(key);
+    expect(resume).toEqual({ size: 4, etag: '"v1"', total: 10 });
+  });
+
+  it("appends a 206 partial-content response onto the existing partial", async () => {
+    const key = "weights.onnx";
+    const full = "0123456789";
+
+    // Seed a prior interrupted download: first 4 bytes + sidecar.
+    fs.writeFileSync(path.join(dir, key + ".incomplete"), full.slice(0, 4));
+    fs.writeFileSync(path.join(dir, key + ".incomplete.json"), JSON.stringify({ etag: '"v1"', total: 10 }));
+
+    // Server continues from byte 4 with a 206.
+    await cache.put(
+      key,
+      streamingResponse([bytes(full.slice(4))], {
+        status: 206,
+        headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6", etag: '"v1"' },
+      }),
+    );
+
+    expect(fs.readFileSync(path.join(dir, key), "utf-8")).toBe(full);
+    expect(fs.existsSync(path.join(dir, key + ".incomplete"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, key + ".incomplete.json"))).toBe(false);
+    expect(await cache.getResumeInfo(key)).toBeUndefined();
+  });
+
+  it("restarts from scratch on a 200 even if a stale partial exists", async () => {
+    const key = "restart.onnx";
+    fs.writeFileSync(path.join(dir, key + ".incomplete"), "STALE-JUNK");
+    fs.writeFileSync(path.join(dir, key + ".incomplete.json"), JSON.stringify({ etag: '"old"', total: 10 }));
+
+    const content = "freshdata!";
+    await cache.put(
+      key,
+      streamingResponse([bytes(content)], {
+        status: 200,
+        headers: { "Content-Length": String(content.length), etag: '"new"' },
+      }),
+    );
+
+    expect(fs.readFileSync(path.join(dir, key), "utf-8")).toBe(content);
+  });
+});

--- a/packages/transformers/tests/utils/file_cache.test.js
+++ b/packages/transformers/tests/utils/file_cache.test.js
@@ -283,6 +283,192 @@ describe("FileCache resumable downloads", () => {
     });
   });
 
+  describe("completion requires the exact declared size", () => {
+    it("refuses to publish an oversized body and discards the partial", async () => {
+      const key = "oversized.onnx";
+      // Server declares 4 bytes and sends 10. Appending the surplus and
+      // renaming would publish a file that is not the one we asked for.
+      await expect(cache.put(key, streamingResponse([bytes("0123456789")], { status: 200, headers: { "Content-Length": "4", etag: '"v1"' } }))).rejects.toThrow(/Oversized download/);
+
+      expect(fs.existsSync(p(key))).toBe(false);
+      // An oversized partial can never be resumed onto (it already runs past
+      // `total`), so it is dropped rather than kept like a truncated one.
+      expect(fs.existsSync(p(key + ".incomplete"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.json"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(await cache.reserveResume(key)).toBeUndefined();
+    });
+
+    it("refuses to publish a 206 that overshoots the total", async () => {
+      const key = "oversized-range.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      expect(await cache.reserveResume(key)).toBeDefined();
+
+      // Content-Range is internally consistent and lines up with the partial,
+      // but the body carries more bytes than it promised.
+      await expect(cache.put(key, streamingResponse([bytes("456789EXTRA")], { status: 206, headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6" } }))).rejects.toThrow(/Oversized download/);
+
+      expect(fs.existsSync(p(key))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+    });
+
+    it("still keeps the partial when the body falls short", async () => {
+      const key = "short.onnx";
+      await expect(cache.put(key, streamingResponse([bytes("012")], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } }))).rejects.toThrow(/Incomplete download/);
+
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("012");
+      expect(await cache.reserveResume(key)).toEqual({ size: 3, etag: '"v1"', total: 10 });
+      await cache.releaseResume(key);
+    });
+  });
+
+  describe("the output stream is closed before the key is handed on", () => {
+    /**
+     * Assert nothing is still holding `target` open.
+     *
+     * On Linux the leaked descriptor is directly observable via `/proc/self/fd`,
+     * which is the assertion that actually bites — POSIX happily unlinks a file
+     * that is still open, so the removable check alone would pass either way.
+     * Elsewhere (notably Windows, where an open handle does block the unlink)
+     * the removable check is what is left.
+     */
+    const expectNotHeldOpen = (target) => {
+      const fdDir = "/proc/self/fd";
+      if (fs.existsSync(fdDir)) {
+        const holding = fs.readdirSync(fdDir).filter((fd) => {
+          try {
+            return fs.readlinkSync(path.join(fdDir, fd)) === target;
+          } catch {
+            // The descriptor used to walk the directory may already be gone.
+            return false;
+          }
+        });
+        expect(holding).toEqual([]);
+      }
+      expect(() => fs.unlinkSync(target)).not.toThrow();
+    };
+
+    it("closes the stream when the reader errors mid-body", async () => {
+      const key = "reader-error.onnx";
+      const body = new ReadableStream({
+        pull(controller) {
+          controller.enqueue(bytes("0123"));
+          controller.error(new Error("connection reset"));
+        },
+      });
+      const response = new Response(body, { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } });
+
+      await expect(cache.put(key, response)).rejects.toThrow(/connection reset/);
+
+      // The lock is gone, so another writer may take this key immediately —
+      // it must not find a partial we are still writing into.
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(fs.existsSync(p(key))).toBe(false);
+      expectNotHeldOpen(p(key + ".incomplete"));
+    });
+
+    it("closes the stream when the progress callback throws", async () => {
+      const key = "callback-error.onnx";
+      const response = streamingResponse([bytes("0123"), bytes("456789")], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } });
+
+      await expect(
+        cache.put(key, response, () => {
+          throw new Error("callback blew up");
+        }),
+      ).rejects.toThrow(/callback blew up/);
+
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(fs.existsSync(p(key))).toBe(false);
+      expectNotHeldOpen(p(key + ".incomplete"));
+    });
+
+    it("closes the stream when the writer errors", async () => {
+      const key = "writer-error.onnx";
+      // Make the partial path a directory: opening it for writing fails, and
+      // the failure surfaces asynchronously through the stream.
+      fs.mkdirSync(p(key + ".incomplete"));
+
+      await expect(cache.put(key, streamingResponse([bytes("0123")], { status: 200, headers: { "Content-Length": "10" } }))).rejects.toThrow();
+
+      // The error must not escape as an unhandled 'error' event, and the key
+      // must be released for the next writer.
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(fs.existsSync(p(key))).toBe(false);
+    });
+
+    it("cleans up the temp file when the fallback path fails", async () => {
+      const key = "fallback-error.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      // Hold the key so `put` takes the unique-temp fallback.
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 0);
+
+      await expect(cache.put(key, streamingResponse([bytes("012")], { status: 200, headers: { "Content-Length": "10" } }))).rejects.toThrow(/Incomplete download/);
+
+      // No `.tmp.*` left behind, and the other writer's artifacts are untouched.
+      expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp."))).toEqual([]);
+      expect(fs.existsSync(p(key))).toBe(false);
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+    });
+  });
+
+  describe("delete removes every artifact of an entry", () => {
+    it("removes the completed file", async () => {
+      const key = "done.onnx";
+      fs.writeFileSync(p(key), "0123456789");
+
+      expect(await cache.delete(key)).toBe(true);
+      expect(fs.readdirSync(dir)).toEqual([]);
+    });
+
+    it("removes a partial, its sidecar, and a stale lock", async () => {
+      const key = "half.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      seedLock(key, { instance: "other", pid: await deadPid(), startedAt: Date.now() }, 10 * 60 * 1000);
+
+      expect(await cache.delete(key)).toBe(true);
+      expect(fs.readdirSync(dir)).toEqual([]);
+      // Nothing is left for a later request to resume onto.
+      expect(await cache.reserveResume(key)).toBeUndefined();
+    });
+
+    it("removes the partial alongside the completed file", async () => {
+      const key = "both.onnx";
+      fs.writeFileSync(p(key), "0123456789");
+      seedPartial(key, "0123", { etag: '"v2"', total: 10 });
+
+      expect(await cache.delete(key)).toBe(true);
+      expect(fs.readdirSync(dir)).toEqual([]);
+    });
+
+    it("releases a reservation this instance holds", async () => {
+      const key = "reserved.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      expect(await cache.reserveResume(key)).toBeDefined();
+
+      expect(await cache.delete(key)).toBe(true);
+      // The lock we owned is gone, not merely unlinked out from under a live
+      // heartbeat — a second delete finds nothing at all.
+      expect(fs.readdirSync(dir)).toEqual([]);
+      expect(await cache.delete(key)).toBe(false);
+    });
+
+    it("returns false when there is nothing cached", async () => {
+      expect(await cache.delete("absent.onnx")).toBe(false);
+    });
+
+    it("does not report a bare leftover lock as a deleted entry", async () => {
+      // `clear_cache` falls back to a second key when `delete` returns false,
+      // so a stray lock must not masquerade as a real entry...
+      const key = "lock-only.onnx";
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 0);
+
+      expect(await cache.delete(key)).toBe(false);
+      // ...but it is still swept up.
+      expect(fs.readdirSync(dir)).toEqual([]);
+    });
+  });
+
   describe("lock ownership", () => {
     const key = "locked.onnx";
 

--- a/packages/transformers/tests/utils/file_cache.test.js
+++ b/packages/transformers/tests/utils/file_cache.test.js
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -23,11 +24,62 @@ function streamingResponse(chunks, { status = 200, headers = {} } = {}) {
   return new Response(body, { status, headers });
 }
 
+/**
+ * A `Response` whose body stalls until `release()` is called, so two writers can
+ * be held in flight at the same time.
+ * @param {string} content
+ */
+function stallingResponse(content) {
+  let release;
+  const gate = new Promise((resolve) => (release = resolve));
+  let sent = false;
+  const body = new ReadableStream({
+    async pull(controller) {
+      if (sent) {
+        controller.close();
+        return;
+      }
+      await gate;
+      sent = true;
+      controller.enqueue(bytes(content));
+    },
+  });
+  return {
+    response: new Response(body, { status: 200, headers: { "Content-Length": String(content.length), etag: '"v1"' } }),
+    release: () => release(),
+  };
+}
+
 const bytes = (str) => new TextEncoder().encode(str);
+
+/** A pid that is guaranteed to be valid but no longer running. */
+async function deadPid() {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  const pid = child.pid;
+  await new Promise((resolve) => child.on("exit", resolve));
+  return pid;
+}
 
 describe("FileCache resumable downloads", () => {
   let dir;
   let cache;
+
+  const p = (...parts) => path.join(dir, ...parts);
+
+  /** Seed an interrupted download: a partial plus its sidecar. */
+  const seedPartial = (key, content, sidecar) => {
+    fs.writeFileSync(p(key + ".incomplete"), content);
+    fs.writeFileSync(p(key + ".incomplete.json"), JSON.stringify(sidecar));
+  };
+
+  /** Write a foreign lock file with an explicit owner and age. */
+  const seedLock = (key, owner, ageMs = 0) => {
+    const lockPath = p(key + ".incomplete.lock");
+    fs.writeFileSync(lockPath, JSON.stringify(owner));
+    const when = new Date(Date.now() - ageMs);
+    fs.utimesSync(lockPath, when, when);
+    return lockPath;
+  };
 
   beforeEach(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "tjs-filecache-"));
@@ -38,85 +90,252 @@ describe("FileCache resumable downloads", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("getResumeInfo returns undefined when there is no partial", async () => {
-    expect(await cache.getResumeInfo("model.onnx")).toBeUndefined();
+  describe("basic write paths", () => {
+    it("reserveResume returns undefined when there is no partial", async () => {
+      expect(await cache.reserveResume("model.onnx")).toBeUndefined();
+      // A failed reservation must not leave a lock behind.
+      expect(fs.existsSync(p("model.onnx.incomplete.lock"))).toBe(false);
+    });
+
+    it("writes a full 200 response and leaves no partial artifacts", async () => {
+      const content = "hello world";
+      await cache.put("model.onnx", streamingResponse([bytes(content)], { status: 200, headers: { "Content-Length": String(content.length), etag: '"abc"' } }));
+
+      expect(fs.readFileSync(p("model.onnx"), "utf-8")).toBe(content);
+      expect(fs.existsSync(p("model.onnx.incomplete"))).toBe(false);
+      expect(fs.existsSync(p("model.onnx.incomplete.json"))).toBe(false);
+      expect(fs.existsSync(p("model.onnx.incomplete.lock"))).toBe(false);
+    });
+
+    it("keeps the partial and sidecar when the body is truncated", async () => {
+      const key = "big.onnx";
+      // Server promises 10 bytes but only delivers 4.
+      await expect(cache.put(key, streamingResponse([bytes("0123")], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } }))).rejects.toThrow(/Incomplete download/);
+
+      // Final file must NOT be published; partial + sidecar remain for resume.
+      expect(fs.existsSync(p(key))).toBe(false);
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await cache.releaseResume(key);
+    });
+
+    it("appends a 206 partial-content response onto the existing partial", async () => {
+      const key = "weights.onnx";
+      const full = "0123456789";
+      seedPartial(key, full.slice(0, 4), { etag: '"v1"', total: 10 });
+
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await cache.put(key, streamingResponse([bytes(full.slice(4))], { status: 206, headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6", etag: '"v1"' } }));
+
+      expect(fs.readFileSync(p(key), "utf-8")).toBe(full);
+      expect(fs.existsSync(p(key + ".incomplete"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.json"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(await cache.reserveResume(key)).toBeUndefined();
+    });
+
+    it("restarts from scratch on a 200 even if a stale partial exists", async () => {
+      const key = "restart.onnx";
+      seedPartial(key, "STALE-JUNK", { etag: '"old"', total: 10 });
+
+      const content = "freshdata!";
+      await cache.put(key, streamingResponse([bytes(content)], { status: 200, headers: { "Content-Length": String(content.length), etag: '"new"' } }));
+
+      expect(fs.readFileSync(p(key), "utf-8")).toBe(content);
+      expect(fs.existsSync(p(key + ".incomplete"))).toBe(false);
+    });
+
+    it("reports a null etag when the sidecar has no validator", async () => {
+      const key = "novalidator.onnx";
+      seedPartial(key, "0123", { etag: null, total: 10 });
+
+      // The caller uses this to decide *not* to send `Range` at all.
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: null, total: 10 });
+      await cache.releaseResume(key);
+    });
   });
 
-  it("writes a full 200 response and leaves no partial artifacts", async () => {
-    const content = "hello world";
-    await cache.put(
-      "model.onnx",
-      streamingResponse([bytes(content)], {
-        status: 200,
-        headers: { "Content-Length": String(content.length), etag: '"abc"' },
-      }),
-    );
+  describe("partial responses are confined to the writer that owns the partial", () => {
+    it("refuses a 206 when no resume was reserved", async () => {
+      const key = "unreserved.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
 
-    expect(fs.readFileSync(path.join(dir, "model.onnx"), "utf-8")).toBe(content);
-    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete"))).toBe(false);
-    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete.json"))).toBe(false);
-    expect(fs.existsSync(path.join(dir, "model.onnx.incomplete.lock"))).toBe(false);
+      // No `reserveResume` call: this writer does not own the partial.
+      await expect(cache.put(key, streamingResponse([bytes("456789")], { status: 206, headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6" } }))).rejects.toThrow(/without a resume reservation/);
+
+      // Crucially, the trailing bytes were not published as the whole file.
+      expect(fs.existsSync(p(key))).toBe(false);
+      // The other writer's partial is untouched.
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+    });
+
+    it("refuses a 206 that arrives while another writer holds the key", async () => {
+      const key = "contended.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+
+      // A second FileCache instance stands in for another process holding the key.
+      const other = new FileCache(dir);
+      expect(await other.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+
+      // This writer could not reserve, so it must never produce a 206...
+      expect(await cache.reserveResume(key)).toBeUndefined();
+      // ...and if one arrives anyway it is refused rather than written to a
+      // unique temp file and renamed over the final path.
+      await expect(cache.put(key, streamingResponse([bytes("456789")], { status: 206, headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6" } }))).rejects.toThrow(/without a resume reservation/);
+
+      expect(fs.existsSync(p(key))).toBe(false);
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+      await other.releaseResume(key);
+    });
   });
 
-  it("keeps the partial and sidecar when the body is truncated", async () => {
-    const key = "big.onnx";
-    // Server promises 10 bytes but only delivers 4.
-    await expect(
-      cache.put(
-        key,
-        streamingResponse([bytes("0123")], {
-          status: 200,
-          headers: { "Content-Length": "10", etag: '"v1"' },
-        }),
-      ),
-    ).rejects.toThrow(/Incomplete download/);
+  describe("Content-Range validation", () => {
+    const key = "range.onnx";
+    // Partial holds bytes 0-3 of a 10-byte file.
+    const reserve = async () => {
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+      expect(await cache.reserveResume(key)).toBeDefined();
+    };
 
-    // Final file must NOT be published; partial + sidecar remain for resume.
-    expect(fs.existsSync(path.join(dir, key))).toBe(false);
-    expect(fs.readFileSync(path.join(dir, key + ".incomplete"), "utf-8")).toBe("0123");
-    expect(fs.existsSync(path.join(dir, key + ".incomplete.lock"))).toBe(false);
+    it.each([
+      ["a gap (server resumed past the partial)", { "Content-Range": "bytes 6-9/10", "Content-Length": "4" }, "456789", /gap/],
+      ["an overlap (server resumed before the partial)", { "Content-Range": "bytes 2-9/10", "Content-Length": "8" }, "23456789", /overlap/],
+      ["a changed total size", { "Content-Range": "bytes 4-9/20", "Content-Length": "6" }, "456789", /total size changed/],
+      ["an unsatisfied range", { "Content-Range": "bytes */10" }, "", /unusable Content-Range/],
+      ["a suffix range", { "Content-Range": "bytes -6/10", "Content-Length": "6" }, "456789", /unusable Content-Range/],
+      ["an unknown total", { "Content-Range": "bytes 4-9/*", "Content-Length": "6" }, "456789", /unusable Content-Range/],
+      ["a missing Content-Range", {}, "456789", /unusable Content-Range/],
+      ["an end before the start", { "Content-Range": "bytes 4-2/10" }, "", /inconsistent Content-Range/],
+      ["an end past the total", { "Content-Range": "bytes 4-99/10" }, "", /inconsistent Content-Range/],
+      ["a Content-Length that disagrees with the span", { "Content-Range": "bytes 4-9/10", "Content-Length": "99" }, "456789", /does not match Content-Range span/],
+    ])("rejects %s", async (_label, headers, body, expected) => {
+      await reserve();
 
-    const resume = await cache.getResumeInfo(key);
-    expect(resume).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await expect(cache.put(key, streamingResponse([bytes(body)], { status: 206, headers }))).rejects.toThrow(expected);
+
+      // Nothing is published, and the suspect partial is dropped so the next
+      // attempt starts clean instead of retrying onto bad data forever.
+      expect(fs.existsSync(p(key))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete"))).toBe(false);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(await cache.reserveResume(key)).toBeUndefined();
+    });
+
+    it("accepts a valid range whose Content-Length is absent", async () => {
+      await reserve();
+      await cache.put(key, streamingResponse([bytes("456789")], { status: 206, headers: { "Content-Range": "bytes 4-9/10" } }));
+      expect(fs.readFileSync(p(key), "utf-8")).toBe("0123456789");
+    });
   });
 
-  it("appends a 206 partial-content response onto the existing partial", async () => {
-    const key = "weights.onnx";
-    const full = "0123456789";
+  describe("concurrent writers", () => {
+    it("both writers finish, and the file is complete exactly once", async () => {
+      const key = "parallel.onnx";
+      const content = "0123456789";
+      const a = stallingResponse(content);
+      const b = stallingResponse(content);
 
-    // Seed a prior interrupted download: first 4 bytes + sidecar.
-    fs.writeFileSync(path.join(dir, key + ".incomplete"), full.slice(0, 4));
-    fs.writeFileSync(path.join(dir, key + ".incomplete.json"), JSON.stringify({ etag: '"v1"', total: 10 }));
+      const pending = [cache.put(key, a.response), cache.put(key, b.response)];
+      // Both are now past lock acquisition: one holds the deterministic partial,
+      // the other fell back to a unique temp file.
+      a.release();
+      b.release();
+      await Promise.all(pending);
 
-    // Server continues from byte 4 with a 206.
-    await cache.put(
-      key,
-      streamingResponse([bytes(full.slice(4))], {
-        status: 206,
-        headers: { "Content-Range": "bytes 4-9/10", "Content-Length": "6", etag: '"v1"' },
-      }),
-    );
+      expect(fs.readFileSync(p(key), "utf-8")).toBe(content);
+      // No partial, sidecar, lock, or temp file survives either writer.
+      expect(fs.readdirSync(dir)).toEqual([key]);
+    });
 
-    expect(fs.readFileSync(path.join(dir, key), "utf-8")).toBe(full);
-    expect(fs.existsSync(path.join(dir, key + ".incomplete"))).toBe(false);
-    expect(fs.existsSync(path.join(dir, key + ".incomplete.json"))).toBe(false);
-    expect(await cache.getResumeInfo(key)).toBeUndefined();
+    it("a failing writer does not strand the key or the other writer", async () => {
+      const key = "parallel-fail.onnx";
+      const content = "0123456789";
+      const good = stallingResponse(content);
+
+      const failing = cache.put(key, streamingResponse([bytes("012")], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } }));
+      await expect(failing).rejects.toThrow(/Incomplete download/);
+
+      good.release();
+      await cache.put(key, good.response);
+
+      expect(fs.readFileSync(p(key), "utf-8")).toBe(content);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+    });
+
+    it("releaseResume hands the key back without writing", async () => {
+      const key = "released.onnx";
+      seedPartial(key, "0123", { etag: '"v1"', total: 10 });
+
+      expect(await cache.reserveResume(key)).toBeDefined();
+      const other = new FileCache(dir);
+      expect(await other.reserveResume(key)).toBeUndefined();
+
+      await cache.releaseResume(key);
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(false);
+      expect(await other.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await other.releaseResume(key);
+    });
+
+    it("releaseResume is a no-op when nothing is held", async () => {
+      await expect(cache.releaseResume("never-reserved.onnx")).resolves.toBeUndefined();
+    });
   });
 
-  it("restarts from scratch on a 200 even if a stale partial exists", async () => {
-    const key = "restart.onnx";
-    fs.writeFileSync(path.join(dir, key + ".incomplete"), "STALE-JUNK");
-    fs.writeFileSync(path.join(dir, key + ".incomplete.json"), JSON.stringify({ etag: '"old"', total: 10 }));
+  describe("lock ownership", () => {
+    const key = "locked.onnx";
 
-    const content = "freshdata!";
-    await cache.put(
-      key,
-      streamingResponse([bytes(content)], {
-        status: 200,
-        headers: { "Content-Length": String(content.length), etag: '"new"' },
-      }),
-    );
+    beforeEach(() => seedPartial(key, "0123", { etag: '"v1"', total: 10 }));
 
-    expect(fs.readFileSync(path.join(dir, key), "utf-8")).toBe(content);
+    it("does not steal a lock that is being refreshed", async () => {
+      seedLock(key, { instance: "other", pid: await deadPid(), startedAt: Date.now() }, 0);
+      // Recently touched: a writer is actively downloading, dead-looking pid or
+      // not. We must wait rather than write concurrently.
+      expect(await cache.reserveResume(key)).toBeUndefined();
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(true);
+    });
+
+    it("does not steal a stale-looking lock whose owner is still alive", async () => {
+      // This is the slow-download case: the lock has not been refreshed for
+      // longer than the stale window, but its owner process still exists.
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 10 * 60 * 1000);
+      expect(await cache.reserveResume(key)).toBeUndefined();
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(true);
+    });
+
+    it("steals a stale lock whose owner is gone", async () => {
+      seedLock(key, { instance: "other", pid: await deadPid(), startedAt: Date.now() }, 10 * 60 * 1000);
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await cache.releaseResume(key);
+    });
+
+    it("steals a lock left untouched past the abandoned ceiling", async () => {
+      // Owner pid resolves (it is us), but nothing has refreshed the lock for
+      // an hour, so it cannot be an in-progress download.
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 2 * 60 * 60 * 1000);
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await cache.releaseResume(key);
+    });
+
+    it("steals an unreadable lock", async () => {
+      // A writer that died midway through creating its lock file.
+      seedLock(key, "{not-json", 10 * 60 * 1000);
+      expect(await cache.reserveResume(key)).toEqual({ size: 4, etag: '"v1"', total: 10 });
+      await cache.releaseResume(key);
+    });
+
+    it("falls back to the unique-temp path for a 200 while the key is locked", async () => {
+      seedLock(key, { instance: "other", pid: process.pid, startedAt: Date.now() }, 0);
+
+      const content = "0123456789";
+      await cache.put(key, streamingResponse([bytes(content)], { status: 200, headers: { "Content-Length": "10", etag: '"v1"' } }));
+
+      // The full download still lands correctly...
+      expect(fs.readFileSync(p(key), "utf-8")).toBe(content);
+      // ...without disturbing the other writer's partial or lock.
+      expect(fs.readFileSync(p(key + ".incomplete"), "utf-8")).toBe("0123");
+      expect(fs.existsSync(p(key + ".incomplete.lock"))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Follow-up to the discussion in #1220 (thanks @emojiiii for handing it over, and @sroussey for the Xet/CDC pointer).

This is **step 1: HTTP Range-resume for the Node file-cache path**, which is where large model weights are streamed to disk. It ships resume for how downloads work today, with no new transport dependency. Xet-native chunk caching (via the huggingface.js download path) is the natural follow-up and is intentionally out of scope here.

### What changes

- **`FileCache`** streams large downloads to a deterministic `<key>.incomplete` file plus a small sidecar (`{ etag, total }`), and **keeps the partial on failure** instead of deleting it.
  - `getResumeInfo(request)` reports `{ size, etag, total }` when a consistent partial exists.
  - `put()` branches on the response status: **206** appends to the partial (offset/total parsed from `Content-Range`); **200** restarts cleanly (truncates any stale partial). A truncated body (`loaded < Content-Length`) is rejected and the partial retained for the next attempt.
  - A per-key **lock** preserves the previous concurrent-writer guarantee: if the partial is already held by another writer, `put()` falls back to the original unique-temp path (correct, non-resumable, never corrupts the shared partial). Stale locks are stolen after a TTL.
- **`hub.js`** only sends `Range`/`If-Range` on the streaming path (`IS_NODE_ENV && return_path`), since a 206 on the buffered path would yield only the trailing bytes. It now accepts `206` alongside `200` and caches both. `If-Range: <etag>` makes the server fall back to a full 200 if the file changed upstream.
- **`CacheInterface`** gains an optional `getResumeInfo` so custom caches can opt in.

### Scope / notes

- Node-only by design. The browser Cache API cannot store partials; OPFS/Xet is the follow-up (step 2).
- Incremental sha256 integrity verification is deliberately left for a follow-up so this PR stays focused on the resume mechanics.

### Tests

New `tests/utils/file_cache.test.js` covers: no-partial, full 200 (no leftovers), truncated body (partial + sidecar retained, `getResumeInfo` correct), 206 append to completion, and 200 restart over a stale partial. Existing `cache`/`custom_cache` suites still pass; typecheck, prettier, and build are green.

Closes #1220

Opening as a draft to get maintainer direction on the Xet question in #1220 before polishing. Happy to adjust.
