### PR TITLE
Fix Moonshine ASR tokenizer decoding

### DIFF
--- a/packages/transformers/src/pipelines/automatic-speech-recognition.js
+++ b/packages/transformers/src/pipelines/automatic-speech-recognition.js
@@ -325,7 +325,7 @@ export class AutomaticSpeechRecognitionPipeline
             const max_new_tokens = Math.floor(aud.length / sampling_rate) * 6;
             const outputs = await this.model.generate({ max_new_tokens, ...kwargs, ...inputs });
 
-            const text = this.processor.batch_decode(/** @type {Tensor} */ (outputs), { skip_special_tokens: true })[0];
+            const text = this.tokenizer.batch_decode(/** @type {Tensor} */ (outputs), { skip_special_tokens: true })[0];
             toReturn.push({ text });
         }
         return single ? toReturn[0] : toReturn;

--- a/packages/transformers/tests/pipelines/test_pipelines_automatic_speech_recognition.js
+++ b/packages/transformers/tests/pipelines/test_pipelines_automatic_speech_recognition.js
@@ -7,6 +7,33 @@ const PIPELINE_ID = "automatic-speech-recognition";
 
 export default () => {
   describe("Automatic Speech Recognition", () => {
+    it("uses the pipeline tokenizer to decode Moonshine output", async () => {
+      const model = {
+        config: { model_type: "moonshine" },
+        generate: async () => ({}),
+        dispose: async () => {},
+      };
+      const processor = Object.assign(async () => ({}), {
+        feature_extractor: { config: { sampling_rate: 16000 } },
+      });
+      let decodeCalls = 0;
+      const tokenizer = {
+        batch_decode: () => {
+          decodeCalls += 1;
+          return ["decoded text"];
+        },
+      };
+      const pipe = new AutomaticSpeechRecognitionPipeline({
+        task: PIPELINE_ID,
+        model,
+        tokenizer,
+        processor,
+      });
+
+      await expect(pipe._call_moonshine(new Float32Array(16000), {})).resolves.toEqual({ text: "decoded text" });
+      expect(decodeCalls).toBe(1);
+    });
+
     describe("whisper (tiny-random)", () => {
       const model_id = "Xenova/tiny-random-WhisperForConditionalGeneration";
       const SAMPLING_RATE = 16000;


### PR DESCRIPTION
## Summary

Fix Moonshine automatic speech recognition pipelines that fail when decoding generated token IDs.

Moonshine processors provide audio feature extraction but do not necessarily include a tokenizer. The pipeline already owns the tokenizer loaded for the model, so decoding must use that pipeline-level tokenizer rather than calling `batch_decode` on the processor.

## Changes

- Decode Moonshine outputs with `this.tokenizer.batch_decode`.
- Add a regression test using a processor without a tokenizer and a pipeline tokenizer.

## Validation

- Direct regression check passed with a minimal Moonshine pipeline.
- Prettier check passed for the changed files.
- TypeScript build passed.
- The focused Jest command could not complete because the test harness encountered a network `fetch failed` during setup.

Fixes #1735
