### PR TITLE
Add StaticCache: fixed-capacity in-place KV cache for WebGPU

### DIFF
--- a/packages/transformers/docs/source/guides/webgpu.md
+++ b/packages/transformers/docs/source/guides/webgpu.md
@@ -83,6 +83,42 @@ console.log(output);
 // ]
 ```
 
+## Text generation with a static KV cache
+
+By default, text-generation models grow their key/value cache on every decoding step, which on WebGPU means destroying and re-creating GPU buffers as the context gets longer. The cost of this per-step reallocation grows with the context length and with the size of the model's KV cache, and for long generations it can become a significant part of the decoding time.
+
+You can opt in to a `StaticCache`, which allocates each cache entry once at a fixed capacity and writes the model's cache outputs in place onto the same GPU buffers, eliminating per-step cache reallocations entirely:
+
+```js
+import { pipeline, StaticCache } from "@huggingface/transformers";
+
+// Create a text generation pipeline on WebGPU
+const generator = await pipeline(
+  "text-generation",
+  "onnx-community/Qwen2.5-0.5B-Instruct",
+  { dtype: "q4", device: "webgpu" },
+);
+
+// Allocate a cache with room for up to 4096 tokens (prompt + generated)
+const past_key_values = new StaticCache({ max_cache_len: 4096 });
+
+const output = await generator("Write me a poem about Machine Learning.", {
+  max_new_tokens: 512,
+  past_key_values,
+});
+
+// The cache is owned by the caller and holds GPU memory: dispose it when done
+await past_key_values.dispose();
+```
+
+Note the following constraints, which are enforced with explicit errors:
+
+- WebGPU only (`device: "webgpu"`).
+- Decoder-only models with batch size 1.
+- The exported model must support past/present cache entries sharing one buffer (true for GQA-based exports).
+
+If any of these do not apply, simply omit `past_key_values` to use the default dynamic cache.
+
 ## Reporting bugs and providing feedback
 
 Due to the experimental nature of WebGPU, especially in non-Chromium browsers, you may experience issues when trying to run a model (even if it can run in WASM). If you do, please open [an issue on GitHub](https://github.com/huggingface/transformers.js/issues/new?title=[WebGPU]%20Error%20running%20MODEL_GOES_HERE&assignees=&labels=bug,webgpu&projects=&template=1_bug-report.yml) and we'll do our best to address it. Thanks!

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -318,6 +318,49 @@ export async function runInferenceSession(session, ortFeed, ortFetches = undefin
     return apis.IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run();
 }
 
+/** Bytes per element for the data types that may appear as model cache states (see `StaticCache`). */
+const GPU_TENSOR_BYTES_PER_ELEMENT = Object.freeze({
+    float16: 2,
+    float32: 4,
+    int32: 4,
+    uint32: 4,
+});
+
+/**
+ * Allocate a zero-initialized WebGPU-buffer ONNX tensor.
+ *
+ * @param {string} dataType The tensor data type.
+ * @param {number[]} dims The tensor dimensions.
+ * @returns {Promise<{tensor: import('onnxruntime-common').Tensor, gpuBuffer: GPUBuffer}>}
+ */
+export async function createGpuBufferTensor(dataType, dims) {
+    const device = await ONNX_ENV?.webgpu?.device;
+    if (!device) {
+        throw new Error("No WebGPU device available. GPU-buffer tensors require the 'webgpu' device.");
+    }
+    const bytesPerElement = GPU_TENSOR_BYTES_PER_ELEMENT[dataType];
+    if (!bytesPerElement) {
+        throw new Error(
+            `Unsupported data type for a GPU-buffer tensor: '${dataType}'. ` +
+                `Supported types: ${Object.keys(GPU_TENSOR_BYTES_PER_ELEMENT).join(', ')}.`,
+        );
+    }
+    const numElements = dims.reduce((a, b) => a * b, 1);
+    const byteLength = Math.ceil((numElements * bytesPerElement) / 16) * 16; // 16-byte aligned
+    const gpuBuffer = device.createBuffer({
+        size: byteLength,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+    try {
+        const tensor = /** @type {any} */ (ONNX.Tensor).fromGpuBuffer(gpuBuffer, { dataType, dims });
+        return { tensor, gpuBuffer };
+    } catch (e) {
+        // The buffer has not been handed to the caller yet, so it must be destroyed here.
+        gpuBuffer.destroy();
+        throw e;
+    }
+}
+
 /**
  * Check if an object is an ONNX tensor.
  * @param {any} x The object to check

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -308,10 +308,13 @@ let webInferenceChain = Promise.resolve();
  * Run an inference session.
  * @param {import('onnxruntime-common').InferenceSession} session The ONNX inference session.
  * @param {Record<string, import('onnxruntime-common').Tensor>} ortFeed The input tensors.
+ * @param {Record<string, import('onnxruntime-common').Tensor|null>} [ortFetches] Optional pre-allocated
+ *   output tensors. Outputs mapped to a tensor are written into it, outputs mapped to `null`
+ *   are allocated by ONNX Runtime as usual.
  * @returns {Promise<Record<string, import('onnxruntime-common').Tensor>>} The output tensors.
  */
-export async function runInferenceSession(session, ortFeed) {
-    const run = () => session.run(ortFeed);
+export async function runInferenceSession(session, ortFeed, ortFetches = undefined) {
+    const run = () => (ortFetches ? session.run(ortFeed, ortFetches) : session.run(ortFeed));
     return apis.IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run();
 }
 

--- a/packages/transformers/src/cache_utils.js
+++ b/packages/transformers/src/cache_utils.js
@@ -1,4 +1,26 @@
+/// <reference types="@webgpu/types" />
 import { Tensor } from './utils/tensor.js';
+import { createGpuBufferTensor, isONNXProxy } from './backends/onnx.js';
+
+/**
+ * Map a cache output name to the corresponding cache input name.
+ * @param {string} name The output name.
+ * @returns {string} The matching input name.
+ */
+export function presentNameToPastName(name) {
+    return (
+        name
+            // Hybrid cache architecture
+            .replace('present_ssm', 'past_ssm') // Mamba
+            .replace('present_conv', 'past_conv') // LFM2
+            .replace('present_recurrent', 'past_recurrent') // Qwen3.5
+            .replace('present_compressor', 'past_compressor') // Deepseek V4
+            .replace('present_indexer', 'past_indexer') // Deepseek V4
+
+            // Standard cache architecture
+            .replace('present', 'past_key_values')
+    );
+}
 
 /**
  * A cache class that stores past key values as named tensors.
@@ -79,4 +101,296 @@ class _DynamicCache {
 
 export const DynamicCache = /** @type {new (entries?: Record<string, Tensor>) => DynamicCache} */ (
     /** @type {unknown} */ (_DynamicCache)
+);
+
+/**
+ * A cache with a fixed, pre-allocated capacity, held entirely in GPU buffers.
+ *
+ * Each entry is allocated once at `max_cache_len` and the model's cache outputs
+ * are written in place onto the same buffers via run-fetches.
+ *
+ * Constraints: WebGPU only, decoder-only models, batch size 1, and the exported
+ * graph must support past/present sharing one buffer (`past_present_share_buffer`
+ * semantics, true for GQA-based exports).
+ *
+ * The cache is owned by the caller and must be disposed:
+ * ```js
+ * const past_key_values = new StaticCache({ max_cache_len: 4096 });
+ * await generator(messages, { max_new_tokens: 256, past_key_values });
+ * await past_key_values.dispose();
+ * ```
+ */
+class _StaticCache {
+    /** @type {number} */
+    #max_cache_len;
+    /** @type {number} */
+    #seq_length = 0;
+    /** @type {Record<string, Tensor|null>|null} Output name -> in-place output tensor (or null = ORT-allocated). */
+    #fetches = null;
+    /** @type {GPUBuffer[]} GPU buffers owned by this cache. */
+    #buffers = [];
+    /** @type {boolean} */
+    #disposed = false;
+    /** @type {boolean} */
+    #in_use = false;
+
+    /**
+     * @param {Object} options
+     * @param {number} options.max_cache_len Maximum total sequence length (prompt + generated tokens).
+     */
+    constructor({ max_cache_len }) {
+        if (!Number.isInteger(max_cache_len) || max_cache_len <= 0) {
+            throw new Error(`StaticCache requires a positive integer \`max_cache_len\`, got ${max_cache_len}.`);
+        }
+        this.#max_cache_len = max_cache_len;
+    }
+
+    get max_cache_len() {
+        return this.#max_cache_len;
+    }
+
+    get allocated() {
+        return this.#fetches !== null;
+    }
+
+    #assertNotDisposed() {
+        if (this.#disposed) {
+            throw new Error('StaticCache has been disposed. Create a new StaticCache instead.');
+        }
+    }
+
+    /**
+     * Get the cached sequence length.
+     * @returns {number} The past sequence length.
+     */
+    get_seq_length() {
+        return this.#seq_length;
+    }
+
+    /**
+     * No-op: cache outputs are written in place, so there is nothing to store.
+     * @param {Record<string, Tensor>} newEntries Ignored.
+     */
+    update(newEntries) {}
+
+    /**
+     * Allocate the cache buffers from the decoder session's metadata.
+     *
+     * Allocation is transactional: entries are first built into local structures and only
+     * committed onto the cache once every allocation has succeeded.
+     *
+     * @param {Object} session The decoder InferenceSession (with `.config.device` attached).
+     * @param {Set<string>} cacheInputNames Cache input names (from `getCacheNames`).
+     * @param {Record<string, number>} symbols Resolved symbolic dims (e.g. `{ batch_size: 1 }`).
+     * @returns {Promise<void>}
+     * @internal
+     */
+    async _allocate(session, cacheInputNames, symbols) {
+        this.#assertNotDisposed();
+        if (session.config?.device !== 'webgpu') {
+            throw new Error(
+                `StaticCache is only supported on the 'webgpu' device (got '${session.config?.device}'). ` +
+                    'Use DynamicCache (the default) instead.',
+            );
+        }
+        if (isONNXProxy()) {
+            throw new Error('StaticCache is not supported when the ONNX backend is proxied.');
+        }
+
+        /** @type {Record<string, Tensor>} */
+        const entries = Object.create(null);
+        /** @type {GPUBuffer[]} */
+        const buffers = [];
+        try {
+            for (const meta of session.inputMetadata) {
+                if (!cacheInputNames.has(meta.name)) continue;
+
+                const isAttention = meta.name.startsWith('past_key_values.');
+                const dims = meta.shape.map((d, i) => {
+                    if (typeof d === 'number' && d > 0) return d;
+                    if (symbols[d] !== undefined) return symbols[d];
+                    if (isAttention && i === meta.shape.length - 2) return this.#max_cache_len;
+                    throw new Error(
+                        `StaticCache: unable to resolve dimension ${i} (${JSON.stringify(d)}) of cache input ` +
+                            `'${meta.name}' (shape: [${meta.shape.map((x) => JSON.stringify(x)).join(', ')}]). ` +
+                            'Use DynamicCache (the default) instead.',
+                    );
+                });
+                const { tensor, gpuBuffer } = await createGpuBufferTensor(meta.type, dims);
+                // Track the buffer before wrapping so it is destroyed on a later failure.
+                buffers.push(gpuBuffer);
+                entries[meta.name] = new Tensor(tensor);
+            }
+            if (buffers.length === 0) {
+                throw new Error(
+                    'StaticCache: the model session has no cache inputs. ' +
+                        'Use DynamicCache (the default) for models without a KV cache.',
+                );
+            }
+
+            const fetches = Object.create(null);
+            for (const meta of session.outputMetadata) {
+                const name = meta.name;
+                const past = presentNameToPastName(name);
+                if (name === past || !(entries[past] instanceof Tensor)) {
+                    fetches[name] = null;
+                    continue;
+                }
+                this.#checkShareBufferSemantics(name, meta.shape, past, entries[past].dims);
+                fetches[name] = entries[past];
+            }
+
+            // Only reached once every allocation has succeeded.
+            Object.assign(this, entries);
+            this.#buffers = buffers;
+            this.#fetches = fetches;
+        } catch (e) {
+            // Release the ORT tensor wrappers, then destroy the underlying GPU buffers.
+            for (const tensor of Object.values(entries)) {
+                tensor.dispose();
+            }
+            for (const buffer of buffers) {
+                if (typeof buffer.destroy === 'function') buffer.destroy();
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Check whether a `present.*` output can safely share the `past.*` buffer.
+     * Rejects concatenation-style shapes whose sequence axis grows with the past length
+     * as they are incompatible with fixed-size buffers.
+     *
+     * @param {string} presentName The output name.
+     * @param {ReadonlyArray<number|string>} presentShape The output's metadata shape.
+     * @param {string} pastName The matching cache input name.
+     * @param {ReadonlyArray<number>} allocatedDims The dims the cache entry was allocated with.
+     */
+    #checkShareBufferSemantics(presentName, presentShape, pastName, allocatedDims) {
+        if (!pastName.startsWith('past_key_values.')) return;
+
+        const axis = allocatedDims.length - 2;
+        const presentDim = presentShape?.[axis];
+        if (typeof presentDim === 'string' && presentDim.includes('+')) {
+            throw new Error(
+                `StaticCache requires past/present buffer sharing (\`past_present_share_buffer\`), but ` +
+                    `'${presentName}' declares its sequence axis as '${presentDim}', which grows with the past length. ` +
+                    'Use DynamicCache (the default) instead.',
+            );
+        }
+        if (typeof presentDim === 'number' && presentDim !== allocatedDims[axis]) {
+            throw new Error(
+                `StaticCache: '${presentName}' has a fixed sequence length of ${presentDim}, ` +
+                    `which does not match the allocated cache length (${allocatedDims[axis]}). ` +
+                    `Set \`max_cache_len\` to ${presentDim} or use DynamicCache (the default) instead.`,
+            );
+        }
+    }
+
+    /**
+     * Mark the cache as in use by a generation.
+     * @internal
+     */
+    _acquire() {
+        this.#assertNotDisposed();
+        if (this.#in_use) {
+            throw new Error(
+                'This StaticCache is already in use by a concurrent generation. ' +
+                    'A StaticCache can only serve one generation at a time.',
+            );
+        }
+        this.#in_use = true;
+    }
+
+    /**
+     * Release the cache after a generation has finished.
+     * @internal
+     */
+    _release() {
+        this.#in_use = false;
+    }
+
+    /**
+     * @internal
+     */
+    _getFetches() {
+        return this.#fetches;
+    }
+
+    /**
+     * Assert that the run wrote every cache output in place. A substituted output would leave the new
+     * KV data outside the cache's buffers, so fail loudly before the sequence length is committed.
+     * @param {Record<string, Tensor>} outputs The outputs returned by the run.
+     * @internal
+     */
+    _assertWrittenInPlace(outputs) {
+        if (!this.#fetches) return;
+        for (const [name, tensor] of Object.entries(this.#fetches)) {
+            if (tensor !== null && outputs[name] !== tensor) {
+                throw new Error(
+                    `StaticCache: the '${name}' output was not written into the pre-allocated cache tensor. ` +
+                        'Use DynamicCache (the default) instead.',
+                );
+            }
+        }
+    }
+
+    /**
+     * Check that `numTokens` more tokens fit in the cache, without changing its state.
+     * @param {number} numTokens Number of tokens about to be written.
+     * @internal
+     */
+    _checkCapacity(numTokens) {
+        this.#assertNotDisposed();
+        if (this.#seq_length + numTokens > this.#max_cache_len) {
+            throw new Error(
+                `StaticCache capacity exceeded: ${this.#seq_length} cached + ${numTokens} new tokens > ` +
+                    `max_cache_len (${this.#max_cache_len}). Increase \`max_cache_len\`.`,
+            );
+        }
+    }
+
+    /**
+     * Advance the cached sequence length. Call only after the run has succeeded.
+     * @param {number} numTokens Number of tokens that were written.
+     * @internal
+     */
+    _commit(numTokens) {
+        this.#seq_length += numTokens;
+    }
+
+    /**
+     * Release the cache's tensors and destroy its GPU buffers. Idempotent; any
+     * further use of the cache throws.
+     * @returns {Promise<void>}
+     */
+    async dispose() {
+        if (this.#disposed) return;
+        if (this.#in_use) {
+            throw new Error('Cannot dispose a StaticCache while it is in use by a generation.');
+        }
+        this.#disposed = true;
+        // Release the wrappers (drops references only); the buffers are destroyed below.
+        for (const key of Object.keys(this)) {
+            const tensor = this[key];
+            if (tensor instanceof Tensor) {
+                tensor.dispose();
+            }
+            delete this[key];
+        }
+        for (const buffer of this.#buffers) {
+            if (typeof buffer.destroy === 'function') buffer.destroy();
+        }
+        this.#buffers = [];
+        this.#fetches = null;
+        this.#seq_length = 0;
+    }
+}
+
+/**
+ * @typedef {Record<string, Tensor> & _StaticCache} StaticCache
+ */
+
+export const StaticCache = /** @type {new (options: { max_cache_len: number }) => StaticCache} */ (
+    /** @type {unknown} */ (_StaticCache)
 );

--- a/packages/transformers/src/models/hrm_text/modeling_hrm_text.js
+++ b/packages/transformers/src/models/hrm_text/modeling_hrm_text.js
@@ -12,7 +12,9 @@ export class HrmTextForCausalLM extends HrmTextPreTrainedModel {
         // HRM-Text can be pretrained as a PrefixLM.
         // token_type_ids=1 marks tokens inside the bidirectional prefix block,
         // and 0 marks autoregressively generated tokens.
-        prepared.token_type_ids = (prepared.past_key_values ? zeros_like : ones_like)(prepared.input_ids);
+        // Check cached tokens.
+        const has_past_tokens = (prepared.past_key_values?.get_seq_length() ?? 0) > 0;
+        prepared.token_type_ids = (has_past_tokens ? zeros_like : ones_like)(prepared.input_ids);
         return prepared;
     }
 }

--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -37,7 +37,7 @@ import { LogitsSampler } from '../generation/logits_sampler.js';
 import { DefaultProgressCallback, pick } from '../utils/core.js';
 import { ModelOutput } from './modeling_outputs.js';
 import { logger } from '../utils/logger.js';
-import { DynamicCache } from '../cache_utils.js';
+import { DynamicCache, StaticCache, presentNameToPastName } from '../cache_utils.js';
 import { get_model_files } from '../utils/model_registry/get_model_files.js';
 import { get_file_metadata } from '../utils/model_registry/get_file_metadata.js';
 import { MODEL_SESSION_CONFIG, MODEL_TYPES } from './session_config.js';
@@ -695,7 +695,7 @@ export class PreTrainedModel extends Callable {
      * @param {Tensor} [params.inputs=null]
      * @param {number} [params.bos_token_id=null]
      * @param {Record<string, Tensor|number[]>} [params.model_kwargs]
-     * @returns {{inputs_tensor: Tensor, model_inputs: Record<string, Tensor> & {past_key_values?: DynamicCache}, model_input_name: string}} The model-specific inputs for generation.
+     * @returns {{inputs_tensor: Tensor, model_inputs: Record<string, Tensor> & {past_key_values?: DynamicCache|StaticCache}, model_input_name: string}} The model-specific inputs for generation.
      */
     _prepare_model_inputs({ inputs, bos_token_id, model_kwargs }) {
         const model_inputs = pick(model_kwargs, this.forward_params);
@@ -895,6 +895,23 @@ export class PreTrainedModel extends Callable {
             generation_config.max_length = input_ids_length + generation_config.max_new_tokens;
         }
 
+        // Fail fast if the generation cannot fit in the StaticCache: the last sampled
+        // token is never forwarded, so at most `max_length - 1` tokens are cached.
+        const provided_cache = model_inputs.past_key_values ?? kwargs.past_key_values;
+        const static_cache = provided_cache instanceof StaticCache ? provided_cache : null;
+        if (
+            static_cache &&
+            generation_config.max_length !== null &&
+            generation_config.max_length - 1 > static_cache.max_cache_len
+        ) {
+            throw new Error(
+                `The requested generation may cache up to ${generation_config.max_length - 1} tokens ` +
+                    `(input length ${input_ids_length}), which exceeds the StaticCache capacity ` +
+                    `(max_cache_len: ${static_cache.max_cache_len}). ` +
+                    'Increase `max_cache_len`, or reduce `max_new_tokens`/`max_length`.',
+            );
+        }
+
         // input_ids_length = model_inputs[model_input_name].dims.at(1);
         // // inputs instanceof Tensor ?  : inputs.length;
 
@@ -959,72 +976,78 @@ export class PreTrainedModel extends Callable {
         let outputs;
         let attentions = {};
         let return_dict_items = {};
-        while (true) {
-            // prepare model inputs
-            model_inputs = this.prepare_inputs_for_generation(all_input_ids, model_inputs, generation_config);
-            outputs = await this.forward(model_inputs);
 
-            if (generation_config.return_dict_in_generate) {
-                if (generation_config.output_attentions) {
-                    // Get attentions if they are present
-                    const token_attentions = getAttentions(outputs);
-                    for (const key in token_attentions) {
-                        if (!(key in attentions)) {
-                            attentions[key] = [];
+        static_cache?._acquire();
+        try {
+            while (true) {
+                // prepare model inputs
+                model_inputs = this.prepare_inputs_for_generation(all_input_ids, model_inputs, generation_config);
+                outputs = await this.forward(model_inputs);
+
+                if (generation_config.return_dict_in_generate) {
+                    if (generation_config.output_attentions) {
+                        // Get attentions if they are present
+                        const token_attentions = getAttentions(outputs);
+                        for (const key in token_attentions) {
+                            if (!(key in attentions)) {
+                                attentions[key] = [];
+                            }
+                            attentions[key].push(token_attentions[key]);
                         }
-                        attentions[key].push(token_attentions[key]);
+                    } else if (this._return_dict_in_generate_keys) {
+                        Object.assign(return_dict_items, pick(outputs, this._return_dict_in_generate_keys));
                     }
-                } else if (this._return_dict_in_generate_keys) {
-                    Object.assign(return_dict_items, pick(outputs, this._return_dict_in_generate_keys));
                 }
-            }
 
-            // Logits are of the form [batch_size, out_seq_length, vocab_size]
-            // In most cases, this will be [batch_size, 1, vocab_size]
-            // So, we select the last token's logits:
-            // (equivalent to `logits = outputs.logits[:, -1, :]`)
-            // The `.to('float32')` is necessary for models with float16 logits,
-            // and is a no-op for float32 logits.
-            // TODO: Support float16 sampling in the sampler directly
-            const logits = outputs.logits.slice(null, -1, null).to('float32');
+                // Logits are of the form [batch_size, out_seq_length, vocab_size]
+                // In most cases, this will be [batch_size, 1, vocab_size]
+                // So, we select the last token's logits:
+                // (equivalent to `logits = outputs.logits[:, -1, :]`)
+                // The `.to('float32')` is necessary for models with float16 logits,
+                // and is a no-op for float32 logits.
+                // TODO: Support float16 sampling in the sampler directly
+                const logits = outputs.logits.slice(null, -1, null).to('float32');
 
-            const next_tokens_scores = prepared_logits_processor(all_input_ids, logits);
+                const next_tokens_scores = prepared_logits_processor(all_input_ids, logits);
 
-            /** @type {[bigint][]} */
-            const generated_input_ids = [];
-            // const new_kv_cache = [];// NOTE: Only used for beam search when concatenating new kv
-            // Loop over each batch
-            for (let batch_idx = 0; batch_idx < next_tokens_scores.dims.at(0); ++batch_idx) {
-                const logs = next_tokens_scores[batch_idx];
+                /** @type {[bigint][]} */
+                const generated_input_ids = [];
+                // const new_kv_cache = [];// NOTE: Only used for beam search when concatenating new kv
+                // Loop over each batch
+                for (let batch_idx = 0; batch_idx < next_tokens_scores.dims.at(0); ++batch_idx) {
+                    const logs = next_tokens_scores[batch_idx];
 
-                const sampledTokens = await sampler(logs);
-                for (const [newTokenId, logProb] of sampledTokens) {
-                    const bigint = BigInt(newTokenId);
-                    // TODO: If branching, use previous beam as a starting point
-                    // update generated ids, model inputs, and length for next step
-                    scores[batch_idx] += logProb;
-                    all_input_ids[batch_idx].push(bigint);
-                    generated_input_ids.push([bigint]);
+                    const sampledTokens = await sampler(logs);
+                    for (const [newTokenId, logProb] of sampledTokens) {
+                        const bigint = BigInt(newTokenId);
+                        // TODO: If branching, use previous beam as a starting point
+                        // update generated ids, model inputs, and length for next step
+                        scores[batch_idx] += logProb;
+                        all_input_ids[batch_idx].push(bigint);
+                        generated_input_ids.push([bigint]);
 
-                    // TODO: Support beam search
+                        // TODO: Support beam search
+                        break;
+                    }
+                }
+                if (streamer) {
+                    streamer.put(generated_input_ids);
+                }
+
+                const stop = prepared_stopping_criteria(all_input_ids);
+                if (stop.every((x) => x)) {
                     break;
                 }
-            }
-            if (streamer) {
-                streamer.put(generated_input_ids);
-            }
 
-            const stop = prepared_stopping_criteria(all_input_ids);
-            if (stop.every((x) => x)) {
-                break;
+                model_inputs = this._update_model_kwargs_for_generation({
+                    generated_input_ids,
+                    outputs,
+                    model_inputs,
+                    is_encoder_decoder,
+                });
             }
-
-            model_inputs = this._update_model_kwargs_for_generation({
-                generated_input_ids,
-                outputs,
-                model_inputs,
-                is_encoder_decoder,
-            });
+        } finally {
+            static_cache?._release();
         }
 
         if (streamer) {
@@ -1037,7 +1060,7 @@ export class PreTrainedModel extends Callable {
         // Update past key values from the final forward pass
         const past_key_values = getPastKeyValues(outputs, model_inputs.past_key_values);
 
-        // Dispose output tensors not held by the cache
+        // Dispose output tensors not held by the cache.
         const cachedTensors = new Set(Object.values(past_key_values));
         for (const tensor of Object.values(outputs)) {
             if (tensor.location === 'gpu-buffer' && !cachedTensors.has(tensor)) {
@@ -1175,25 +1198,20 @@ export async function auto_encoder_forward(self, model_inputs) {
  * Always updates in-place when pastKeyValues is provided; creates a new DynamicCache otherwise.
  *
  * @param {Object} decoderResults The decoder results object.
- * @param {DynamicCache} pastKeyValues The previous past key values.
- * @returns {DynamicCache} The updated past key values cache.
+ * @param {DynamicCache|StaticCache} pastKeyValues The previous past key values.
+ * @returns {DynamicCache|StaticCache} The updated past key values cache.
  */
 export function getPastKeyValues(decoderResults, pastKeyValues) {
+    if (pastKeyValues instanceof StaticCache) {
+        return pastKeyValues;
+    }
+
     /** @type {Record<string, Tensor>} */
     const pkvs = Object.create(null);
 
     for (const name in decoderResults) {
         if (name.startsWith('present')) {
-            const newName = name
-                // Hybrid cache architecture
-                .replace('present_ssm', 'past_ssm') // Mamba
-                .replace('present_conv', 'past_conv') // LFM2
-                .replace('present_recurrent', 'past_recurrent') // Qwen3.5
-                .replace('present_compressor', 'past_compressor') // Deepseek V4
-                .replace('present_indexer', 'past_indexer') // Deepseek V4
-
-                // Standard cache architecture
-                .replace('present', 'past_key_values');
+            const newName = presentNameToPastName(name);
             const is_encoder_pkv = name.includes('encoder');
             if (is_encoder_pkv && pastKeyValues) {
                 // Optimization introduced by optimum to reuse past key values.
@@ -1256,16 +1274,36 @@ export function resolveCacheShape(metadataShape, symbols) {
  *
  * @param {PreTrainedModel} self The model instance.
  * @param {Record<string, any>} decoderFeeds The decoder feeds object to add past key values to.
- * @param {DynamicCache|null} pastKeyValues The cache containing past key values.
- * @returns {DynamicCache} The past key values cache (existing or newly created).
+ * @param {DynamicCache|StaticCache|null} pastKeyValues The cache containing past key values.
+ * @param {Object} [session] The decoder InferenceSession.
+ * @returns {Promise<DynamicCache|StaticCache>} The past key values cache (existing or newly created).
  */
-export function addPastKeyValues(self, decoderFeeds, pastKeyValues) {
+export async function addPastKeyValues(self, decoderFeeds, pastKeyValues, session = undefined) {
+    session ??= self.sessions['decoder_model_merged'] ?? self.sessions['model'];
+
+    if (pastKeyValues instanceof StaticCache && !pastKeyValues.allocated) {
+        // First forward pass, allocate the cache from the decoder session's metadata.
+        if (self.config.is_encoder_decoder) {
+            throw new Error('StaticCache does not support encoder-decoder models.');
+        }
+        const batch_size = (decoderFeeds[self.main_input_name] ?? decoderFeeds.attention_mask)?.dims?.[0] ?? 1;
+        if (batch_size !== 1) {
+            throw new Error(`StaticCache currently only supports batch_size 1 (got ${batch_size}).`);
+        }
+        const num_heads = self.config?.normalized_config?.num_heads;
+        /** @type {Record<string, number>} */
+        const symbols = { batch_size };
+        if (typeof num_heads === 'number') {
+            symbols['batch_size x num_heads'] = batch_size * num_heads;
+        }
+        await pastKeyValues._allocate(session, getCacheNames(self.config), symbols);
+    }
+
     if (pastKeyValues && Object.keys(pastKeyValues).length > 0) {
         Object.assign(decoderFeeds, pastKeyValues);
         return pastKeyValues;
     }
 
-    const session = self.sessions['decoder_model_merged'] ?? self.sessions['model'];
     const batch_size = (decoderFeeds[self.main_input_name] ?? decoderFeeds.attention_mask)?.dims?.[0] ?? 1;
 
     const names = getCacheNames(self.config);
@@ -1350,11 +1388,32 @@ export async function decoder_forward(self, model_inputs, is_encoder_decoder = f
     setNumLogitsToKeep(self, new_model_inputs, 0n);
 
     // Unpack the `past_key_values` object into model inputs
-    addPastKeyValues(self, new_model_inputs, past_key_values);
+    await addPastKeyValues(self, new_model_inputs, past_key_values, session);
 
     // Select only the inputs that are needed for the current session
     const fixed = pick(new_model_inputs, session.inputNames);
-    return await sessionRun(session, fixed);
+    return await runDecoderSession(session, fixed, past_key_values);
+}
+
+/**
+ * Run a decoder session, binding cache outputs in place when a `StaticCache` is
+ * used. Decoder runs that may carry a `StaticCache` must go through this function.
+ *
+ * @param {Object} session The decoder InferenceSession.
+ * @param {Record<string, Tensor>} inputs The session inputs.
+ * @param {DynamicCache|StaticCache|null} past_key_values The cache in use.
+ * @returns {Promise<Object>} The session outputs.
+ */
+export async function runDecoderSession(session, inputs, past_key_values) {
+    if (past_key_values instanceof StaticCache) {
+        const num_new_tokens = (inputs.input_ids ?? inputs.inputs_embeds).dims[1];
+        past_key_values._checkCapacity(num_new_tokens);
+        const outputs = await sessionRun(session, inputs, past_key_values._getFetches());
+        past_key_values._assertWrittenInPlace(outputs);
+        past_key_values._commit(num_new_tokens);
+        return outputs;
+    }
+    return await sessionRun(session, inputs);
 }
 
 /**
@@ -1369,7 +1428,7 @@ export async function decoder_forward(self, model_inputs, is_encoder_decoder = f
  * @param {Tensor} [params.attention_mask=null]
  * @param {Tensor} [params.position_ids=null]
  * @param {Tensor} [params.inputs_embeds=null]
- * @param {DynamicCache} [params.past_key_values=null]
+ * @param {DynamicCache|StaticCache} [params.past_key_values=null]
  * @param {Object} [params.generation_config=null]
  * @param {Object} [params.logits_processor=null]
  * @param {Tensor} [params.num_logits_to_keep=null]

--- a/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
+++ b/packages/transformers/src/models/multi_modality/modeling_multi_modality.js
@@ -37,8 +37,11 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
         //     //  && model_inputs.input_ids.dims[1] === 1
         // }
 
+        // Check cached tokens.
+        const has_past_tokens = (model_inputs.past_key_values?.get_seq_length() ?? 0) > 0;
+
         let output_1;
-        if (mode === 'text' || !model_inputs.past_key_values) {
+        if (mode === 'text' || !has_past_tokens) {
             const session = this.sessions['prepare_inputs_embeds'];
             const prep_inputs = pick(model_inputs, session.inputNames);
             output_1 = await sessionRun(session, prep_inputs);
@@ -71,7 +74,8 @@ export class MultiModalityCausalLM extends MultiModalityPreTrainedModel {
     }
 
     prepare_inputs_for_generation(input_ids, model_inputs, generation_config) {
-        const has_past_key_values = !!model_inputs.past_key_values;
+        // Check cached tokens, not cache presence (see forward()).
+        const has_past_key_values = (model_inputs.past_key_values?.get_seq_length() ?? 0) > 0;
 
         setNumLogitsToKeep(this, model_inputs, 1n);
 

--- a/packages/transformers/src/models/qwen2_vl/modeling_qwen2_vl.js
+++ b/packages/transformers/src/models/qwen2_vl/modeling_qwen2_vl.js
@@ -302,8 +302,9 @@ export class Qwen2VLForConditionalGeneration extends Qwen2VLPreTrainedModel {
             return model_inputs;
         }
 
-        // Calculate position_ids and rope_deltas
-        if (!model_inputs.past_key_values) {
+        // Check cached tokens, not cache presence.
+        const past_length = model_inputs.past_key_values?.get_seq_length() ?? 0;
+        if (past_length === 0) {
             [model_inputs.position_ids, model_inputs.rope_deltas] = this.get_rope_index(
                 model_inputs.input_ids,
                 model_inputs.image_grid_thw,
@@ -313,8 +314,6 @@ export class Qwen2VLForConditionalGeneration extends Qwen2VLPreTrainedModel {
         } else {
             model_inputs.pixel_values = null;
             // model_inputs.pixel_values_videos = null;
-
-            const past_length = model_inputs.past_key_values.get_seq_length();
 
             if (past_length < model_inputs.input_ids.dims[1]) {
                 // Externally provided `past_key_values` with full input_ids:

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -186,10 +186,12 @@ function replaceTensors(obj) {
  *
  * @param {Object} session The InferenceSession object to run.
  * @param {Object} inputs An object that maps input names to input tensors.
+ * @param {Record<string, Tensor|null>} [fetches] Optional map of output names to pre-allocated output
+ *   tensors (or `null` to let ONNX Runtime allocate them).
  * @returns {Promise<Object>} A Promise that resolves to an object that maps output names to output tensors.
  * @private
  */
-export async function sessionRun(session, inputs) {
+export async function sessionRun(session, inputs, fetches = undefined) {
     const checkedInputs = validateInputs(session, inputs);
     try {
         // pass the original ort tensor
@@ -206,8 +208,17 @@ export async function sessionRun(session, inputs) {
                 return [k, tensor];
             }),
         );
+        let ortFetches;
+        if (fetches) {
+            ortFetches = Object.fromEntries(
+                Object.entries(fetches).map(([k, v]) => [
+                    k,
+                    v instanceof Tensor ? /** @type {any} */ (v).ort_tensor : v,
+                ]),
+            );
+        }
 
-        const output = await runInferenceSession(session, ortFeed);
+        const output = await runInferenceSession(session, ortFeed, ortFetches);
         return replaceTensors(output);
     } catch (e) {
         // Error messages can be long (nested) and uninformative. For this reason,

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -219,7 +219,21 @@ export async function sessionRun(session, inputs, fetches = undefined) {
         }
 
         const output = await runInferenceSession(session, ortFeed, ortFetches);
-        return replaceTensors(output);
+
+        // ORT returns pre-allocated outputs as the exact tensors passed in `fetches`, reuse
+        // the caller's wrappers so no per-run alias wrappers are created and output identity
+        // and disposal stay in the caller's hands.
+        /** @type {Record<string, Tensor>} */
+        const preallocated = {};
+        if (fetches) {
+            for (const [name, tensor] of Object.entries(fetches)) {
+                if (tensor instanceof Tensor && output[name] === /** @type {any} */ (tensor).ort_tensor) {
+                    preallocated[name] = tensor;
+                    delete output[name];
+                }
+            }
+        }
+        return Object.assign(replaceTensors(output), preallocated);
     } catch (e) {
         // Error messages can be long (nested) and uninformative. For this reason,
         // we apply minor formatting to show the most important information

--- a/packages/transformers/src/models/speecht5/modeling_speecht5.js
+++ b/packages/transformers/src/models/speecht5/modeling_speecht5.js
@@ -127,7 +127,7 @@ export class SpeechT5ForTextToSpeech extends SpeechT5PreTrainedModel {
                 encoder_hidden_states: encoder_outputs,
             };
 
-            addPastKeyValues(this, decoderFeeds, past_key_values);
+            await addPastKeyValues(this, decoderFeeds, past_key_values);
             decoder_outputs = await sessionRun(this.sessions['decoder_model_merged'], decoderFeeds);
             past_key_values = getPastKeyValues(decoder_outputs, past_key_values);
 

--- a/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
+++ b/packages/transformers/src/models/voxtral_realtime/modeling_voxtral_realtime.js
@@ -1,4 +1,4 @@
-import { PreTrainedModel, addPastKeyValues, resolveCacheShape } from '../modeling_utils.js';
+import { PreTrainedModel, addPastKeyValues, resolveCacheShape, runDecoderSession } from '../modeling_utils.js';
 import { sessionRun } from '../session.js';
 import { getCacheNames } from '../../configs.js';
 import { Tensor, ones } from '../../utils/tensor.js';
@@ -218,11 +218,11 @@ export class VoxtralRealtimeForConditionalGeneration extends VoxtralRealtimePreT
         }
 
         const decoder_feeds = { inputs_embeds, ...kwargs };
-        addPastKeyValues(this, decoder_feeds, past_key_values);
+        await addPastKeyValues(this, decoder_feeds, past_key_values);
 
         const session = this.sessions['decoder_model_merged'];
         const fixed = pick(decoder_feeds, session.inputNames);
-        return await sessionRun(session, fixed);
+        return await runDecoderSession(session, fixed, past_key_values);
     }
 
     async generate({ input_features, stopping_criteria: userStoppingCriteria, ...kwargs }) {

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -53,7 +53,7 @@ export * from './utils/tensor.js';
 export { softmax, log_softmax, dot, cos_sim } from './utils/maths.js';
 export { random } from './utils/random.js';
 
-export { DynamicCache } from './cache_utils.js';
+export { DynamicCache, StaticCache } from './cache_utils.js';
 
 // Cache and file management
 export { ModelRegistry } from './utils/model_registry/ModelRegistry.js';

--- a/packages/transformers/tests/cache_utils.test.js
+++ b/packages/transformers/tests/cache_utils.test.js
@@ -1,0 +1,636 @@
+import { StaticCache, Tensor, AutoModelForCausalLM, AutoTokenizer } from "../src/transformers.js";
+import { presentNameToPastName } from "../src/cache_utils.js";
+import { runDecoderSession } from "../src/models/modeling_utils.js";
+import { sessionRun } from "../src/models/session.js";
+import { createGpuBufferTensor } from "../src/backends/onnx.js";
+// In Node, `src/backends/onnx.js` uses `onnxruntime-node`'s `env` and Tensor class, not the
+// copy of `onnxruntime-common`, so the fake WebGPU device must be injected there, and
+// fake ORT output tensors must be instances of its Tensor class.
+import * as ONNX_NODE from "onnxruntime-node";
+
+import { init, MAX_MODEL_LOAD_TIME, MAX_MODEL_DISPOSE_TIME, MAX_TEST_EXECUTION_TIME, DEFAULT_MODEL_OPTIONS } from "./init.js";
+
+// Initialise the testing environment
+init();
+
+class FakeGpuBuffer {
+  destroyed = false;
+  constructor(descriptor) {
+    this.size = descriptor.size;
+    this.usage = descriptor.usage;
+  }
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+class FakeGpuDevice {
+  /** @type {FakeGpuBuffer[]} */
+  buffers = [];
+  #calls = 0;
+  #failOnCall;
+
+  /**
+   * @param {Object} [options]
+   * @param {number} [options.failOnCall]
+   */
+  constructor({ failOnCall = Infinity } = {}) {
+    this.#failOnCall = failOnCall;
+  }
+
+  createBuffer(descriptor) {
+    if (++this.#calls === this.#failOnCall) {
+      throw new Error("FakeGpuDevice: createBuffer failed.");
+    }
+    const buffer = new FakeGpuBuffer(descriptor);
+    this.buffers.push(buffer);
+    return buffer;
+  }
+}
+
+// GPUBufferUsage flag values.
+const GPU_BUFFER_USAGE = Object.freeze({ COPY_SRC: 0x0004, COPY_DST: 0x0008, STORAGE: 0x0080 });
+
+const NUM_KV_HEADS = 8;
+const HEAD_DIM = 64;
+
+/**
+ * Build a fake decoder session whose metadata mirrors a GQA-based WebGPU export.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.numLayers] Number of decoder layers.
+ * @param {string|number} [options.presentSeqDim] Sequence-axis dim of the `present.*` outputs.
+ * @param {string} [options.device] The session's device.
+ */
+function makeGqaSession({ numLayers = 2, presentSeqDim = "total_sequence_length", device = "webgpu" } = {}) {
+  const inputMetadata = [{ name: "input_ids", isTensor: true, type: "int64", shape: ["batch_size", "sequence_length"] }];
+  const outputMetadata = [{ name: "logits", isTensor: true, type: "float32", shape: ["batch_size", "sequence_length", 32064] }];
+  for (let i = 0; i < numLayers; ++i) {
+    for (const kv of ["key", "value"]) {
+      inputMetadata.push({
+        name: `past_key_values.${i}.${kv}`,
+        isTensor: true,
+        type: "float32",
+        shape: ["batch_size", NUM_KV_HEADS, "past_sequence_length", HEAD_DIM],
+      });
+      outputMetadata.push({
+        name: `present.${i}.${kv}`,
+        isTensor: true,
+        type: "float32",
+        shape: ["batch_size", NUM_KV_HEADS, presentSeqDim, HEAD_DIM],
+      });
+    }
+  }
+  return { config: { device }, inputMetadata, outputMetadata };
+}
+
+/** Collect the cache input names of a fake session. */
+function cacheInputNames(session) {
+  return new Set(session.inputMetadata.map((m) => m.name).filter((name) => name.startsWith("past_")));
+}
+
+describe("StaticCache", () => {
+  describe("state machine (no allocation)", () => {
+    it("constructs with a positive integer max_cache_len", () => {
+      const cache = new StaticCache({ max_cache_len: 4096 });
+      expect(cache.max_cache_len).toBe(4096);
+      expect(cache.allocated).toBe(false);
+      expect(cache.get_seq_length()).toBe(0);
+    });
+
+    it("rejects invalid max_cache_len values", () => {
+      for (const max_cache_len of [0, -1, 1.5, NaN, Infinity, "4096", null, undefined]) {
+        expect(() => new StaticCache({ max_cache_len })).toThrow(/max_cache_len/);
+      }
+    });
+
+    it("checks capacity without mutating state, and only _commit advances the length", () => {
+      const cache = new StaticCache({ max_cache_len: 8 });
+
+      expect(() => cache._checkCapacity(8)).not.toThrow();
+      expect(() => cache._checkCapacity(9)).toThrow(/capacity exceeded/);
+      expect(cache.get_seq_length()).toBe(0);
+
+      cache._commit(5);
+      expect(cache.get_seq_length()).toBe(5);
+      expect(() => cache._checkCapacity(3)).not.toThrow();
+      expect(() => cache._checkCapacity(4)).toThrow(/capacity exceeded/);
+      // A failed check must leave the logical length untouched.
+      expect(cache.get_seq_length()).toBe(5);
+
+      cache._commit(3);
+      expect(cache.get_seq_length()).toBe(8);
+      expect(() => cache._checkCapacity(1)).toThrow(/capacity exceeded/);
+    });
+
+    it("update() is a no-op", () => {
+      const cache = new StaticCache({ max_cache_len: 8 });
+      cache._commit(2);
+      expect(() => cache.update({})).not.toThrow();
+      expect(cache.get_seq_length()).toBe(2);
+      expect(Object.keys(cache)).toHaveLength(0);
+    });
+
+    it("cannot be acquired by two generations at once, nor disposed while in use", async () => {
+      const cache = new StaticCache({ max_cache_len: 8 });
+      cache._acquire();
+      expect(() => cache._acquire()).toThrow(/already in use/);
+      await expect(cache.dispose()).rejects.toThrow(/in use/);
+      cache._release();
+      // Released caches can be reused by a later generation, and disposed.
+      expect(() => cache._acquire()).not.toThrow();
+      cache._release();
+      await expect(cache.dispose()).resolves.toBeUndefined();
+    });
+
+    it("rejects any use after dispose, and dispose is idempotent", async () => {
+      const cache = new StaticCache({ max_cache_len: 8 });
+      await cache.dispose();
+      await expect(cache.dispose()).resolves.toBeUndefined();
+
+      expect(() => cache._acquire()).toThrow(/disposed/);
+      expect(() => cache._checkCapacity(1)).toThrow(/disposed/);
+      await expect(cache._allocate({}, new Set(), {})).rejects.toThrow(/disposed/);
+    });
+  });
+
+  describe("allocation (mocked WebGPU device)", () => {
+    const ORT_ENV = ONNX_NODE.env;
+    /** @type {FakeGpuDevice} */
+    let device;
+
+    beforeAll(() => {
+      // `createGpuBufferTensor` reads the global GPUBufferUsage flags, which don't exist in Node.
+      globalThis.GPUBufferUsage ??= GPU_BUFFER_USAGE;
+    });
+
+    beforeEach(() => {
+      device = new FakeGpuDevice();
+      ORT_ENV.webgpu.device = device;
+    });
+
+    afterEach(() => {
+      delete ORT_ENV.webgpu.device;
+    });
+
+    it("allocates one fixed-size GPU entry per cache input and binds present outputs in place", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession();
+      await cache._allocate(session, cacheInputNames(session), { batch_size: 1 });
+
+      expect(cache.allocated).toBe(true);
+      expect(Object.keys(cache).sort()).toEqual(["past_key_values.0.key", "past_key_values.0.value", "past_key_values.1.key", "past_key_values.1.value"]);
+
+      // The symbolic sequence axis is pinned to max_cache_len; other symbols come from `symbols`.
+      const entry = cache["past_key_values.0.key"];
+      expect(entry.dims).toEqual([1, NUM_KV_HEADS, 128, HEAD_DIM]);
+      expect(entry.location).toBe("gpu-buffer");
+
+      // One zero-copy buffer per entry, sized for float32 and 16-byte aligned.
+      expect(device.buffers).toHaveLength(4);
+      const expectedBytes = 1 * NUM_KV_HEADS * 128 * HEAD_DIM * 4;
+      for (const buffer of device.buffers) {
+        expect(buffer.size).toBe(expectedBytes);
+        expect(buffer.usage).toBe(GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_SRC | GPU_BUFFER_USAGE.COPY_DST);
+        expect(buffer.destroyed).toBe(false);
+      }
+
+      // Each `present.*` output is fetched into the matching `past.*` tensor (same wrapper),
+      // while non-cache outputs stay ORT-allocated (null).
+      const fetches = cache._getFetches();
+      expect(fetches["present.0.key"]).toBe(cache["past_key_values.0.key"]);
+      expect(fetches["present.1.value"]).toBe(cache["past_key_values.1.value"]);
+      expect(fetches["logits"]).toBeNull();
+
+      await cache.dispose();
+    });
+
+    it("allocates non-attention states (hybrid caches) from fully-resolved dims", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession({ numLayers: 1 });
+      // Model a conv state entry: fixed dims apart from the batch axis.
+      session.inputMetadata.push({ name: "past_conv.0", isTensor: true, type: "float32", shape: ["batch_size", 512, 3] });
+      session.outputMetadata.push({ name: "present_conv.0", isTensor: true, type: "float32", shape: ["batch_size", 512, 3] });
+      await cache._allocate(session, cacheInputNames(session), { batch_size: 1 });
+
+      expect(cache["past_conv.0"].dims).toEqual([1, 512, 3]);
+      expect(cache._getFetches()["present_conv.0"]).toBe(cache["past_conv.0"]);
+
+      await cache.dispose();
+    });
+
+    it("destroys a fresh buffer if wrapping it into a tensor fails", async () => {
+      const original = ONNX_NODE.Tensor.fromGpuBuffer;
+      ONNX_NODE.Tensor.fromGpuBuffer = () => {
+        throw new Error("fromGpuBuffer failed.");
+      };
+      try {
+        await expect(createGpuBufferTensor("float32", [1, 2, 2])).rejects.toThrow(/fromGpuBuffer failed/);
+      } finally {
+        ONNX_NODE.Tensor.fromGpuBuffer = original;
+      }
+      expect(device.buffers).toHaveLength(1);
+      expect(device.buffers[0].destroyed).toBe(true);
+    });
+
+    it("rolls back a mid-allocation failure and can retry cleanly", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession();
+
+      // Fail on the 3rd of 4 buffer allocations.
+      device = new FakeGpuDevice({ failOnCall: 3 });
+      ORT_ENV.webgpu.device = device;
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).rejects.toThrow(/createBuffer failed/);
+
+      // The two buffers created before the failure must be destroyed, and no partial
+      // state may remain on the cache.
+      expect(device.buffers).toHaveLength(2);
+      expect(device.buffers.every((buffer) => buffer.destroyed)).toBe(true);
+      expect(cache.allocated).toBe(false);
+      expect(Object.keys(cache)).toHaveLength(0);
+      expect(cache._getFetches()).toBeNull();
+
+      // A retry on a healthy device starts from a clean slate and succeeds.
+      device = new FakeGpuDevice();
+      ORT_ENV.webgpu.device = device;
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).resolves.toBeUndefined();
+      expect(cache.allocated).toBe(true);
+      expect(device.buffers).toHaveLength(4);
+
+      await cache.dispose();
+    });
+
+    it("throws on an unresolvable symbolic dimension instead of guessing, and cleans up", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession({ numLayers: 1 });
+      // Only the second-to-last (sequence) axis of an attention entry may be inferred;
+      // an unknown symbol elsewhere must be reported, not silently defaulted.
+      session.inputMetadata.find((m) => m.name === "past_key_values.0.value").shape = ["batch_size", NUM_KV_HEADS, "past_sequence_length", "head_dim"];
+
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).rejects.toThrow(/past_key_values\.0\.value.*head_dim|head_dim.*past_key_values\.0\.value/s);
+
+      // The entry allocated before the failure (past_key_values.0.key) must be destroyed.
+      expect(device.buffers).toHaveLength(1);
+      expect(device.buffers[0].destroyed).toBe(true);
+      expect(cache.allocated).toBe(false);
+      expect(Object.keys(cache)).toHaveLength(0);
+    });
+
+    it("rejects concatenation-style exports that cannot share past/present buffers", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      // Non-GQA (MHA) exports declare the present sequence axis as an expression over
+      // the past length, so the output grows every step.
+      const session = makeGqaSession({ presentSeqDim: "past_sequence_length + 1" });
+
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).rejects.toThrow(/past_present_share_buffer/);
+
+      // All buffers were created before the fetches check, so all must be destroyed.
+      expect(device.buffers).toHaveLength(4);
+      expect(device.buffers.every((buffer) => buffer.destroyed)).toBe(true);
+      expect(cache.allocated).toBe(false);
+    });
+
+    it("rejects a fixed present sequence length that differs from max_cache_len", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession({ presentSeqDim: 64 });
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).rejects.toThrow(/does not match the allocated cache length/);
+      expect(cache.allocated).toBe(false);
+
+      // A fixed size that matches the allocated length is share-buffer compatible.
+      const matching = makeGqaSession({ presentSeqDim: 128 });
+      await cache._allocate(matching, cacheInputNames(matching), { batch_size: 1 });
+      expect(cache.allocated).toBe(true);
+      await cache.dispose();
+    });
+
+    it("rejects sessions that are not on the webgpu device", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession({ device: "wasm" });
+      await expect(cache._allocate(session, cacheInputNames(session), { batch_size: 1 })).rejects.toThrow(/webgpu/);
+      expect(device.buffers).toHaveLength(0);
+    });
+
+    it("rejects sessions without cache inputs", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = {
+        config: { device: "webgpu" },
+        inputMetadata: [{ name: "input_ids", isTensor: true, type: "int64", shape: ["batch_size", "sequence_length"] }],
+        outputMetadata: [{ name: "logits", isTensor: true, type: "float32", shape: ["batch_size", "sequence_length", 32064] }],
+      };
+      await expect(cache._allocate(session, new Set(), {})).rejects.toThrow(/no cache inputs/);
+    });
+
+    it("dispose() destroys all buffers and fully resets the cache", async () => {
+      const cache = new StaticCache({ max_cache_len: 128 });
+      const session = makeGqaSession();
+      await cache._allocate(session, cacheInputNames(session), { batch_size: 1 });
+      cache._commit(100);
+
+      await cache.dispose();
+
+      expect(device.buffers).toHaveLength(4);
+      expect(device.buffers.every((buffer) => buffer.destroyed)).toBe(true);
+      expect(Object.keys(cache)).toHaveLength(0);
+      expect(cache.allocated).toBe(false);
+      expect(cache.get_seq_length()).toBe(0);
+    });
+  });
+
+  describe("generate() integration (tiny model, CPU)", () => {
+    const model_id = "hf-internal-testing/tiny-random-LlamaForCausalLM";
+
+    /** @type {import("../src/transformers.js").PreTrainedModel} */
+    let model;
+    let tokenizer;
+    let inputs;
+    /** @type {number} Prompt length in tokens. */
+    let n;
+
+    beforeAll(async () => {
+      model = await AutoModelForCausalLM.from_pretrained(model_id, DEFAULT_MODEL_OPTIONS);
+      tokenizer = await AutoTokenizer.from_pretrained(model_id);
+      inputs = tokenizer("hello");
+      n = inputs.input_ids.dims.at(-1);
+    }, MAX_MODEL_LOAD_TIME);
+
+    afterAll(async () => {
+      await model?.dispose();
+    }, MAX_MODEL_DISPOSE_TIME);
+
+    it(
+      "capacity precheck is exact and fires before any inference runs",
+      async () => {
+        const max_new_tokens = 4;
+
+        const tooSmall = new StaticCache({ max_cache_len: n + max_new_tokens - 2 });
+        await expect(model.generate({ ...inputs, past_key_values: tooSmall, max_new_tokens, do_sample: false })).rejects.toThrow(/exceeds the StaticCache capacity/);
+
+        expect(tooSmall.allocated).toBe(false);
+        expect(() => tooSmall._acquire()).not.toThrow();
+        tooSmall._release();
+        await tooSmall.dispose();
+
+        // Exactly `max_length - 1`.
+        const exact = new StaticCache({ max_cache_len: n + max_new_tokens - 1 });
+        await expect(model.generate({ ...inputs, past_key_values: exact, max_new_tokens, do_sample: false })).rejects.toThrow(/webgpu/);
+        await exact.dispose();
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+
+    it(
+      "fails with a clear error on non-WebGPU sessions and is released for retry",
+      async () => {
+        const cache = new StaticCache({ max_cache_len: 64 });
+        await expect(model.generate({ ...inputs, past_key_values: cache, max_new_tokens: 2, do_sample: false })).rejects.toThrow(/webgpu/);
+        expect(cache.allocated).toBe(false);
+
+        // The `finally` in generate() must release the cache even on failure.
+        await expect(model.generate({ ...inputs, past_key_values: cache, max_new_tokens: 2, do_sample: false })).rejects.toThrow(/webgpu/);
+        await cache.dispose();
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+
+    it(
+      "cannot be used by a second generation while one is in flight",
+      async () => {
+        const cache = new StaticCache({ max_cache_len: 64 });
+        cache._acquire(); // Simulate a generation in flight.
+        await expect(model.generate({ ...inputs, past_key_values: cache, max_new_tokens: 2, do_sample: false })).rejects.toThrow(/already in use/);
+        cache._release();
+        await cache.dispose();
+      },
+      MAX_TEST_EXECUTION_TIME,
+    );
+  });
+});
+
+describe("sessionRun with pre-allocated outputs (fetches)", () => {
+  /** Create a fake InferenceSession whose `run` is provided by the test. */
+  function makeFakeSession(run) {
+    return {
+      inputNames: ["input_ids"],
+      outputNames: ["logits", "present.0.key"],
+      config: {},
+      run,
+    };
+  }
+
+  /** Create a Tensor wrapper backed by onnxruntime-node's Tensor class. */
+  function makeCacheTensor() {
+    return new Tensor(new ONNX_NODE.Tensor("float32", new Float32Array(8), [1, 2, 2, 2]));
+  }
+
+  const INPUTS = () => ({ input_ids: new Tensor("int64", new BigInt64Array([1n]), [1, 1]) });
+
+  it("returns the caller's exact wrapper for outputs written in place", async () => {
+    const present = makeCacheTensor();
+    let receivedFetches;
+    const session = makeFakeSession(async (feeds, fetches) => {
+      receivedFetches = fetches;
+      // ORT returns pre-allocated outputs as the exact tensor objects passed in `fetches`.
+      return {
+        logits: new ONNX_NODE.Tensor("float32", new Float32Array(2), [1, 2]),
+        "present.0.key": fetches["present.0.key"],
+      };
+    });
+
+    const outputs = await sessionRun(session, INPUTS(), { logits: null, "present.0.key": present });
+
+    // The fetches are unwrapped before being handed to ORT: raw ort tensors and nulls.
+    expect(receivedFetches["present.0.key"]).toBe(present.ort_tensor);
+    expect(receivedFetches["logits"]).toBeNull();
+
+    expect(outputs["present.0.key"]).toBe(present);
+    expect(outputs["logits"]).toBeInstanceOf(Tensor);
+    expect(outputs["logits"]).not.toBe(present);
+  });
+
+  it("wraps an output freshly if ORT did not write it into the requested tensor", async () => {
+    const present = makeCacheTensor();
+    const substitute = new ONNX_NODE.Tensor("float32", new Float32Array(8), [1, 2, 2, 2]);
+    const session = makeFakeSession(async () => ({
+      logits: new ONNX_NODE.Tensor("float32", new Float32Array(2), [1, 2]),
+      "present.0.key": substitute,
+    }));
+
+    const outputs = await sessionRun(session, INPUTS(), { logits: null, "present.0.key": present });
+
+    expect(outputs["present.0.key"]).not.toBe(present);
+    expect(outputs["present.0.key"]).toBeInstanceOf(Tensor);
+    expect(outputs["present.0.key"].ort_tensor).toBe(substitute);
+  });
+});
+
+describe("runDecoderSession StaticCache integrity guard (mocked WebGPU device)", () => {
+  const ORT_ENV = ONNX_NODE.env;
+  /** @type {FakeGpuDevice} */
+  let device;
+
+  beforeAll(() => {
+    globalThis.GPUBufferUsage ??= GPU_BUFFER_USAGE;
+  });
+
+  beforeEach(() => {
+    device = new FakeGpuDevice();
+    ORT_ENV.webgpu.device = device;
+  });
+
+  afterEach(() => {
+    delete ORT_ENV.webgpu.device;
+  });
+
+  async function makeAllocatedCache() {
+    const cache = new StaticCache({ max_cache_len: 128 });
+    const session = makeGqaSession();
+    await cache._allocate(session, cacheInputNames(session), { batch_size: 1 });
+    return cache;
+  }
+
+  /**
+   * Create a fake decode session. `substituteName` selects a fetched output that ORT
+   * "fails" to write in place, returning a freshly allocated tensor for it instead.
+   */
+  function makeDecodeSession({ substituteName = null } = {}) {
+    return {
+      inputNames: ["input_ids"],
+      config: { device: "webgpu" },
+      async run(feeds, fetches) {
+        const outputs = { logits: new ONNX_NODE.Tensor("float32", new Float32Array(4), [1, 1, 4]) };
+        for (const [name, tensor] of Object.entries(fetches)) {
+          if (tensor === null) continue;
+          outputs[name] = name === substituteName ? new ONNX_NODE.Tensor("float32", new Float32Array(tensor.dims.reduce((a, b) => a * b, 1)), tensor.dims) : tensor;
+        }
+        return outputs;
+      },
+    };
+  }
+
+  const inputIds = (numTokens) => ({ input_ids: new Tensor("int64", new BigInt64Array(numTokens).fill(1n), [1, numTokens]) });
+
+  it("commits the step when all cache outputs were written in place", async () => {
+    const cache = await makeAllocatedCache();
+    const outputs = await runDecoderSession(makeDecodeSession(), inputIds(3), cache);
+    expect(cache.get_seq_length()).toBe(3);
+    expect(outputs["present.0.key"]).toBe(cache["past_key_values.0.key"]);
+    await cache.dispose();
+  });
+
+  it("fails loudly without committing if an output was not written into the cache tensor", async () => {
+    const cache = await makeAllocatedCache();
+
+    // ORT contractually writes fetched outputs in place; if a backend ever substituted
+    // its own tensor, the new KV data would not be in the cache's buffers. Committing
+    // would silently corrupt the cache, so the step must fail before `_commit`.
+    const broken = makeDecodeSession({ substituteName: "present.1.value" });
+    await expect(runDecoderSession(broken, inputIds(3), cache)).rejects.toThrow(/present\.1\.value.*not written into the pre-allocated cache tensor/);
+    expect(cache.get_seq_length()).toBe(0);
+
+    // The cache state is untouched, so a healthy session can still use it.
+    await runDecoderSession(makeDecodeSession(), inputIds(2), cache);
+    expect(cache.get_seq_length()).toBe(2);
+    await cache.dispose();
+  });
+});
+
+describe("long-generation resource behaviour (mocked WebGPU device)", () => {
+  const ORT_ENV = ONNX_NODE.env;
+  /** @type {FakeGpuDevice} */
+  let device;
+
+  beforeAll(() => {
+    globalThis.GPUBufferUsage ??= GPU_BUFFER_USAGE;
+  });
+
+  beforeEach(() => {
+    device = new FakeGpuDevice();
+    ORT_ENV.webgpu.device = device;
+  });
+
+  afterEach(() => {
+    delete ORT_ENV.webgpu.device;
+  });
+
+  it("holds one wrapper per entry, releases every transient output, and allocates zero buffers across hundreds of steps", async () => {
+    const NUM_STEPS = 300;
+    const cache = new StaticCache({ max_cache_len: NUM_STEPS });
+    const session = makeGqaSession();
+    await cache._allocate(session, cacheInputNames(session), { batch_size: 1 });
+    expect(device.buffers).toHaveLength(4);
+
+    // A fake decode session faithful to ORT's `run(feeds, fetches)` contract: fetched
+    // outputs are returned as the exact ort tensors that were passed in, while `logits`
+    // is a freshly ORT-allocated GPU tensor on every step, whose release we can observe
+    // through its `dispose` callback.
+    let transientDisposed = 0;
+    const fakeSession = {
+      inputNames: ["input_ids"],
+      outputNames: [...Object.keys(cache._getFetches())],
+      config: { device: "webgpu" },
+      async run(feeds, fetches) {
+        const logitsBuffer = { destroyed: false, destroy() {} };
+        const logits = /** @type {any} */ (ONNX_NODE.Tensor).fromGpuBuffer(logitsBuffer, {
+          dataType: "float32",
+          dims: [1, 1, 4],
+          dispose: () => {
+            transientDisposed += 1;
+          },
+        });
+        const outputs = { logits };
+        for (const [name, tensor] of Object.entries(fetches)) {
+          if (tensor !== null) outputs[name] = tensor;
+        }
+        return outputs;
+      },
+    };
+
+    const fetches = cache._getFetches();
+    const presentNames = Object.keys(fetches).filter((name) => fetches[name] !== null);
+    /** @type {Map<string, Set<Tensor>>} Every distinct wrapper observed per present output. */
+    const seenWrappers = new Map(presentNames.map((name) => [name, new Set()]));
+
+    for (let step = 0; step < NUM_STEPS; ++step) {
+      // One decode step, as performed by `runDecoderSession`.
+      cache._checkCapacity(1);
+      const outputs = await sessionRun(fakeSession, { input_ids: new Tensor("int64", new BigInt64Array([1n]), [1, 1]) }, fetches);
+      cache._commit(1);
+
+      for (const name of presentNames) {
+        seenWrappers.get(name).add(outputs[name]);
+      }
+
+      // Apply `generate()`'s identity-based disposal (it runs once, on the final outputs;
+      // here deliberately on every step) to verify it never touches the cache's own
+      // tensors while transient outputs stay freeable.
+      const cachedTensors = new Set(Object.values(cache));
+      for (const tensor of Object.values(outputs)) {
+        if (tensor.location === "gpu-buffer" && !cachedTensors.has(tensor)) {
+          tensor.dispose();
+        }
+      }
+    }
+
+    expect(cache.get_seq_length()).toBe(NUM_STEPS);
+
+    // Exactly one wrapper per cache entry across all steps: the cache's own. No per-step
+    // alias wrappers accumulate for the GC.
+    for (const name of presentNames) {
+      const wrappers = seenWrappers.get(name);
+      expect(wrappers.size).toBe(1);
+      expect(wrappers.has(cache[presentNameToPastName(name)])).toBe(true);
+    }
+
+    // Every transient (non-cache) output was released, once per step...
+    expect(transientDisposed).toBe(NUM_STEPS);
+
+    for (const name of presentNames) {
+      expect(cache[presentNameToPastName(name)].location).toBe("gpu-buffer");
+    }
+    expect(device.buffers).toHaveLength(4);
+    expect(device.buffers.every((buffer) => !buffer.destroyed)).toBe(true);
+
+    await cache.dispose();
+    expect(device.buffers.every((buffer) => buffer.destroyed)).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds an opt-in `StaticCache` that eliminates per-step KV cache reallocation on WebGPU. 

Fixes https://github.com/huggingface/transformers.js/issues/1741

With `DynamicCache` (the default), every decode step replaces every KV tensor with a slightly larger one. On WebGPU each replacement destroys and re-creates a zero-filled GPU buffer, so the per-step cost grows with context length and jumps permanently at the buffer-pool bucket boundaries,  producing a staircase-shaped latency curve.

`StaticCache` allocates each cache entry **once** at a fixed `max_cache_len`, and binds the model's `present.*` outputs in place onto the same GPU buffers via `session.run(feeds, fetches)`. Decoding performs zero cache (re-)allocations per step.

## Usage

```js
const past_key_values = new StaticCache({ max_cache_len: 4096 });
const output = await generator(messages, { max_new_tokens: 256, past_key_values });
await past_key_values.dispose(); // caller owns the cache
```

## Performance

Decode throughput, q4f16 on WebGPU (TPS), 256 new tokens:

| Model | Prefill | DynamicCache | StaticCache | Δ |
|---|---|---|---|---|
| Phi-4-mini-instruct | 2048 | 10.1 | 25.4 | +151% |
| Phi-4-mini-instruct | 4096 | 5.6 | 20.8 | +271% |
| Qwen3.5-4B | 2048 | 17.7 | 19.2 | +8% |
| Qwen3.5-4B | 4096 | 15.1 | 18.2 | +21% |

The gain grows with context length: `DynamicCache` throughput degrades as buffers get larger while `StaticCache` stays nearly flat. Qwen3.5 (hybrid attention) benefits less because only its full-attention layers have growing KV entries. In our measurements `StaticCache` matches a hand-written ORT static-KV baseline within 2%.

## Correctness

Token-identical output vs `DynamicCache` (greedy, 256 new tokens, crossing the 2048/4096 bucket boundaries), on Phi-4-mini-instructand Qwen3.5-4B, Both paths are self-deterministic.

## Constraints

Enforced with explicit errors, `DynamicCache` remains the default everywhere:

- WebGPU only (the problem and the mechanism are WebGPU-specific).
- Decoder-only models, batch size 1.
- The exported graph must support past/present sharing one buffer (`past_present_share_buffer` semantics — true for GQA-based exports, which current WebGPU decoder exports use). This is why the feature is opt-in.