### PR TITLE
Pin WebGPU KV cache for ImageAudioTextToText models (Gemma3n, Gemma4)

### DIFF
--- a/packages/transformers/src/models/session_config.js
+++ b/packages/transformers/src/models/session_config.js
@@ -84,6 +84,7 @@ export const MODEL_SESSION_CONFIG = {
             }
             return s;
         },
+        cache_sessions: { decoder_model_merged: true },
         optional_configs: { generation_config: 'generation_config.json' },
     },
     [MODEL_TYPES.Phi3V]: {

--- a/packages/transformers/tests/utils/session_config.test.js
+++ b/packages/transformers/tests/utils/session_config.test.js
@@ -1,0 +1,22 @@
+import { MODEL_TYPES, MODEL_SESSION_CONFIG, getSessionsConfig } from "../../src/models/session_config.js";
+
+describe("MODEL_SESSION_CONFIG", () => {
+  it("should pin the KV cache of the ImageAudioTextToText decoder (regression: missing cache_sessions)", () => {
+    const { cache_sessions } = getSessionsConfig(MODEL_TYPES.ImageAudioTextToText, {});
+    expect(cache_sessions?.decoder_model_merged).toBe(true);
+  });
+
+  it("should declare cache_sessions for every generating model type", () => {
+    // Every model type that loads a generation config runs an autoregressive decode loop,
+    // so at least one of its sessions must have its KV-cache outputs marked as cacheable
+    // (used on WebGPU to keep `present.*` outputs on-GPU via preferredOutputLocation).
+    const missing = [];
+    for (const [name, type] of Object.entries(MODEL_TYPES)) {
+      const typeConfig = MODEL_SESSION_CONFIG[type];
+      if (!typeConfig?.optional_configs?.generation_config) continue;
+      const hasCacheSession = Object.values(typeConfig.cache_sessions ?? {}).some(Boolean);
+      if (!hasCacheSession) missing.push(name);
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
`[MODEL_TYPES.ImageAudioTextToText]` (src/models/session_config.js:77 on main) is the only generating model type in `MODEL_SESSION_CONFIG` with no `cache_sessions` declaration. `constructSessions` reads `cache_sessions?.[name] ?? false` (src/models/session.js:149), so `cache_config` is `false` for `decoder_model_merged`, and the `if (cache_config && selectedDevice === 'webgpu')` gate in `getSession` (src/models/session.js:110) never sets `preferredOutputLocation: 'gpu-buffer'` for the `present.*` outputs.

The result: on WebGPU, every decode step of `Gemma3nForConditionalGeneration` and `Gemma4ForConditionalGeneration` (src/models/registry.js:627-636) downloads the full KV cache to the CPU and re-uploads it as `past_key_values`, with cost growing per token. The same weights loaded text-only keep the cache on-GPU, since `Gemma3nForCausalLM`/`Gemma4ForCausalLM` route through `MODEL_TYPES.DecoderOnly`, which declares `cache_sessions: { model: true }` (session_config.js:24). The pinning machinery even has a dedicated `gemma4`/`gemma4_text` branch in `getCacheNames` (src/configs.js:403-415) that the multimodal path never reached.

Fix: add `cache_sessions: { decoder_model_merged: true }` to the `ImageAudioTextToText` entry, matching the `AudioTextToText` (session_config.js:74) and `ImageTextToText` (session_config.js:64) siblings exactly.

Also adds `tests/utils/session_config.test.js`: a regression test that the `ImageAudioTextToText` decoder is cache-pinned, plus an invariant that every model type declaring a `generation_config` also declares at least one cache session, so the next model type added cannot silently repeat this. Without the source change both tests fail (`missing: ["ImageAudioTextToText"]`); with it, the affected slice is green (17 suites, 294 passed, 1 skipped). `pnpm format:check` and `tsc --build` pass.

One thing deliberately not changed: no encoder pinning. `VoxtralRealtime` pins its `audio_encoder` (session_config.js:137) because streaming re-invokes the encoder; Gemma3n/Gemma4 run their vision and audio encoders once per input, so only the decoder KV cache benefits.