### PR TITLE
Bump @huggingface/jinja to pick up generation tag whitespace-trim support

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/huggingface/transformers.js#readme",
   "dependencies": {
-    "@huggingface/jinja": "^0.5.6",
+    "@huggingface/jinja": "^0.5.9",
     "@huggingface/tokenizers": "^0.1.3",
     "onnxruntime-node": "1.24.3",
     "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",

--- a/packages/transformers/tests/templating.test.js
+++ b/packages/transformers/tests/templating.test.js
@@ -1,0 +1,9 @@
+import { Template } from "@huggingface/jinja";
+
+describe("Jinja templating (chat templates)", () => {
+  it("should strip generation/endgeneration tags, including their whitespace-trim variants", () => {
+    const template = new Template("Before{%- generation -%}Middle{%- endgeneration -%}After");
+
+    expect(template.render({})).toEqual("BeforeMiddleAfter");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   packages/transformers:
     dependencies:
       '@huggingface/jinja':
-        specifier: ^0.5.6
-        version: 0.5.6
+        specifier: ^0.5.9
+        version: 0.5.9
       '@huggingface/tokenizers':
         specifier: ^0.1.3
         version: 0.1.3
@@ -390,8 +390,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@huggingface/jinja@0.5.6':
-    resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
   '@huggingface/tokenizers@0.1.3':
@@ -2331,7 +2331,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@huggingface/jinja@0.5.6': {}
+  '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tokenizers@0.1.3': {}
 


### PR DESCRIPTION
Closes #1724.

The bundled jinja package already gained support for the `{%- generation -%}` / `{%- endgeneration -%}` whitespace-trim variants of the transformers-specific generation tag back in 0.5.7, but this package's own lockfile still resolved `@huggingface/jinja` to 0.5.6, even though the `^0.5.6` range in `package.json` already permits the newer release. Chat templates using the trimmed form (as some newer models on the hub do, per the issue) failed to parse with `Unknown statement type: generation` as a result.

Bumped the declared range to `^0.5.9` and refreshed the lockfile to actually pick up the fix that was already published. Added a regression test that renders a template using the trimmed tag form directly against `@huggingface/jinja`'s `Template` class, so this doesn't silently regress again if the lockfile drifts.

Verified by temporarily reverting just the `package.json` bump and reinstalling: the new test fails with the exact reported `Unknown statement type: generation` error against 0.5.6, and passes once the bump and lockfile update are restored and reinstalled.