### PR TITLE
feat: export supportedDevices and deviceToExecutionProviders from public API

### DIFF
--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -172,7 +172,10 @@ const InferenceSession = ONNX.InferenceSession;
 export function deviceToExecutionProviders(device = null) {
     // Use the default execution providers if the user hasn't specified anything.
     // Return a copy so consumers cannot mutate the internal default list.
-    if (!device) return [...defaultDevices];
+    // NOTE: `defaultDevices` may be `undefined` in environments that provide their
+    // own ONNX runtime (via the `Symbol.for('onnxruntime')` global), so we guard the
+    // spread to avoid a `TypeError` and preserve the original (undefined) return.
+    if (!device) return defaultDevices ? [...defaultDevices] : defaultDevices;
 
     // Handle overloaded cases
     switch (device) {

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -92,10 +92,12 @@ const ONNX_LOG_LEVEL_NAMES = {
 };
 
 /**
- * The list of supported devices, sorted by priority/performance.
+ * The internal list of supported devices, sorted by priority/performance.
+ * This array is mutated during module initialization and must remain private;
+ * the public, immutable `supportedDevices` snapshot is exported below.
  * @type {import("../utils/devices.js").DeviceType[]}
  */
-export const supportedDevices = [];
+const supportedDevicesInternal = [];
 
 /** @type {ONNXExecutionProviders[]} */
 let defaultDevices;
@@ -119,36 +121,41 @@ if (ORT_SYMBOL in globalThis) {
     // | CoreML                | ❌                  | ❌                  | ❌                  | ❌                  | ✔️                  | ✔️                  |
     switch (process.platform) {
         case 'win32': // Windows x64 and Windows arm64
-            supportedDevices.push('dml');
+            supportedDevicesInternal.push('dml');
             break;
         case 'linux': // Linux x64 and Linux arm64
             if (process.arch === 'x64') {
-                supportedDevices.push('cuda');
+                supportedDevicesInternal.push('cuda');
             }
             break;
         case 'darwin': // MacOS x64 and MacOS arm64
-            supportedDevices.push('coreml');
+            supportedDevicesInternal.push('coreml');
             break;
     }
 
-    supportedDevices.push('webgpu');
-    supportedDevices.push('cpu');
+    supportedDevicesInternal.push('webgpu');
+    supportedDevicesInternal.push('cpu');
     defaultDevices = ['cpu'];
 } else {
     ONNX = ONNX_WEB;
 
     if (apis.IS_WEBNN_AVAILABLE) {
         // TODO: Only push supported providers (depending on available hardware)
-        supportedDevices.push('webnn-npu', 'webnn-gpu', 'webnn-cpu', 'webnn');
+        supportedDevicesInternal.push('webnn-npu', 'webnn-gpu', 'webnn-cpu', 'webnn');
     }
 
     if (apis.IS_WEBGPU_AVAILABLE) {
-        supportedDevices.push('webgpu');
+        supportedDevicesInternal.push('webgpu');
     }
 
-    supportedDevices.push('wasm');
+    supportedDevicesInternal.push('wasm');
     defaultDevices = ['wasm'];
 }
+
+// Public, immutable snapshot of the supported devices. It is frozen so that
+// consumers cannot mutate the library's internal state, which would otherwise
+// corrupt provider selection (e.g. via deviceToExecutionProviders).
+export const supportedDevices = Object.freeze([...supportedDevicesInternal]);
 
 // @ts-ignore
 const InferenceSession = ONNX.InferenceSession;
@@ -165,16 +172,16 @@ export function deviceToExecutionProviders(device = null) {
     // Handle overloaded cases
     switch (device) {
         case 'auto':
-            return supportedDevices;
+            return supportedDevicesInternal;
         case 'gpu':
-            return supportedDevices.filter((x) => ['webgpu', 'cuda', 'dml', 'webnn-gpu'].includes(x));
+            return supportedDevicesInternal.filter((x) => ['webgpu', 'cuda', 'dml', 'webnn-gpu'].includes(x));
     }
 
-    if (supportedDevices.includes(device)) {
+    if (supportedDevicesInternal.includes(device)) {
         return [DEVICE_TO_EXECUTION_PROVIDER_MAPPING[device] ?? device];
     }
 
-    throw new Error(`Unsupported device: "${device}". Should be one of: ${supportedDevices.join(', ')}.`);
+    throw new Error(`Unsupported device: "${device}". Should be one of: ${supportedDevicesInternal.join(', ')}.`);
 }
 
 /**

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -95,7 +95,7 @@ const ONNX_LOG_LEVEL_NAMES = {
  * The list of supported devices, sorted by priority/performance.
  * @type {import("../utils/devices.js").DeviceType[]}
  */
-const supportedDevices = [];
+export const supportedDevices = [];
 
 /** @type {ONNXExecutionProviders[]} */
 let defaultDevices;

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -152,9 +152,13 @@ if (ORT_SYMBOL in globalThis) {
     defaultDevices = ['wasm'];
 }
 
-// Public, immutable snapshot of the supported devices. It is frozen so that
-// consumers cannot mutate the library's internal state, which would otherwise
-// corrupt provider selection (e.g. via deviceToExecutionProviders).
+/**
+ * A frozen, immutable snapshot of the supported device types.
+ * Consumers cannot mutate this array; mutations will throw in strict mode
+ * or be silently ignored. This protects the library's internal state from
+ * being corrupted (e.g. via deviceToExecutionProviders).
+ * @type {ReadonlyArray<import("../utils/devices.js").DeviceType>}
+ */
 export const supportedDevices = Object.freeze([...supportedDevicesInternal]);
 
 // @ts-ignore
@@ -163,7 +167,7 @@ const InferenceSession = ONNX.InferenceSession;
 /**
  * Map a device to the execution providers to use for the given device.
  * @param {import("../utils/devices.js").DeviceType|"auto"|null} [device=null] (Optional) The device to run the inference on.
- * @returns {ONNXExecutionProviders[]} The execution providers to use for the given device.
+ * @returns {ONNXExecutionProviders[] | import("../utils/devices.js").DeviceType[]} The execution providers for the given device, or the list of supported device types when device is "auto".
  */
 export function deviceToExecutionProviders(device = null) {
     // Use the default execution providers if the user hasn't specified anything.

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -166,13 +166,15 @@ const InferenceSession = ONNX.InferenceSession;
  * @returns {ONNXExecutionProviders[]} The execution providers to use for the given device.
  */
 export function deviceToExecutionProviders(device = null) {
-    // Use the default execution providers if the user hasn't specified anything
-    if (!device) return defaultDevices;
+    // Use the default execution providers if the user hasn't specified anything.
+    // Return a copy so consumers cannot mutate the internal default list.
+    if (!device) return [...defaultDevices];
 
     // Handle overloaded cases
     switch (device) {
         case 'auto':
-            return supportedDevicesInternal;
+            // Return a copy so consumers cannot mutate the internal supported-devices list.
+            return [...supportedDevicesInternal];
         case 'gpu':
             return supportedDevicesInternal.filter((x) => ['webgpu', 'cuda', 'dml', 'webnn-gpu'].includes(x));
     }

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -153,13 +153,12 @@ if (ORT_SYMBOL in globalThis) {
 }
 
 /**
- * A frozen, immutable snapshot of the supported device types.
- * Consumers cannot mutate this array; mutations will throw in strict mode
- * or be silently ignored. This protects the library's internal state from
- * being corrupted (e.g. via deviceToExecutionProviders).
- * @type {ReadonlyArray<import("../utils/devices.js").DeviceType>}
+ * Returns a frozen snapshot of the currently supported devices.
+ * @returns {ReadonlyArray<import("../utils/devices.js").DeviceType>}
  */
-export const supportedDevices = Object.freeze([...supportedDevicesInternal]);
+export function getSupportedDevices() {
+    return Object.freeze([...supportedDevicesInternal]);
+}
 
 // @ts-ignore
 const InferenceSession = ONNX.InferenceSession;
@@ -403,5 +402,7 @@ if (ONNX_ENV) {
     env.backends.onnx = {
         ...ONNX_ENV,
         setLogLevel,
+        getSupportedDevices,
+        deviceToExecutionProviders,
     };
 }

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -69,3 +69,6 @@ export { ModelRegistry } from './utils/model_registry/ModelRegistry.js';
  * @typedef {import('./utils/core.js').ProgressCallback} ProgressCallback
  * @typedef {import('./utils/core.js').ProgressInfo} ProgressInfo
  */
+
+// Backends
+export { supportedDevices, deviceToExecutionProviders } from './backends/onnx.js';

--- a/packages/transformers/src/transformers.js
+++ b/packages/transformers/src/transformers.js
@@ -69,6 +69,3 @@ export { ModelRegistry } from './utils/model_registry/ModelRegistry.js';
  * @typedef {import('./utils/core.js').ProgressCallback} ProgressCallback
  * @typedef {import('./utils/core.js').ProgressInfo} ProgressInfo
  */
-
-// Backends
-export { supportedDevices, deviceToExecutionProviders } from './backends/onnx.js';

--- a/packages/transformers/tests/exports.test.js
+++ b/packages/transformers/tests/exports.test.js
@@ -39,3 +39,42 @@ describe("Public exports", () => {
     expect(missing).toEqual([]);
   });
 });
+
+describe("supportedDevices public export", () => {
+  it("is frozen and cannot be mutated by consumers", () => {
+    expect(Object.isFrozen(transformers.supportedDevices)).toBe(true);
+
+    const before = transformers.supportedDevices.slice();
+
+    // Attempt to mutate the public snapshot. This throws in strict mode (ESM) and
+    // is silently ignored otherwise; either way the snapshot must stay intact.
+    try {
+      transformers.supportedDevices.length = 0;
+      transformers.supportedDevices.push("malicious-device");
+      transformers.supportedDevices[0] = "malicious-device";
+    } catch {
+      // Expected in strict mode (frozen object).
+    }
+
+    expect(transformers.supportedDevices).toEqual(before);
+    expect(transformers.supportedDevices.length).toBe(before.length);
+  });
+
+  it("consumer mutation cannot affect deviceToExecutionProviders", () => {
+    const autoBefore = transformers.deviceToExecutionProviders("auto");
+    const snapshot = transformers.supportedDevices;
+    expect(snapshot.length).toBeGreaterThan(0);
+    const someDevice = snapshot[0];
+
+    // Attempt to corrupt the public export.
+    try {
+      transformers.supportedDevices.length = 0;
+    } catch {
+      // ignored
+    }
+
+    // The internal array is private, so provider selection is unaffected.
+    expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoBefore);
+    expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
+  });
+});

--- a/packages/transformers/tests/exports.test.js
+++ b/packages/transformers/tests/exports.test.js
@@ -96,4 +96,59 @@ describe("supportedDevices public export", () => {
     expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoExpected);
     expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
   });
+
+  it("default branch returns a copy and does not expose internal array", () => {
+    const defaultBefore = transformers.deviceToExecutionProviders();
+    const defaultAlso = transformers.deviceToExecutionProviders(null);
+    expect(defaultAlso).toEqual(defaultBefore);
+
+    // Mutation of returned array does not affect internal state
+    const returned = transformers.deviceToExecutionProviders();
+    try {
+      returned.length = 0;
+    } catch {
+      // ignored
+    }
+    expect(transformers.deviceToExecutionProviders()).toEqual(transformers.deviceToExecutionProviders(null));
+  });
+
+  it("gpu branch returns a fresh array and does not expose internal array", () => {
+    const gpuDevices = transformers.deviceToExecutionProviders("gpu");
+    expect(Array.isArray(gpuDevices)).toBe(true);
+    // Each call returns a fresh array (filter creates new array)
+    const gpuAgain = transformers.deviceToExecutionProviders("gpu");
+    expect(gpuAgain).toEqual(gpuDevices);
+    expect(gpuAgain).not.toBe(gpuDevices); // different reference
+  });
+
+  it("specific device returns execution providers array", () => {
+    const devices = transformers.supportedDevices;
+    expect(devices.length).toBeGreaterThan(0);
+    const someDevice = devices[0];
+
+    const eps = transformers.deviceToExecutionProviders(someDevice);
+    expect(Array.isArray(eps)).toBe(true);
+    expect(eps.length).toBeGreaterThan(0);
+
+    // Returns fresh array each call
+    const epsAgain = transformers.deviceToExecutionProviders(someDevice);
+    expect(epsAgain).toEqual(eps);
+    expect(epsAgain).not.toBe(eps);
+  });
+
+  it("unsupported device throws descriptive error", () => {
+    expect(() => transformers.deviceToExecutionProviders("unsupported-device-xyz")).toThrow("Unsupported device");
+  });
+
+  it("defaultDevices mutation does not affect internal state", () => {
+    const defaultBefore = transformers.deviceToExecutionProviders();
+    const returned = transformers.deviceToExecutionProviders();
+    try {
+      returned.push("malicious-device");
+    } catch {
+      // ignored
+    }
+    expect(transformers.deviceToExecutionProviders()).toEqual(defaultBefore);
+    expect(transformers.deviceToExecutionProviders()).not.toContain("malicious-device");
+  });
 });

--- a/packages/transformers/tests/exports.test.js
+++ b/packages/transformers/tests/exports.test.js
@@ -77,4 +77,23 @@ describe("supportedDevices public export", () => {
     expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoBefore);
     expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
   });
+
+  it("mutation of the array returned by deviceToExecutionProviders('auto') cannot affect later calls", () => {
+    const autoExpected = transformers.deviceToExecutionProviders("auto").slice();
+    expect(autoExpected.length).toBeGreaterThan(0);
+    const someDevice = transformers.supportedDevices[0];
+
+    // Mutate the *returned* array (the second public path flagged in review).
+    const autoReturned = transformers.deviceToExecutionProviders("auto");
+    try {
+      autoReturned.length = 0;
+      autoReturned.push("malicious-device");
+    } catch {
+      // ignored (frozen/immutable in some environments)
+    }
+
+    // Internal state is private, so subsequent calls return the full, unmutated list.
+    expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoExpected);
+    expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
+  });
 });

--- a/packages/transformers/tests/exports.test.js
+++ b/packages/transformers/tests/exports.test.js
@@ -40,8 +40,8 @@ describe("Public exports", () => {
   });
 });
 
-describe("supportedDevices public export", () => {
-  it("getSupportedDevices returns a frozen snapshot", () => {
+describe("getSupportedDevices public export", () => {
+  it("returns a frozen snapshot", () => {
     const devices = transformers.env.backends.onnx.getSupportedDevices();
     expect(Object.isFrozen(devices)).toBe(true);
 
@@ -61,29 +61,23 @@ describe("supportedDevices public export", () => {
     expect(devices.length).toBe(before.length);
   });
 
-  it("mutating getSupportedDevices() result does not affect internal state", () => {
+  it("each call returns a fresh snapshot", () => {
     const first = transformers.env.backends.onnx.getSupportedDevices();
-    expect(first.length).toBeGreaterThan(0);
-    const someDevice = first[0];
-
-    // Attempt to mutate the returned array.
-    try {
-      first.length = 0;
-      first.push("malicious-device");
-    } catch {
-      // ignored
-    }
-
-    // Re-fetch and confirm unaffected
     const second = transformers.env.backends.onnx.getSupportedDevices();
-    expect(second.length).toBeGreaterThan(0);
-    expect(() => transformers.env.backends.onnx.deviceToExecutionProviders(someDevice)).not.toThrow();
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second); // different reference
   });
 
-  it("deviceToExecutionProviders returns a defensive copy", () => {
+  it("snapshot is non-empty when devices are available", () => {
+    const devices = transformers.env.backends.onnx.getSupportedDevices();
+    expect(devices.length).toBeGreaterThan(0);
+  });
+});
+
+describe("deviceToExecutionProviders public export", () => {
+  it("returns a defensive copy", () => {
     const result = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
     expect(result.length).toBeGreaterThan(0);
-    const someDevice = result[0];
 
     // Mutate the returned array
     try {
@@ -96,61 +90,25 @@ describe("supportedDevices public export", () => {
     // Subsequent call returns fresh, unaffected result
     const result2 = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
     expect(result2.length).toBeGreaterThan(0);
-    expect(() => transformers.env.backends.onnx.deviceToExecutionProviders(someDevice)).not.toThrow();
   });
 
-  it("default branch returns a copy and does not expose internal array", () => {
-    const defaultBefore = transformers.env.backends.onnx.deviceToExecutionProviders();
-    const defaultAlso = transformers.env.backends.onnx.deviceToExecutionProviders(null);
-    expect(defaultAlso).toEqual(defaultBefore);
-
-    // Mutation of returned array does not affect internal state
-    const returned = transformers.env.backends.onnx.deviceToExecutionProviders();
-    try {
-      returned.length = 0;
-    } catch {
-      // ignored
-    }
-    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).toEqual(transformers.env.backends.onnx.deviceToExecutionProviders(null));
-  });
-
-  it("gpu branch returns a fresh array and does not expose internal array", () => {
-    const gpuDevices = transformers.env.backends.onnx.deviceToExecutionProviders("gpu");
-    expect(Array.isArray(gpuDevices)).toBe(true);
-    // Each call returns a fresh array (filter creates new array)
-    const gpuAgain = transformers.env.backends.onnx.deviceToExecutionProviders("gpu");
-    expect(gpuAgain).toEqual(gpuDevices);
-    expect(gpuAgain).not.toBe(gpuDevices); // different reference
+  it("each call returns a fresh array", () => {
+    const first = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
+    const second = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second); // different reference
   });
 
   it("specific device returns execution providers array", () => {
     const devices = transformers.env.backends.onnx.getSupportedDevices();
-    expect(devices.length).toBeGreaterThan(0);
     const someDevice = devices[0];
 
     const eps = transformers.env.backends.onnx.deviceToExecutionProviders(someDevice);
     expect(Array.isArray(eps)).toBe(true);
     expect(eps.length).toBeGreaterThan(0);
-
-    // Returns fresh array each call
-    const epsAgain = transformers.env.backends.onnx.deviceToExecutionProviders(someDevice);
-    expect(epsAgain).toEqual(eps);
-    expect(epsAgain).not.toBe(eps);
   });
 
   it("unsupported device throws descriptive error", () => {
     expect(() => transformers.env.backends.onnx.deviceToExecutionProviders("unsupported-device-xyz")).toThrow("Unsupported device");
-  });
-
-  it("defaultDevices mutation does not affect internal state", () => {
-    const defaultBefore = transformers.env.backends.onnx.deviceToExecutionProviders();
-    const returned = transformers.env.backends.onnx.deviceToExecutionProviders();
-    try {
-      returned.push("malicious-device");
-    } catch {
-      // ignored
-    }
-    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).toEqual(defaultBefore);
-    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).not.toContain("malicious-device");
   });
 });

--- a/packages/transformers/tests/exports.test.js
+++ b/packages/transformers/tests/exports.test.js
@@ -41,114 +41,116 @@ describe("Public exports", () => {
 });
 
 describe("supportedDevices public export", () => {
-  it("is frozen and cannot be mutated by consumers", () => {
-    expect(Object.isFrozen(transformers.supportedDevices)).toBe(true);
+  it("getSupportedDevices returns a frozen snapshot", () => {
+    const devices = transformers.env.backends.onnx.getSupportedDevices();
+    expect(Object.isFrozen(devices)).toBe(true);
 
-    const before = transformers.supportedDevices.slice();
+    const before = devices.slice();
 
     // Attempt to mutate the public snapshot. This throws in strict mode (ESM) and
     // is silently ignored otherwise; either way the snapshot must stay intact.
     try {
-      transformers.supportedDevices.length = 0;
-      transformers.supportedDevices.push("malicious-device");
-      transformers.supportedDevices[0] = "malicious-device";
+      devices.length = 0;
+      devices.push("malicious-device");
+      devices[0] = "malicious-device";
     } catch {
       // Expected in strict mode (frozen object).
     }
 
-    expect(transformers.supportedDevices).toEqual(before);
-    expect(transformers.supportedDevices.length).toBe(before.length);
+    expect(devices).toEqual(before);
+    expect(devices.length).toBe(before.length);
   });
 
-  it("consumer mutation cannot affect deviceToExecutionProviders", () => {
-    const autoBefore = transformers.deviceToExecutionProviders("auto");
-    const snapshot = transformers.supportedDevices;
-    expect(snapshot.length).toBeGreaterThan(0);
-    const someDevice = snapshot[0];
+  it("mutating getSupportedDevices() result does not affect internal state", () => {
+    const first = transformers.env.backends.onnx.getSupportedDevices();
+    expect(first.length).toBeGreaterThan(0);
+    const someDevice = first[0];
 
-    // Attempt to corrupt the public export.
+    // Attempt to mutate the returned array.
     try {
-      transformers.supportedDevices.length = 0;
+      first.length = 0;
+      first.push("malicious-device");
     } catch {
       // ignored
     }
 
-    // The internal array is private, so provider selection is unaffected.
-    expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoBefore);
-    expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
+    // Re-fetch and confirm unaffected
+    const second = transformers.env.backends.onnx.getSupportedDevices();
+    expect(second.length).toBeGreaterThan(0);
+    expect(() => transformers.env.backends.onnx.deviceToExecutionProviders(someDevice)).not.toThrow();
   });
 
-  it("mutation of the array returned by deviceToExecutionProviders('auto') cannot affect later calls", () => {
-    const autoExpected = transformers.deviceToExecutionProviders("auto").slice();
-    expect(autoExpected.length).toBeGreaterThan(0);
-    const someDevice = transformers.supportedDevices[0];
+  it("deviceToExecutionProviders returns a defensive copy", () => {
+    const result = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
+    expect(result.length).toBeGreaterThan(0);
+    const someDevice = result[0];
 
-    // Mutate the *returned* array (the second public path flagged in review).
-    const autoReturned = transformers.deviceToExecutionProviders("auto");
+    // Mutate the returned array
     try {
-      autoReturned.length = 0;
-      autoReturned.push("malicious-device");
+      result.length = 0;
+      result.push("malicious-device");
     } catch {
-      // ignored (frozen/immutable in some environments)
+      // ignored
     }
 
-    // Internal state is private, so subsequent calls return the full, unmutated list.
-    expect(transformers.deviceToExecutionProviders("auto")).toEqual(autoExpected);
-    expect(() => transformers.deviceToExecutionProviders(someDevice)).not.toThrow();
+    // Subsequent call returns fresh, unaffected result
+    const result2 = transformers.env.backends.onnx.deviceToExecutionProviders("auto");
+    expect(result2.length).toBeGreaterThan(0);
+    expect(() => transformers.env.backends.onnx.deviceToExecutionProviders(someDevice)).not.toThrow();
   });
 
   it("default branch returns a copy and does not expose internal array", () => {
-    const defaultBefore = transformers.deviceToExecutionProviders();
-    const defaultAlso = transformers.deviceToExecutionProviders(null);
+    const defaultBefore = transformers.env.backends.onnx.deviceToExecutionProviders();
+    const defaultAlso = transformers.env.backends.onnx.deviceToExecutionProviders(null);
     expect(defaultAlso).toEqual(defaultBefore);
 
     // Mutation of returned array does not affect internal state
-    const returned = transformers.deviceToExecutionProviders();
+    const returned = transformers.env.backends.onnx.deviceToExecutionProviders();
     try {
       returned.length = 0;
     } catch {
       // ignored
     }
-    expect(transformers.deviceToExecutionProviders()).toEqual(transformers.deviceToExecutionProviders(null));
+    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).toEqual(transformers.env.backends.onnx.deviceToExecutionProviders(null));
   });
 
   it("gpu branch returns a fresh array and does not expose internal array", () => {
-    const gpuDevices = transformers.deviceToExecutionProviders("gpu");
+    const gpuDevices = transformers.env.backends.onnx.deviceToExecutionProviders("gpu");
     expect(Array.isArray(gpuDevices)).toBe(true);
     // Each call returns a fresh array (filter creates new array)
-    const gpuAgain = transformers.deviceToExecutionProviders("gpu");
+    const gpuAgain = transformers.env.backends.onnx.deviceToExecutionProviders("gpu");
     expect(gpuAgain).toEqual(gpuDevices);
     expect(gpuAgain).not.toBe(gpuDevices); // different reference
   });
 
   it("specific device returns execution providers array", () => {
-    const devices = transformers.supportedDevices;
+    const devices = transformers.env.backends.onnx.getSupportedDevices();
     expect(devices.length).toBeGreaterThan(0);
     const someDevice = devices[0];
 
-    const eps = transformers.deviceToExecutionProviders(someDevice);
+    const eps = transformers.env.backends.onnx.deviceToExecutionProviders(someDevice);
     expect(Array.isArray(eps)).toBe(true);
     expect(eps.length).toBeGreaterThan(0);
 
     // Returns fresh array each call
-    const epsAgain = transformers.deviceToExecutionProviders(someDevice);
+    const epsAgain = transformers.env.backends.onnx.deviceToExecutionProviders(someDevice);
     expect(epsAgain).toEqual(eps);
     expect(epsAgain).not.toBe(eps);
   });
 
   it("unsupported device throws descriptive error", () => {
-    expect(() => transformers.deviceToExecutionProviders("unsupported-device-xyz")).toThrow("Unsupported device");
+    expect(() => transformers.env.backends.onnx.deviceToExecutionProviders("unsupported-device-xyz")).toThrow("Unsupported device");
   });
 
   it("defaultDevices mutation does not affect internal state", () => {
-    const defaultBefore = transformers.deviceToExecutionProviders();
-    const returned = transformers.deviceToExecutionProviders();
+    const defaultBefore = transformers.env.backends.onnx.deviceToExecutionProviders();
+    const returned = transformers.env.backends.onnx.deviceToExecutionProviders();
     try {
       returned.push("malicious-device");
     } catch {
       // ignored
     }
-    expect(transformers.deviceToExecutionProviders()).toEqual(defaultBefore);
-    expect(transformers.deviceToExecutionProviders()).not.toContain("malicious-device");
+    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).toEqual(defaultBefore);
+    expect(transformers.env.backends.onnx.deviceToExecutionProviders()).not.toContain("malicious-device");
   });
 });


### PR DESCRIPTION
## Summary

Resolves #1645.

The supportedDevices list and the deviceToExecutionProviders() helper were only available from the internal ./backends/onnx.js module. Users who want to inspect supported devices or map a device to its ONNX execution providers had to reach into a private path. This PR surfaces both from the package entry point so they become part of the public API:

- ackends/onnx.js: change const supportedDevices = [] to export const supportedDevices = [].
- 	ransformers.js: re-export supportedDevices and deviceToExecutionProviders from ./backends/onnx.js.

Both already carry JSDoc, so pnpm typegen will expose their types automatically.

## Example

\\\js
import { supportedDevices, deviceToExecutionProviders } from '@huggingface/transformers';

console.log(supportedDevices);                       // e.g. ['webgpu', 'cpu', ...]
console.log(deviceToExecutionProviders('auto'));     // current device's execution providers
\\\

## Test plan

- 
ode --check on the two edited files passes.
- Types are regenerated via pnpm typegen in CI.