### PR TITLE
Fix Moonshine ASR token decoding

### DIFF
--- a/packages/transformers/src/pipelines/automatic-speech-recognition.js
+++ b/packages/transformers/src/pipelines/automatic-speech-recognition.js
@@ -325,7 +325,7 @@ export class AutomaticSpeechRecognitionPipeline
             const max_new_tokens = Math.floor(aud.length / sampling_rate) * 6;
             const outputs = await this.model.generate({ max_new_tokens, ...kwargs, ...inputs });
 
-            const text = this.processor.batch_decode(/** @type {Tensor} */ (outputs), { skip_special_tokens: true })[0];
+            const text = this.tokenizer.batch_decode(/** @type {Tensor} */ (outputs), { skip_special_tokens: true })[0];
             toReturn.push({ text });
         }
         return single ? toReturn[0] : toReturn;

--- a/packages/transformers/tests/pipelines/test_pipelines_automatic_speech_recognition.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_automatic_speech_recognition.js
@@ -458,5 +458,43 @@ export default () => {
         await pipe?.dispose();
       }, MAX_MODEL_DISPOSE_TIME);
     });
+
+    describe("moonshine", () => {
+      it("decodes generated tokens with the pipeline tokenizer", async () => {
+        const sampling_rate = 16000;
+        const generated_tokens = [[1n, 2n, 3n]];
+        let decode_args;
+
+        const processor = Object.assign(async (audio) => ({ input_values: audio }), {
+          feature_extractor: { config: { sampling_rate } },
+        });
+        const tokenizer = {
+          batch_decode(outputs, options) {
+            decode_args = { outputs, options };
+            return ["decoded transcript"];
+          },
+        };
+        const model = {
+          config: { model_type: "moonshine" },
+          async generate() {
+            return generated_tokens;
+          },
+        };
+        const pipe = new AutomaticSpeechRecognitionPipeline({
+          task: PIPELINE_ID,
+          model,
+          tokenizer,
+          processor,
+        });
+
+        const output = await pipe(new Float32Array(sampling_rate));
+
+        expect(output).toEqual({ text: "decoded transcript" });
+        expect(decode_args).toEqual({
+          outputs: generated_tokens,
+          options: { skip_special_tokens: true },
+        });
+      });
+    });
   });
 };


### PR DESCRIPTION
## What does this PR do?

Fixes Moonshine automatic speech recognition pipelines that fail during token decoding.

Moonshine processors can contain only a feature extractor, while the tokenizer is loaded separately on the pipeline. `_call_moonshine` currently asks the processor to decode generated token IDs, which raises `Unable to decode without a tokenizer`. This change uses the pipeline tokenizer, matching the other ASR paths.

The regression test constructs a processor without a tokenizer and verifies that generated tokens are decoded through the pipeline tokenizer.

Fixes #1735.

## Tests

- focused Moonshine Jest test passes
- Prettier checks pass for both changed files
- `pnpm build` passes, including TypeScript type generation
