### PR TITLE
Allow all `origins` for Cross-Origin Storage

### DIFF
--- a/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
+++ b/packages/transformers/src/utils/cache/CrossOriginStorageCache.js
@@ -112,6 +112,7 @@ export class CrossOriginStorage {
     _storeBlobInCOS = async (blob, hashHex) => {
         const handle = await navigator.crossOriginStorage.requestFileHandle(makeHashDescriptor(hashHex), {
             create: true,
+            origins: '*',
         });
         const writableStream = await handle.createWritable();
         await writableStream.write(blob);

--- a/packages/transformers/src/utils/cache/cross-origin-storage.d.ts
+++ b/packages/transformers/src/utils/cache/cross-origin-storage.d.ts
@@ -17,6 +17,15 @@ interface CrossOriginStorageRequestFileHandleHash {
  */
 interface CrossOriginStorageRequestFileHandleOptions {
     create?: boolean;
+    /**
+     * Restricts (or opens up) which origins may later read the stored file.
+     * `'*'` makes the resource available to all origins; an array of origin
+     * strings restricts it to that set; omitting the field keeps the
+     * default (same-site only). Visibility can be upgraded but never
+     * downgraded.
+     * @see https://github.com/WICG/cross-origin-storage#example-restricting-resources-to-specific-origins
+     */
+    origins?: '*' | string[];
 }
 
 /**


### PR DESCRIPTION
This makes the resources available globally. Initially this wasn't implemented in the extension, but the `origins` check is implemented now, so we need to update the code to make use of it. (Internally, the extension as a one-off upgrades all resources that were stored already as `origins: '*'`.)