### PR TITLE
Fix Whisper ASR timestamp regression

### DIFF
--- a/packages/transformers/src/generation/logits_process.js
+++ b/packages/transformers/src/generation/logits_process.js
@@ -304,7 +304,6 @@ export class WhisperTimeStampLogitsProcessor extends LogitsProcessor {
 
             if (input_ids[i].length === this.begin_index) {
                 batch_logits_data.subarray(0, this.timestamp_begin).fill(-Infinity);
-                continue;
             }
 
             // timestamps have to appear in pairs, except directly before eos_token; mask logits accordingly

--- a/packages/transformers/src/models/whisper/modeling_whisper.js
+++ b/packages/transformers/src/models/whisper/modeling_whisper.js
@@ -201,7 +201,7 @@ export class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
 
         // input_features shape: [batch=1, n_mels, total_frames]
         const input_features = inputs;
-        const total_frames = generation_config.num_frames
+        const total_frames = generation_config.num_frames != null
             ? Math.min(input_features.dims[2], generation_config.num_frames)
             : input_features.dims[2];
 

--- a/packages/transformers/src/models/whisper/modeling_whisper.js
+++ b/packages/transformers/src/models/whisper/modeling_whisper.js
@@ -201,7 +201,9 @@ export class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
 
         // input_features shape: [batch=1, n_mels, total_frames]
         const input_features = inputs;
-        const total_frames = input_features.dims[2];
+        const total_frames = generation_config.num_frames
+            ? Math.min(input_features.dims[2], generation_config.num_frames)
+            : input_features.dims[2];
 
         // The encoder downsamples by input_stride (=2 for whisper), so:
         //   num_segment_frames = input_stride * max_source_positions = 3000 mel frames per segment
@@ -343,6 +345,7 @@ export class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
             if (seek_token_timestamps) {
                 allTokenTimestamps.push(...seek_token_timestamps.slice(0, tokens_to_keep));
             }
+            if (segment_offset <= 0) break;
             seek += segment_offset;
         }
 

--- a/packages/transformers/tests/models/whisper/test_modeling_whisper.js
+++ b/packages/transformers/tests/models/whisper/test_modeling_whisper.js
@@ -1,4 +1,4 @@
-import { WhisperTokenizer, WhisperForConditionalGeneration, full } from "../../../src/transformers.js";
+import { WhisperTokenizer, WhisperForConditionalGeneration, full, Tensor } from "../../../src/transformers.js";
 
 import { MAX_MODEL_LOAD_TIME, MAX_TEST_EXECUTION_TIME, MAX_MODEL_DISPOSE_TIME, DEFAULT_MODEL_OPTIONS } from "../../init.js";
 
@@ -136,6 +136,65 @@ export default () => {
             [/* Prefix */ 50258n, 50259n, 50358n, 50363n, /* Generated */ 45084n],
             [/* Prefix */ 50258n, 50265n, 50359n, 50363n, /* Generated */ 45084n],
           ]);
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+    });
+
+    describe("num_frames edge cases", () => {
+      it(
+        "num_frames=0 does not fall back to padded tensor length",
+        async () => {
+          const input_features = full([1, 80, 3000], 0.0);
+          const outputs = await model.generate({
+            input_features,
+            max_new_tokens: 1,
+            return_timestamps: true,
+            num_frames: 0,
+          });
+          // With 0 frames the seek loop should not execute — output is just
+          // init tokens + EOS, no generated content from padded silence.
+          const tokens = outputs.tolist()[0];
+          expect(tokens.length).toBeLessThanOrEqual(4);
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+
+      it(
+        "short audio (fewer frames than one segment) with timestamps",
+        async () => {
+          // 500 frames << 3000 (one full segment)
+          const short_features = full([1, 80, 500], 0.0);
+          const outputs = await model.generate({
+            input_features: short_features,
+            max_new_tokens: 5,
+            return_timestamps: true,
+            num_frames: 500,
+          });
+          const tokens = outputs.tolist()[0];
+          // Should produce some output without crashing
+          expect(tokens.length).toBeGreaterThan(0);
+        },
+        MAX_TEST_EXECUTION_TIME,
+      );
+    });
+
+    describe("timestamp masking", () => {
+      it(
+        "return_timestamps produces timestamp tokens",
+        async () => {
+          const input_features = full([1, 80, 3000], 0.0);
+          const outputs = await model.generate({
+            input_features,
+            max_new_tokens: 4,
+            return_timestamps: true,
+          });
+          const tokens = outputs.tolist()[0].map(Number);
+          // no_timestamps_token_id + 1 is the first timestamp token
+          const { no_timestamps_token_id } = model.generation_config;
+          const timestamp_begin = no_timestamps_token_id + 1;
+          const has_timestamp = tokens.some((t) => t >= timestamp_begin);
+          expect(has_timestamp).toBe(true);
         },
         MAX_TEST_EXECUTION_TIME,
       );


### PR DESCRIPTION
## Summary

Fixes #1684 — Whisper ASR timestamp regression between v3.8.1 and v4.2.0.

Three fixes targeting the seek loop and logits processor introduced in commit `43b2662` ("Overdue Whisper fixes #1594"):

- **Use actual audio length for seek loop bounds** (`modeling_whisper.js`): The seek loop used `input_features.dims[2]` (always 3000 = padded 30s) as `total_frames` instead of `generation_config.num_frames` (set by the ASR pipeline to the real mel frame count). For clips shorter than 30 seconds, this caused the loop to process silence/padding as real audio, producing hallucinated text and incorrect timestamps.

- **Apply `max_initial_timestamp_index` constraint** (`logits_process.js`): A `continue` statement in `WhisperTimeStampLogitsProcessor._call()` skipped the `max_initial_timestamp_index` check at line 326, making it dead code. This allowed the model to generate any timestamp as its first token instead of being constrained to the allowed range. The Python reference implementation has no such early exit — both blocks execute sequentially.

- **Guard against infinite seek loop** (`modeling_whisper.js`): If `segment_offset` computes to zero (e.g., from a degenerate timestamp pair), the seek loop would run forever. Added a `break` when `segment_offset <= 0`.

## Test plan

- [ ] Verify with the reproduction case from #1684 (Steve Jobs keynote audio) — timestamps should match v3.8.1 output
- [ ] Verify `[applause]` segment is no longer dropped
- [ ] Existing Whisper prefix token tests (`test_modeling_whisper.js`) still pass — they use `max_new_tokens` which bypasses the seek loop
- [ ] Test with audio shorter than 30s — seek loop should terminate after one iteration
- [ ] Test with audio longer than 30s — multi-segment seek should still work correctly