### PR TITLE
deps: bump onnxruntime-node and sharp

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@huggingface/transformers",
   "version": "4.2.0",
-  "description": "State-of-the-art Machine Learning for the web. Run 🤗 Transformers directly in your browser, with no need for a server!",
+  "description": "State-of-the-art Machine Learning for the web. Run \ud83e\udd17 Transformers directly in your browser, with no need for a server!",
   "main": "./dist/transformers.node.cjs",
   "types": "./types/transformers.d.ts",
   "type": "module",
@@ -57,9 +57,9 @@
   "dependencies": {
     "@huggingface/jinja": "^0.5.6",
     "@huggingface/tokenizers": "^0.1.3",
-    "onnxruntime-node": "1.24.3",
+    "onnxruntime-node": "^1.27.0",
     "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
-    "sharp": "^0.34.5"
+    "sharp": "^0.35.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@huggingface/transformers",
   "version": "4.2.0",
-  "description": "State-of-the-art Machine Learning for the web. Run \ud83e\udd17 Transformers directly in your browser, with no need for a server!",
+  "description": "State-of-the-art Machine Learning for the web. Run 🤗 Transformers directly in your browser, with no need for a server!",
   "main": "./dist/transformers.node.cjs",
   "types": "./types/transformers.d.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `onnxruntime-node` to `^1.27.0` so installs drop the deprecated `boolean` transitive dependency (`global-agent@4`).
- Bump `sharp` to `^0.35.0` so the caret range can resolve the patched libvips release for GHSA-f88m-g3jw-g9cj.

Fixes #1718
Fixes #1729

## Test plan
- [ ] `npm install` in `packages/transformers` resolves `onnxruntime-node@>=1.27` and `sharp@>=0.35`
- [ ] `npm ls boolean` no longer shows `boolean@3` via onnxruntime-node
- [ ] `npm audit` no longer reports GHSA-f88m-g3jw-g9cj from sharp 0.34.x
- [ ] Existing Node image / pipeline smoke tests still pass

Made with [Cursor](https://cursor.com)