### PR TITLE
Support optional pre-allocated output tensors (fetches) in sessionRun

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -308,10 +308,13 @@ let webInferenceChain = Promise.resolve();
  * Run an inference session.
  * @param {import('onnxruntime-common').InferenceSession} session The ONNX inference session.
  * @param {Record<string, import('onnxruntime-common').Tensor>} ortFeed The input tensors.
+ * @param {Record<string, import('onnxruntime-common').Tensor|null>} [ortFetches] Optional pre-allocated
+ *   output tensors. Outputs mapped to a tensor are written into it, outputs mapped to `null`
+ *   are allocated by ONNX Runtime as usual.
  * @returns {Promise<Record<string, import('onnxruntime-common').Tensor>>} The output tensors.
  */
-export async function runInferenceSession(session, ortFeed) {
-    const run = () => session.run(ortFeed);
+export async function runInferenceSession(session, ortFeed, ortFetches = undefined) {
+    const run = () => (ortFetches ? session.run(ortFeed, ortFetches) : session.run(ortFeed));
     return apis.IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run();
 }
 

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -186,10 +186,12 @@ function replaceTensors(obj) {
  *
  * @param {Object} session The InferenceSession object to run.
  * @param {Object} inputs An object that maps input names to input tensors.
+ * @param {Record<string, Tensor|null>} [fetches] Optional map of output names to pre-allocated output
+ *   tensors (or `null` to let ONNX Runtime allocate them).
  * @returns {Promise<Object>} A Promise that resolves to an object that maps output names to output tensors.
  * @private
  */
-export async function sessionRun(session, inputs) {
+export async function sessionRun(session, inputs, fetches = undefined) {
     const checkedInputs = validateInputs(session, inputs);
     try {
         // pass the original ort tensor
@@ -206,8 +208,17 @@ export async function sessionRun(session, inputs) {
                 return [k, tensor];
             }),
         );
+        let ortFetches;
+        if (fetches) {
+            ortFetches = Object.fromEntries(
+                Object.entries(fetches).map(([k, v]) => [
+                    k,
+                    v instanceof Tensor ? /** @type {any} */ (v).ort_tensor : v,
+                ]),
+            );
+        }
 
-        const output = await runInferenceSession(session, ortFeed);
+        const output = await runInferenceSession(session, ortFeed, ortFetches);
         return replaceTensors(output);
     } catch (e) {
         // Error messages can be long (nested) and uninformative. For this reason,


### PR DESCRIPTION
Thread an optional fetches map through `sessionRun ` and `runInferenceSession ` to `onnxruntime's session.run(feeds, fetches)`. Outputs bound to a tensor are written in place (e.g. a pre-allocated GPU buffer, avoiding a fresh allocation per run); outputs bound to null are allocated by ORT as before. No callers yet, so no behavior change.