### PR TITLE
Register devices when the ONNX runtime is injected via Symbol.for('onnxruntime')

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -102,11 +102,14 @@ let defaultDevices;
 let ONNX;
 const ORT_SYMBOL = Symbol.for('onnxruntime');
 
-if (ORT_SYMBOL in globalThis) {
-    // If the JS runtime exposes their own ONNX runtime, use it
-    ONNX = globalThis[ORT_SYMBOL];
-} else if (apis.IS_NODE_ENV) {
-    ONNX = ONNX_NODE;
+// If the JS runtime exposes their own ONNX runtime, use it in place of the bundled one. The environment still
+// decides which device list applies: `ONNX` and `supportedDevices` are set together in every branch below, and
+// an injected runtime that set only the former would leave every `device` option rejected against an empty
+// list ("Unsupported device: ... Should be one of: ").
+const injectedONNX = ORT_SYMBOL in globalThis ? globalThis[ORT_SYMBOL] : undefined;
+
+if (apis.IS_NODE_ENV) {
+    ONNX = injectedONNX ?? ONNX_NODE;
 
     // Updated as of ONNX Runtime 1.23.0-dev.20250612-70f14d7670
     // The following table lists the supported versions of ONNX Runtime Node.js binding provided with pre-built binaries.
@@ -135,7 +138,7 @@ if (ORT_SYMBOL in globalThis) {
     supportedDevices.push('cpu');
     defaultDevices = ['cpu'];
 } else {
-    ONNX = ONNX_WEB;
+    ONNX = injectedONNX ?? ONNX_WEB;
 
     if (apis.IS_WEBNN_AVAILABLE) {
         // TODO: Only push supported providers (depending on available hardware)

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -102,13 +102,37 @@ let defaultDevices;
 let ONNX;
 const ORT_SYMBOL = Symbol.for('onnxruntime');
 
-// If the JS runtime exposes their own ONNX runtime, use it in place of the bundled one. The environment still
-// decides which device list applies: `ONNX` and `supportedDevices` are set together in every branch below, and
-// an injected runtime that set only the former would leave every `device` option rejected against an empty
-// list ("Unsupported device: ... Should be one of: ").
+// If the JS runtime exposes its own ONNX runtime, use it in place of the bundled one.
 const injectedONNX = ORT_SYMBOL in globalThis ? globalThis[ORT_SYMBOL] : undefined;
 
-if (apis.IS_NODE_ENV) {
+/**
+ * Which ONNX Runtime is in use, which decides the list of supported devices below:
+ *  - `node`: onnxruntime-node — the devices depend on the platform.
+ *  - `web`: onnxruntime-web — the devices depend on the browser APIs available.
+ *  - `custom`: an injected runtime that is neither. It implements the onnxruntime API surface (`Tensor`,
+ *    `InferenceSession`, …) without being one of the official packages, so no device list is assumed and the
+ *    runtime is left to apply its own defaults.
+ *
+ * An injected runtime is told apart by the version it stamps on its `env`: every official package sets
+ * `env.versions.web` or `env.versions.node` (see `Env.versions` in onnxruntime-common), a custom runtime sets
+ * neither. The environment alone cannot tell, because embedders inject `onnxruntime-web` from processes where
+ * `IS_NODE_ENV` is true (Electron renderers, Bun, Node fallbacks) and would otherwise be given the node device
+ * list. Without an injected runtime, the environment decides as before.
+ * @type {'node' | 'web' | 'custom'}
+ */
+const runtime = injectedONNX?.env?.versions?.node
+    ? 'node'
+    : injectedONNX?.env?.versions?.web
+      ? 'web'
+      : injectedONNX
+        ? 'custom'
+        : apis.IS_NODE_ENV
+          ? 'node'
+          : 'web';
+
+if (runtime === 'custom') {
+    ONNX = injectedONNX;
+} else if (runtime === 'node') {
     ONNX = injectedONNX ?? ONNX_NODE;
 
     // Updated as of ONNX Runtime 1.23.0-dev.20250612-70f14d7670

--- a/packages/transformers/tests/injected_runtime.test.js
+++ b/packages/transformers/tests/injected_runtime.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+const ORT_SYMBOL = Symbol.for("onnxruntime");
+
+/**
+ * Evaluate `backends/onnx.js` afresh with `globalThis[Symbol.for('onnxruntime')]` set to `runtime`, and return
+ * the devices it resolved. The module reads the symbol once, when it is evaluated, so every case needs its own
+ * module registry.
+ */
+async function devicesWith(runtime) {
+  let devices;
+  globalThis[ORT_SYMBOL] = runtime;
+  try {
+    await jest.isolateModulesAsync(async () => {
+      const { deviceToExecutionProviders } = await import("../src/backends/onnx.js");
+      devices = { auto: deviceToExecutionProviders("auto"), defaults: deviceToExecutionProviders(null) };
+    });
+  } finally {
+    delete globalThis[ORT_SYMBOL];
+  }
+  return devices;
+}
+
+/** The shape an injected runtime has: the onnxruntime API surface, with an `env` that may carry a version stamp. */
+const runtime = (versions) => ({
+  env: versions ? { versions: { common: "0.0.0", ...versions } } : {},
+  Tensor: class {},
+  InferenceSession: { create() {} },
+});
+
+describe("Injected ONNX runtime (globalThis[Symbol.for('onnxruntime')])", () => {
+  it("an injected onnxruntime-web gets the web device list, whatever the process", async () => {
+    // This test runs under Node, where the environment alone would pick the node list.
+    const { auto, defaults } = await devicesWith(runtime({ web: "0.0.0" }));
+    expect(auto).toContain("wasm");
+    expect(auto).not.toContain("cpu");
+    expect(defaults).toEqual(["wasm"]);
+  });
+
+  it("an injected onnxruntime-node gets the node device list", async () => {
+    const { auto, defaults } = await devicesWith(runtime({ node: "0.0.0" }));
+    expect(auto).toContain("cpu");
+    expect(auto).not.toContain("wasm");
+    expect(defaults).toEqual(["cpu"]);
+  });
+
+  it("a custom runtime, stamped with no version, gets no device list and keeps its own defaults", async () => {
+    const { auto, defaults } = await devicesWith(runtime(null));
+    expect(auto).toEqual([]);
+    expect(defaults).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`backends/onnx.js` documents an injection point:

```js
if (ORT_SYMBOL in globalThis) {
    // If the JS runtime exposes their own ONNX runtime, use it
    ONNX = globalThis[ORT_SYMBOL];
} else if (apis.IS_NODE_ENV) {
    ...
```

That branch sets `ONNX` and then falls past **both** of the branches that populate `supportedDevices` and
`defaultDevices`. Every other path sets the module and the device list together.

The result is that an embedder using the documented seam gets an empty device list, and every `device`
option is rejected before anything loads:

```
Error: Unsupported device: "webgpu". Should be one of:
```

— with nothing after the colon.

## Reproduction

In a browser, with any alternative `onnxruntime-web` build:

```js
globalThis[Symbol.for('onnxruntime')] = await import('onnxruntime-web/jspi');
const { pipeline } = await import('@huggingface/transformers');
await pipeline('text-generation', model_id, { device: 'webgpu', dtype: 'q4f16' });
```

## Fix

Let the *injected runtime* decide which device list applies, by the package it is — not by the process it runs in, and not by assuming it is an official package at all.

Every official package stamps its `env`: `onnxruntime-web` sets `env.versions.web`, `onnxruntime-node` sets
`env.versions.node` (`Env.versions` in `onnxruntime-common`). A custom runtime that only implements the API surface (`Tensor`, `InferenceSession`, …) sets neither. So the stamp tells the three cases apart:

```js
const injectedONNX = ORT_SYMBOL in globalThis ? globalThis[ORT_SYMBOL] : undefined;

const runtime = injectedONNX?.env?.versions?.node
    ? 'node'
    : injectedONNX?.env?.versions?.web
      ? 'web'
      : injectedONNX
        ? 'custom'
        : apis.IS_NODE_ENV
          ? 'node'
          : 'web';

if (runtime === 'custom') {
    ONNX = injectedONNX;                 // no device list assumed — the runtime applies its own defaults, as before
} else if (runtime === 'node') {
    ONNX = injectedONNX ?? ONNX_NODE;    // ...unchanged node device list
} else {
    ONNX = injectedONNX ?? ONNX_WEB;     // ...unchanged browser device list
}
```

- An injected `onnxruntime-web` gets the browser list wherever it runs — including processes where
  `IS_NODE_ENV` is true, which is exactly where embedders inject it (Electron renderers, Bun, Node fallbacks).
- An injected `onnxruntime-node` gets the platform list.
- A custom runtime keeps today's behaviour: no list, no `executionProviders` forced on it.
- Without an injected runtime nothing changes: the environment decides, as before.

## Validation

`tests/injected_runtime.test.js` evaluates the module afresh under each of the three shapes - a module
stamped `versions.web`, one stamped `versions.node`, and a bare `{ Tensor, InferenceSession, env: {} }` and checks the device list each resolves to.

With this branch applied and built, the same call above loads a real 4.9 GB model (`onnx-community/gemma-4-E4B-it-ONNX`, q4f16) on the GPU under an injected JSPI runtime:

```
Ready on WebGPU, q4f16 weights, loaded in 11.5s · 24 KV layers kept between turns.
```