### PR TITLE
Skip browser cache writes for non-http(s) resources

### DIFF
--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -15,6 +15,7 @@ import {
     isValidHfModelId,
     makePretrainedOptionsKey,
     readResponse,
+    toAbsoluteURL,
 } from './hub/utils.js';
 import { getCache, tryCache } from './cache.js';
 import { get_file_metadata } from './model_registry/get_file_metadata.js';
@@ -204,12 +205,12 @@ export async function storeCachedResource(path_or_repo_id, filename, cache, cach
     if (
         typeof Cache !== 'undefined' &&
         cache instanceof Cache &&
-        isValidUrl(cacheKey) &&
-        !isValidUrl(cacheKey, ['http:', 'https:'])
+        !isValidUrl(toAbsoluteURL(cacheKey), ['http:', 'https:'])
     ) {
         // The browser Cache API only supports http(s) URLs as keys, so do not attempt to cache
-        // responses for other schemes (e.g., files bundled within a browser extension).
-        // Relative keys are not skipped, since the Cache API resolves them against the page URL.
+        // responses for other schemes (e.g., files bundled within a browser extension). Relative
+        // keys are resolved against the page URL first, since a relative key on an extension page
+        // still resolves to a chrome-extension:// request.
         return;
     }
 

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -201,6 +201,18 @@ export async function storeCachedResource(path_or_repo_id, filename, cache, cach
         return;
     }
 
+    if (
+        typeof Cache !== 'undefined' &&
+        cache instanceof Cache &&
+        isValidUrl(cacheKey) &&
+        !isValidUrl(cacheKey, ['http:', 'https:'])
+    ) {
+        // The browser Cache API only supports http(s) URLs as keys, so do not attempt to cache
+        // responses for other schemes (e.g., files bundled within a browser extension).
+        // Relative keys are not skipped, since the Cache API resolves them against the page URL.
+        return;
+    }
+
     if (!result) {
         // We haven't yet read the response body, so we need to do so now.
         // Ensure progress updates include consistent metadata.

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -205,7 +205,7 @@ export async function storeCachedResource(path_or_repo_id, filename, cache, cach
     if (
         typeof Cache !== 'undefined' &&
         cache instanceof Cache &&
-        !isValidUrl(toAbsoluteURL(cacheKey), ['http:', 'https:'])
+        !isValidUrl(toAbsoluteURL(cacheKey, { allowUnresolved: true }), ['http:', 'https:'])
     ) {
         // The browser Cache API only supports http(s) URLs as keys, so do not attempt to cache
         // responses for other schemes (e.g., files bundled within a browser extension). Relative

--- a/packages/transformers/src/utils/hub/utils.js
+++ b/packages/transformers/src/utils/hub/utils.js
@@ -168,8 +168,9 @@ export function isBlobURL(url) {
  * Converts any URL to an absolute URL if needed.
  * If the URL is already absolute (http://, https://, or blob:), returns it unchanged (handled by new URL(...)).
  * Otherwise, resolves it relative to the current page location (browser) or module location (Node/Bun/Deno).
+ * If the base itself has an opaque origin (e.g. "about:blank"), the URL is returned unresolved.
  * @param {string} url - The URL to convert (can be relative or absolute).
- * @returns {string} The absolute URL.
+ * @returns {string} The absolute URL, or the original URL if it could not be resolved.
  */
 export function toAbsoluteURL(url) {
     let baseURL;
@@ -185,5 +186,10 @@ export function toAbsoluteURL(url) {
         return url;
     }
 
-    return new URL(url, baseURL).href;
+    try {
+        return new URL(url, baseURL).href;
+    } catch {
+        // baseURL has an opaque origin (e.g. "about:blank"), so return the URL unchanged
+        return url;
+    }
 }

--- a/packages/transformers/src/utils/hub/utils.js
+++ b/packages/transformers/src/utils/hub/utils.js
@@ -168,11 +168,14 @@ export function isBlobURL(url) {
  * Converts any URL to an absolute URL if needed.
  * If the URL is already absolute (http://, https://, or blob:), returns it unchanged (handled by new URL(...)).
  * Otherwise, resolves it relative to the current page location (browser) or module location (Node/Bun/Deno).
- * If the base itself has an opaque origin (e.g. "about:blank"), the URL is returned unresolved.
  * @param {string} url - The URL to convert (can be relative or absolute).
- * @returns {string} The absolute URL, or the original URL if it could not be resolved.
+ * @param {Object} [options]
+ * @param {boolean} [options.allowUnresolved=false] - Return `url` unchanged instead of throwing when it
+ * cannot be resolved, which happens for a relative URL on a page whose base is opaque (e.g. "about:blank").
+ * Off by default, so a malformed URL still throws for callers that expect one.
+ * @returns {string} The absolute URL.
  */
-export function toAbsoluteURL(url) {
+export function toAbsoluteURL(url, { allowUnresolved = false } = {}) {
     let baseURL;
 
     if (typeof location !== 'undefined' && location.href) {
@@ -186,10 +189,14 @@ export function toAbsoluteURL(url) {
         return url;
     }
 
+    if (!allowUnresolved) {
+        return new URL(url, baseURL).href;
+    }
+
     try {
         return new URL(url, baseURL).href;
     } catch {
-        // baseURL has an opaque origin (e.g. "about:blank"), so return the URL unchanged
+        // Nothing resolves against an opaque base, so hand back the original for the caller to check
         return url;
     }
 }

--- a/packages/transformers/src/utils/hub/utils.js
+++ b/packages/transformers/src/utils/hub/utils.js
@@ -189,13 +189,12 @@ export function toAbsoluteURL(url, { allowUnresolved = false } = {}) {
         return url;
     }
 
-    if (!allowUnresolved) {
-        return new URL(url, baseURL).href;
-    }
-
     try {
         return new URL(url, baseURL).href;
-    } catch {
+    } catch (error) {
+        if (!allowUnresolved) {
+            throw error;
+        }
         // Nothing resolves against an opaque base, so hand back the original for the caller to check
         return url;
     }

--- a/packages/transformers/tests/utils/browser_cache.test.js
+++ b/packages/transformers/tests/utils/browser_cache.test.js
@@ -44,6 +44,7 @@ class FakeBrowserCache extends Cache {
 describe("Browser cache", () => {
   // Store original values so we can restore them after tests
   const originalCaches = globalThis.caches;
+  const originalLocation = globalThis.location;
   const originalFetch = env.fetch;
   const originalUseFS = env.useFS;
   const originalUseBrowserCache = env.useBrowserCache;
@@ -58,6 +59,8 @@ describe("Browser cache", () => {
   beforeEach(() => {
     cache = new FakeBrowserCache();
     globalThis.caches = { open: async () => cache };
+    // No real `location` exists in Node.js, so emulate an extension page by default
+    globalThis.location = { href: "chrome-extension://abcdefghijklmnop/popup.html" };
 
     env.useFS = false;
     env.useBrowserCache = true;
@@ -84,6 +87,7 @@ describe("Browser cache", () => {
       globalThis.Cache = originalCache;
     }
     globalThis.caches = originalCaches;
+    globalThis.location = originalLocation;
     env.fetch = originalFetch;
     env.useFS = originalUseFS;
     env.useBrowserCache = originalUseBrowserCache;
@@ -100,7 +104,27 @@ describe("Browser cache", () => {
     expect(cache.puts).toEqual([]);
   });
 
-  it("should still cache local files served from a relative path", async () => {
+  it("should not attempt to cache a relative model path that resolves against an extension page", async () => {
+    env.localModelPath = "/models/";
+
+    const file = await getModelFile("my-model", "config.json", true, {});
+
+    expect(file).toBeInstanceOf(Uint8Array);
+    expect(cache.puts).toEqual([]);
+  });
+
+  it("should not throw for a relative model path on an opaque-origin page (e.g. about:blank)", async () => {
+    globalThis.location = { href: "about:blank" };
+    env.localModelPath = "/models/";
+
+    const file = await getModelFile("my-model", "config.json", true, {});
+
+    expect(file).toBeInstanceOf(Uint8Array);
+    expect(cache.puts).toEqual([]);
+  });
+
+  it("should still cache local files served from a relative path on a regular page", async () => {
+    globalThis.location = { href: "https://example.com/index.html" };
     env.localModelPath = "/models/";
 
     const file = await getModelFile("my-model", "config.json", true, {});

--- a/packages/transformers/tests/utils/browser_cache.test.js
+++ b/packages/transformers/tests/utils/browser_cache.test.js
@@ -1,0 +1,121 @@
+import { env } from "../../src/transformers.js";
+import { getModelFile } from "../../src/utils/hub.js";
+import { init } from "../init.js";
+
+// Initialise the testing environment
+init();
+
+// The browser Cache API is not available in Node.js, so emulate it
+const originalCache = globalThis.Cache;
+if (typeof globalThis.Cache === "undefined") {
+  globalThis.Cache = class Cache {};
+}
+
+/**
+ * A minimal stand-in for the browser Cache API, which only supports
+ * http(s) URLs as keys and throws a TypeError for any other scheme.
+ */
+class FakeBrowserCache extends Cache {
+  constructor() {
+    super();
+    /** @type {string[]} */
+    this.puts = [];
+  }
+
+  async match(_request) {
+    return undefined;
+  }
+
+  async put(request, _response) {
+    const key = String(request);
+    this.puts.push(key);
+    let scheme = null;
+    try {
+      scheme = new URL(key).protocol;
+    } catch {
+      // Relative keys are resolved against the page URL by the real Cache API
+    }
+    if (scheme !== null && scheme !== "http:" && scheme !== "https:") {
+      throw new TypeError(`Request scheme '${scheme.slice(0, -1)}' is unsupported`);
+    }
+  }
+}
+
+describe("Browser cache", () => {
+  // Store original values so we can restore them after tests
+  const originalCaches = globalThis.caches;
+  const originalFetch = env.fetch;
+  const originalUseFS = env.useFS;
+  const originalUseBrowserCache = env.useBrowserCache;
+  const originalUseFSCache = env.useFSCache;
+  const originalAllowLocalModels = env.allowLocalModels;
+  const originalAllowRemoteModels = env.allowRemoteModels;
+  const originalLocalModelPath = env.localModelPath;
+
+  /** @type {FakeBrowserCache} */
+  let cache;
+
+  beforeEach(() => {
+    cache = new FakeBrowserCache();
+    globalThis.caches = { open: async () => cache };
+
+    env.useFS = false;
+    env.useBrowserCache = true;
+    env.useFSCache = false;
+    env.allowLocalModels = true;
+    env.allowRemoteModels = true;
+    env.localModelPath = "chrome-extension://abcdefghijklmnop/models/";
+    env.fetch = async (url) => {
+      const key = String(url);
+      if (key.startsWith("chrome-extension://") || key.startsWith("https://") || key.startsWith("/models/")) {
+        return new Response(JSON.stringify({ hello: "world" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(null, { status: 404 });
+    };
+  });
+
+  afterAll(() => {
+    if (originalCache === undefined) {
+      delete globalThis.Cache;
+    } else {
+      globalThis.Cache = originalCache;
+    }
+    globalThis.caches = originalCaches;
+    env.fetch = originalFetch;
+    env.useFS = originalUseFS;
+    env.useBrowserCache = originalUseBrowserCache;
+    env.useFSCache = originalUseFSCache;
+    env.allowLocalModels = originalAllowLocalModels;
+    env.allowRemoteModels = originalAllowRemoteModels;
+    env.localModelPath = originalLocalModelPath;
+  });
+
+  it("should not attempt to cache files with non-http(s) schemes (e.g., bundled in a browser extension)", async () => {
+    const file = await getModelFile("my-model", "config.json", true, {});
+
+    expect(file).toBeInstanceOf(Uint8Array);
+    expect(cache.puts).toEqual([]);
+  });
+
+  it("should still cache local files served from a relative path", async () => {
+    env.localModelPath = "/models/";
+
+    const file = await getModelFile("my-model", "config.json", true, {});
+
+    expect(file).toBeInstanceOf(Uint8Array);
+    expect(cache.puts).toEqual(["/models/my-model/config.json"]);
+  });
+
+  it("should still cache remote files", async () => {
+    env.allowLocalModels = false;
+
+    const file = await getModelFile("my-org/my-model", "config.json", true, {});
+
+    expect(file).toBeInstanceOf(Uint8Array);
+    expect(cache.puts).toHaveLength(1);
+    expect(cache.puts[0]).toMatch(/^https:/);
+  });
+});

--- a/packages/transformers/tests/utils/utils.test.js
+++ b/packages/transformers/tests/utils/utils.test.js
@@ -1,6 +1,7 @@
 import { AutoProcessor } from "../../src/transformers.js";
 import { hamming, hanning, mel_filter_bank } from "../../src/utils/audio.js";
 import { getFile } from "../../src/utils/hub.js";
+import { toAbsoluteURL } from "../../src/utils/hub/utils.js";
 import { RawImage } from "../../src/utils/image.js";
 
 import { MAX_TEST_EXECUTION_TIME } from "../init.js";
@@ -58,6 +59,36 @@ describe("Utilities", () => {
       const blobUrl = URL.createObjectURL(blob);
       const data = await getFile(blobUrl);
       expect(await data.text()).toBe("Hello, world!");
+    });
+
+    describe("toAbsoluteURL", () => {
+      const originalLocation = globalThis.location;
+
+      afterEach(() => {
+        globalThis.location = originalLocation;
+      });
+
+      it("resolves a relative URL against the page", () => {
+        globalThis.location = { href: "https://example.com/app/index.html" };
+        expect(toAbsoluteURL("models/")).toBe("https://example.com/app/models/");
+      });
+
+      it("throws for a malformed URL, so a bad env.backends.onnx.wasm.wasmPaths is not passed on", () => {
+        globalThis.location = { href: "https://example.com/app/index.html" };
+        expect(() => toAbsoluteURL("https://bad host/wasm/")).toThrow(/Invalid URL/);
+      });
+
+      it("throws for a relative URL on an opaque-origin page by default", () => {
+        globalThis.location = { href: "about:blank" };
+        expect(() => toAbsoluteURL("models/")).toThrow(/Invalid URL/);
+      });
+
+      it("returns the URL unchanged instead of throwing when allowUnresolved is set", () => {
+        globalThis.location = { href: "about:blank" };
+        expect(toAbsoluteURL("models/", { allowUnresolved: true })).toBe("models/");
+        // The caller checks the result with isValidUrl, which rejects anything unresolved
+        expect(toAbsoluteURL("https://bad host/wasm/", { allowUnresolved: true })).toBe("https://bad host/wasm/");
+      });
     });
   });
 


### PR DESCRIPTION
This replaces #614, the original report of this problem. That PR patched a file that has since been rewritten and moved, so it is being closed as obsolete in favor of this one. Related background: #380.

When a model is bundled inside a browser extension (`env.localModelPath` pointing at a `chrome-extension://` URL) with the browser cache enabled, every file load attempts `cache.put()` with a `chrome-extension://` key. The browser Cache API only supports http(s) request keys, so the put always fails: one call site logs `Unable to add response to browser cache: TypeError: ...` on every load, and the streaming path has no error handling at all.

This skips the write when the cache is the browser Cache API and the key does not resolve to an http(s) URL. Keys are resolved against the page location first, so a relative `env.localModelPath` on an extension page is caught too. The other cache backends (FileCache, custom caches, Cross-Origin Storage) are untouched.

Resolving can itself fail, since nothing resolves against an opaque base like `about:blank`. `toAbsoluteURL` takes an opt-in `allowUnresolved` flag for that, and only this call site passes it, so the pre-existing `wasmPaths` callers still throw on a bad value.

Tests cover the cache behavior on extension, opaque-origin and regular pages, the remote case, and the `toAbsoluteURL` flag itself.
