### PR TITLE
Pass `revision` through the file-listing and config paths

### DIFF
--- a/packages/transformers/src/pipelines.js
+++ b/packages/transformers/src/pipelines.js
@@ -143,7 +143,7 @@ export async function pipeline(
     let files_loading = {};
     if (progress_callback) {
         /** @type {Array<{exists: boolean, size?: number, contentType?: string, fromCache?: boolean}>} */
-        const metadata = await Promise.all(expected_files.map(async (file) => get_file_metadata(model, file)));
+        const metadata = await Promise.all(expected_files.map(async (file) => get_file_metadata(model, file, { cache_dir, local_files_only, revision })));
         metadata.forEach((m, i) => {
             if (m.exists) {
                 files_loading[expected_files[i]] = {

--- a/packages/transformers/src/pipelines.js
+++ b/packages/transformers/src/pipelines.js
@@ -134,6 +134,9 @@ export async function pipeline(
     const expected_files = await get_pipeline_files(task, model, {
         device,
         dtype,
+        cache_dir,
+        local_files_only,
+        revision,
     });
 
     /** @type {import('./utils/core.js').FilesLoadingMap} */

--- a/packages/transformers/src/tokenization_utils.js
+++ b/packages/transformers/src/tokenization_utils.js
@@ -26,7 +26,7 @@ import { get_tokenizer_files } from './utils/model_registry/get_tokenizer_files.
  * @returns {Promise<any[]>} A promise that resolves with information about the loaded tokenizer.
  */
 export async function loadTokenizer(pretrained_model_name_or_path, options) {
-    const tokenizerFiles = await get_tokenizer_files(pretrained_model_name_or_path);
+    const tokenizerFiles = await get_tokenizer_files(pretrained_model_name_or_path, options);
     return await Promise.all(
         tokenizerFiles.map((file) => getModelJSON(pretrained_model_name_or_path, file, true, options)),
     );

--- a/packages/transformers/src/utils/model_registry/ModelRegistry.js
+++ b/packages/transformers/src/utils/model_registry/ModelRegistry.js
@@ -127,6 +127,9 @@ export class ModelRegistry {
      * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
      * @param {boolean} [options.include_tokenizer=true] - Whether to check for tokenizer files
      * @param {boolean} [options.include_processor=true] - Whether to check for processor files
+     * @param {string} [options.revision='main'] - Git branch, tag, or commit SHA to list files from
+     * @param {string} [options.cache_dir] - Path to the cache directory
+     * @param {boolean} [options.local_files_only=false] - Whether to only look for the files locally
      * @returns {Promise<string[]>} Array of file paths
      *
      * @example
@@ -148,6 +151,9 @@ export class ModelRegistry {
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
      * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string} [options.revision='main'] - Git branch, tag, or commit SHA to list files from
+     * @param {string} [options.cache_dir] - Path to the cache directory
+     * @param {boolean} [options.local_files_only=false] - Whether to only look for the files locally
      * @returns {Promise<string[]>} Array of file paths
      *
      * @example
@@ -167,6 +173,9 @@ export class ModelRegistry {
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
      * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string} [options.revision='main'] - Git branch, tag, or commit SHA to list files from
+     * @param {string} [options.cache_dir] - Path to the cache directory
+     * @param {boolean} [options.local_files_only=false] - Whether to only look for the files locally
      * @returns {Promise<string[]>} Array of model file paths
      *
      * @example
@@ -181,28 +190,32 @@ export class ModelRegistry {
      * Get tokenizer files needed for a specific model.
      *
      * @param {string} modelId - The model id
+     * @param {import('../hub.js').PretrainedOptions} [options] - Options forwarded to the metadata request, so the
+     * existence check reads the same revision the files will be loaded from.
      * @returns {Promise<string[]>} Array of tokenizer file paths
      *
      * @example
      * const files = await ModelRegistry.get_tokenizer_files('onnx-community/gpt2-ONNX');
      * console.log(files); // ['tokenizer.json', 'tokenizer_config.json']
      */
-    static async get_tokenizer_files(modelId) {
-        return get_tokenizer_files(modelId);
+    static async get_tokenizer_files(modelId, options = {}) {
+        return get_tokenizer_files(modelId, options);
     }
 
     /**
      * Get processor files needed for a specific model.
      *
      * @param {string} modelId - The model id
+     * @param {import('../hub.js').PretrainedOptions} [options] - Options forwarded to the metadata request, so the
+     * existence check reads the same revision the files will be loaded from.
      * @returns {Promise<string[]>} Array of processor file paths
      *
      * @example
      * const files = await ModelRegistry.get_processor_files('onnx-community/vit-base-patch16-224-ONNX');
      * console.log(files); // ['preprocessor_config.json']
      */
-    static async get_processor_files(modelId) {
-        return get_processor_files(modelId);
+    static async get_processor_files(modelId, options = {}) {
+        return get_processor_files(modelId, options);
     }
 
     /**

--- a/packages/transformers/src/utils/model_registry/get_files.js
+++ b/packages/transformers/src/utils/model_registry/get_files.js
@@ -14,6 +14,10 @@ import { get_processor_files } from './get_processor_files.js';
  * @param {string|null} [options.model_file_name=null|null] Override the model file name (excluding .onnx suffix)
  * @param {boolean} [options.include_tokenizer=true] Whether to check for tokenizer files (set to false for vision-only models)
  * @param {boolean} [options.include_processor=true] Whether to check for processor files
+ * @param {string} [options.revision='main'] Git branch, tag, or commit SHA — forwarded, with the other
+ * pretrained options below, to every file lookup this makes
+ * @param {string} [options.cache_dir] Path to the cache directory
+ * @param {boolean} [options.local_files_only=false] Whether to only look for the files locally
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  */
 export async function get_files(
@@ -25,16 +29,19 @@ export async function get_files(
         model_file_name = null,
         include_tokenizer = true,
         include_processor = true,
+        ...options
     } = {},
 ) {
-    const files = await get_model_files(modelId, { config, dtype, device, model_file_name });
+    // Forward the remaining pretrained options (`revision`, `cache_dir`, ...) to every lookup below: naming a
+    // fixed subset here meant a pinned load listed its files from `main`.
+    const files = await get_model_files(modelId, { config, dtype, device, model_file_name, ...options });
 
     if (include_tokenizer) {
-        const tokenizerFiles = await get_tokenizer_files(modelId);
+        const tokenizerFiles = await get_tokenizer_files(modelId, options);
         files.push(...tokenizerFiles);
     }
     if (include_processor) {
-        const processorFiles = await get_processor_files(modelId);
+        const processorFiles = await get_processor_files(modelId, options);
         files.push(...processorFiles);
     }
 

--- a/packages/transformers/src/utils/model_registry/get_model_files.js
+++ b/packages/transformers/src/utils/model_registry/get_model_files.js
@@ -55,13 +55,24 @@ export function get_config(
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] Override dtype (use this if passing dtype to pipeline)
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] Override device (use this if passing device to pipeline)
  * @param {string} [options.model_file_name=null] Override the model file name (excluding .onnx suffix).
+ * @param {string} [options.revision='main'] Git branch, tag, or commit SHA to read the config from
+ * @param {string} [options.cache_dir] Path to the cache directory
+ * @param {boolean} [options.local_files_only=false] Whether to only look for the files locally
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  */
 export async function get_model_files(
     modelId,
-    { config = null, dtype: overrideDtype = null, device: overrideDevice = null, model_file_name = null } = {},
+    {
+        config = null,
+        dtype: overrideDtype = null,
+        device: overrideDevice = null,
+        model_file_name = null,
+        ...options
+    } = {},
 ) {
-    config = await get_config(modelId, { config });
+    // Forward the remaining pretrained options (`revision`, `cache_dir`, ...): without them the config is read
+    // from `main` even when the caller pinned a revision.
+    config = await get_config(modelId, { config, ...options });
 
     const files = [
         // Add config.json (always loaded)

--- a/packages/transformers/src/utils/model_registry/get_pipeline_files.js
+++ b/packages/transformers/src/utils/model_registry/get_pipeline_files.js
@@ -16,6 +16,9 @@ import { SUPPORTED_TASKS, TASK_ALIASES } from '../../pipelines/index.js';
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
  * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+ * @param {string} [options.revision='main'] - Git branch, tag, or commit SHA to list files from
+ * @param {string} [options.cache_dir] - Path to the cache directory
+ * @param {boolean} [options.local_files_only=false] - Whether to only look for the files locally
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  * @throws {Error} If the task is not supported
  */

--- a/packages/transformers/src/utils/model_registry/get_processor_files.js
+++ b/packages/transformers/src/utils/model_registry/get_processor_files.js
@@ -6,15 +6,17 @@ import { get_file_metadata } from './get_file_metadata.js';
  * Auto-detects if the model has a processor by checking if preprocessor_config.json exists.
  *
  * @param {string} modelId The model id (e.g., "Xenova/detr-resnet-50")
+ * @param {import('../hub.js').PretrainedOptions} [options] Options forwarded to the metadata request, so the
+ * existence check reads the same revision the files will be loaded from.
  * @returns {Promise<string[]>} Array of processor file names (empty if no processor)
  */
-export async function get_processor_files(modelId) {
+export async function get_processor_files(modelId, options = {}) {
     if (!modelId) {
         throw new Error('modelId is required');
     }
 
     // Check if preprocessor_config.json exists
-    const metadata = await get_file_metadata(modelId, IMAGE_PROCESSOR_NAME, {});
+    const metadata = await get_file_metadata(modelId, IMAGE_PROCESSOR_NAME, options);
 
     return metadata.exists ? [IMAGE_PROCESSOR_NAME] : [];
 }

--- a/packages/transformers/src/utils/model_registry/get_tokenizer_files.js
+++ b/packages/transformers/src/utils/model_registry/get_tokenizer_files.js
@@ -5,14 +5,16 @@ import { get_file_metadata } from './get_file_metadata.js';
  * Automatically detects whether the model has tokenizer files.
  *
  * @param {string} modelId The model id to check for tokenizer files
+ * @param {import('../hub.js').PretrainedOptions} [options] Options forwarded to the metadata request, so the
+ * existence check reads the same revision the files will be loaded from.
  * @returns {Promise<string[]>} An array of file names that will be loaded
  */
-export async function get_tokenizer_files(modelId) {
+export async function get_tokenizer_files(modelId, options = {}) {
     if (!modelId) {
         throw new Error('modelId is required for get_tokenizer_files');
     }
 
-    const metadata = await get_file_metadata(modelId, 'tokenizer_config.json', {});
+    const metadata = await get_file_metadata(modelId, 'tokenizer_config.json', options);
     if (metadata.exists) {
         return ['tokenizer.json', 'tokenizer_config.json'];
     }

--- a/packages/transformers/tests/utils/model_registry.test.js
+++ b/packages/transformers/tests/utils/model_registry.test.js
@@ -11,6 +11,9 @@ await import("../../src/models/registry.js");
 
 // Dynamic import after mock setup (required for ESM)
 const { get_available_dtypes } = await import("../../src/utils/model_registry/get_available_dtypes.js");
+const { get_files } = await import("../../src/utils/model_registry/get_files.js");
+const { get_model_files } = await import("../../src/utils/model_registry/get_model_files.js");
+const { AutoConfig } = await import("../../src/configs.js");
 
 // A minimal config that mimics a BERT-like encoder-only model
 const ENCODER_ONLY_CONFIG = {
@@ -179,5 +182,66 @@ describe("get_available_dtypes", () => {
     for (const dtype of dtypes) {
       expect(validDtypes).toContain(dtype);
     }
+  });
+});
+
+describe("get_files", () => {
+  beforeEach(() => {
+    mockGetFileMetadata.mockReset();
+  });
+
+  it("should pass revision and cache_dir to every file lookup", async () => {
+    // Including the tokenizer and processor lookups: listing those from `main` while the weights come from a
+    // pinned revision leaves stray files in the cache, and can list files the pinned revision does not have.
+    setupExistingFiles("onnx/model.onnx", "tokenizer_config.json", "tokenizer.json", "preprocessor_config.json");
+
+    const files = await get_files("test/model", {
+      config: ENCODER_ONLY_CONFIG,
+      revision: "v2",
+      cache_dir: "/tmp/cache",
+    });
+
+    expect(files).toContain("tokenizer_config.json");
+    expect(mockGetFileMetadata.mock.calls.length).toBeGreaterThan(0);
+    for (const call of mockGetFileMetadata.mock.calls) {
+      expect(call[0]).toBe("test/model");
+      expect(call[2]).toMatchObject({ revision: "v2", cache_dir: "/tmp/cache" });
+    }
+  });
+
+  it("should still work when no options are passed", async () => {
+    setupExistingFiles("onnx/model.onnx", "tokenizer_config.json");
+
+    const files = await get_files("test/model", { config: ENCODER_ONLY_CONFIG });
+
+    expect(files).toContain("onnx/model.onnx");
+    for (const call of mockGetFileMetadata.mock.calls) {
+      expect(call[2]).toBeDefined();
+    }
+  });
+});
+
+describe("get_model_files", () => {
+  /** @type {import("@jest/globals").jest.SpiedFunction<typeof AutoConfig.from_pretrained>} */
+  let configSpy;
+
+  beforeEach(() => {
+    mockGetFileMetadata.mockReset();
+    // Spied rather than fetched: the assertion is about the options it receives, not its result.
+    configSpy = jest.spyOn(AutoConfig, "from_pretrained").mockResolvedValue(ENCODER_ONLY_CONFIG);
+  });
+
+  afterEach(() => {
+    configSpy.mockRestore();
+  });
+
+  it("should read config.json from the requested revision", async () => {
+    // The config is fetched separately from the file listing; leaving it on `main` both reads the wrong
+    // config for a pinned load and leaves a stray `main` entry in the browser cache.
+    setupExistingFiles("onnx/model.onnx");
+
+    await get_model_files("test/model", { revision: "v2", cache_dir: "/tmp/cache" });
+
+    expect(configSpy).toHaveBeenCalledWith("test/model", expect.objectContaining({ revision: "v2", cache_dir: "/tmp/cache" }));
   });
 });

--- a/packages/transformers/tests/utils/model_registry.test.js
+++ b/packages/transformers/tests/utils/model_registry.test.js
@@ -13,6 +13,7 @@ await import("../../src/models/registry.js");
 const { get_available_dtypes } = await import("../../src/utils/model_registry/get_available_dtypes.js");
 const { get_files } = await import("../../src/utils/model_registry/get_files.js");
 const { get_model_files } = await import("../../src/utils/model_registry/get_model_files.js");
+const { ModelRegistry } = await import("../../src/utils/model_registry/ModelRegistry.js");
 const { AutoConfig } = await import("../../src/configs.js");
 
 // A minimal config that mimics a BERT-like encoder-only model
@@ -218,6 +219,41 @@ describe("get_files", () => {
     for (const call of mockGetFileMetadata.mock.calls) {
       expect(call[2]).toBeDefined();
     }
+  });
+});
+
+describe("ModelRegistry facades", () => {
+  // The static ModelRegistry methods are the exported API — the bare helpers are not — so the options
+  // have to survive this extra hop too, or public callers stay pinned to `main`.
+  beforeEach(() => {
+    mockGetFileMetadata.mockReset();
+  });
+
+  it("should pass revision and cache_dir through get_tokenizer_files", async () => {
+    setupExistingFiles("tokenizer_config.json");
+
+    const files = await ModelRegistry.get_tokenizer_files("test/model", { revision: "v2", cache_dir: "/tmp/cache" });
+
+    expect(files).toEqual(["tokenizer.json", "tokenizer_config.json"]);
+    expect(mockGetFileMetadata).toHaveBeenCalledWith("test/model", "tokenizer_config.json", expect.objectContaining({ revision: "v2", cache_dir: "/tmp/cache" }));
+  });
+
+  it("should pass revision and cache_dir through get_processor_files", async () => {
+    setupExistingFiles("preprocessor_config.json");
+
+    const files = await ModelRegistry.get_processor_files("test/model", { revision: "v2", cache_dir: "/tmp/cache" });
+
+    expect(files).toEqual(["preprocessor_config.json"]);
+    expect(mockGetFileMetadata).toHaveBeenCalledWith("test/model", "preprocessor_config.json", expect.objectContaining({ revision: "v2", cache_dir: "/tmp/cache" }));
+  });
+
+  it("should still work when no options are passed", async () => {
+    setupExistingFiles("tokenizer_config.json");
+
+    const files = await ModelRegistry.get_tokenizer_files("test/model");
+
+    expect(files).toEqual(["tokenizer.json", "tokenizer_config.json"]);
+    expect(mockGetFileMetadata).toHaveBeenCalledWith("test/model", "tokenizer_config.json", expect.anything());
   });
 });
 


### PR DESCRIPTION
### What

`pipeline()` accepts a `revision`, and the weights are indeed fetched from it, but four functions on the way to the file listing drop it and fall back to `main`:

- `pipeline()` passes only `{device, dtype}` to `get_pipeline_files()`, though it has `revision`, `cache_dir` and `local_files_only` in scope
- `get_files()` destructures a fixed option set, so anything it does not name is lost
- `get_model_files()` does the same, then calls `get_config(modelId, { config })` — dropping the revision `get_config` is written to accept
- `get_tokenizer_files()` / `get_processor_files()` take no options at all and hardcode `{}` into `get_file_metadata()`
- `loadTokenizer()` has `options` and does not pass them to `get_tokenizer_files()`

Each of these now forwards the pretrained options it does not name, so the whole chain reads a single revision.

### How it shows up

Loading a model pinned to a commit in the browser, every file resolves twice — once at the pinned sha, once at `@main`:

```
https://huggingface.co/<repo>/resolve/<sha>/config.json
https://huggingface.co/<repo>/resolve/main/config.json            <- listing/config path
https://huggingface.co/<repo>/resolve/<sha>/tokenizer_config.json
https://huggingface.co/<repo>/resolve/main/tokenizer_config.json  <- listing path
```

Since the browser cache is keyed on the resolved URL, the `@main` copies are cached and never read again. They are small, but they are permanent, and they are confusing to anyone auditing what a pinned load actually downloaded.

The stray entries are the mild symptom. The listing can also disagree with the revision being loaded: if `main` has moved on — different dtypes available, a processor added, a session renamed — `get_files()` reports files that do not exist at the pinned commit, and `get_config()` reads a config that does not describe the weights being loaded.

### Tests

Two cases in `tests/utils/model_registry.test.js`, modelled on the existing `get_available_dtypes` revision test:

- `get_files` forwards `revision`/`cache_dir` to **every** metadata lookup, tokenizer and processor included
- `get_model_files` reads the config from the requested revision

Both fail on `main` and pass with this change. `pnpm test` for `tests/utils` is green (293 passing), as are `prettier --check` and `tsc --build`.