### PR TITLE
fix: bump @huggingface/jinja to ^0.5.9 for {%- generation -%} support

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/huggingface/transformers.js#readme",
   "dependencies": {
-    "@huggingface/jinja": "^0.5.6",
+    "@huggingface/jinja": "^0.5.9",
     "@huggingface/tokenizers": "^0.1.3",
     "onnxruntime-node": "1.24.3",
     "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   packages/transformers:
     dependencies:
       '@huggingface/jinja':
-        specifier: ^0.5.6
-        version: 0.5.6
+        specifier: ^0.5.9
+        version: 0.5.9
       '@huggingface/tokenizers':
         specifier: ^0.1.3
         version: 0.1.3
@@ -390,8 +390,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@huggingface/jinja@0.5.6':
-    resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
   '@huggingface/tokenizers@0.1.3':
@@ -2331,7 +2331,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@huggingface/jinja@0.5.6': {}
+  '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tokenizers@0.1.3': {}
 


### PR DESCRIPTION
## Summary
- Bumps `@huggingface/jinja` from `^0.5.6` → `^0.5.9` and updates `pnpm-lock.yaml` accordingly.
- Fixes chat templates that use whitespace-control custom generation tags (`{%- generation -%}` / `{%- endgeneration -%}`), as used by LiquidAI LFM models.

## Why
`@huggingface/jinja@0.5.6` only strips plain `{% generation %}` tags. Templates with `{%- generation -%}` leave a `generation` statement for the parser and throw:

```
Unknown statement type: generation
```

Support for whitespace-control generation tags was added in `@huggingface/jinja@0.5.8` ([huggingface/huggingface.js#2124](https://github.com/huggingface/huggingface.js/pull/2124)). Latest published is `0.5.9`.

## Verification
Rendered a minimal template with `{%- generation -%}` against both versions:

| Version | Result |
|---------|--------|
| 0.5.6 | `Unknown statement type: generation` |
| 0.5.9 | Renders successfully |

Plain `{% generation %}` continues to work on both.

## Test plan
- [x] Confirm npm package versions/integrity for 0.5.9
- [x] Repro failure on 0.5.6 and success on 0.5.9 with `{%- generation -%}`
- [ ] CI / maintainer release of `@huggingface/transformers` after merge

Closes #1724