### PR TITLE
Support custom file names for multi-session models

### DIFF
--- a/packages/transformers/src/models/modeling_utils.js
+++ b/packages/transformers/src/models/modeling_utils.js
@@ -40,7 +40,7 @@ import { logger } from '../utils/logger.js';
 import { DynamicCache } from '../cache_utils.js';
 import { get_model_files } from '../utils/model_registry/get_model_files.js';
 import { get_file_metadata } from '../utils/model_registry/get_file_metadata.js';
-import { MODEL_SESSION_CONFIG, MODEL_TYPES } from './session_config.js';
+import { getSessionsConfig, MODEL_SESSION_CONFIG, MODEL_TYPES } from './session_config.js';
 
 /**
  * Converts an array or Tensor of integers to an int64 Tensor.
@@ -346,12 +346,13 @@ export class PreTrainedModel extends Callable {
             }
         }
 
-        const sessions = typeConfig.sessions(config, options, textOnly);
-        const promises = [
-            constructSessions(pretrained_model_name_or_path, sessions, options, typeConfig.cache_sessions),
-        ];
-        if (typeConfig.optional_configs) {
-            promises.push(get_optional_configs(pretrained_model_name_or_path, typeConfig.optional_configs, options));
+        const { sessions, cache_sessions, optional_configs } = getSessionsConfig(modelType, config, {
+            ...options,
+            textOnly,
+        });
+        const promises = [constructSessions(pretrained_model_name_or_path, sessions, options, cache_sessions)];
+        if (optional_configs) {
+            promises.push(get_optional_configs(pretrained_model_name_or_path, optional_configs, options));
         }
         const info = await Promise.all(promises);
 

--- a/packages/transformers/src/models/session_config.js
+++ b/packages/transformers/src/models/session_config.js
@@ -143,6 +143,29 @@ export const MODEL_SESSION_CONFIG = {
 };
 
 /**
+ * Apply user-provided file names to a session map.
+ *
+ * Multi-session models accept overrides keyed by either the runtime session
+ * name or its default file name. For example, Seq2Seq's encoder session is
+ * named `model` but loads `encoder_model.onnx` by default, so either key can
+ * be used to override it.
+ *
+ * @param {Record<string, string>} sessions The default session-to-file mapping.
+ * @param {Record<string, string>|null|undefined} overrides Custom file names.
+ * @returns {Record<string, string>}
+ */
+function applyModelFileNames(sessions, overrides) {
+    if (overrides == null) return sessions;
+
+    return Object.fromEntries(
+        Object.entries(sessions).map(([sessionName, defaultName]) => {
+            const override = overrides[sessionName] ?? overrides[defaultName];
+            return [sessionName, typeof override === 'string' ? override : defaultName];
+        }),
+    );
+}
+
+/**
  * Returns the text-only session names for a given model type, or `null` if
  * the model type does not define a text-only session set.
  * @param {number} modelType The model type enum value.
@@ -162,8 +185,13 @@ export function getTextOnlySessions(modelType) {
  */
 export function getSessionsConfig(modelType, config, options = {}) {
     const typeConfig = MODEL_SESSION_CONFIG[modelType] ?? MODEL_SESSION_CONFIG.default;
+    const modelFileName = options.model_file_name;
+    const modelFileNameOverrides = modelFileName !== null && typeof modelFileName === 'object' ? modelFileName : null;
+    const sessionOptions = modelFileNameOverrides ? { ...options, model_file_name: null } : options;
+    const sessions = typeConfig.sessions(config, sessionOptions, options.textOnly ?? false);
+
     return {
-        sessions: typeConfig.sessions(config, options, options.textOnly ?? false),
+        sessions: applyModelFileNames(sessions, modelFileNameOverrides),
         cache_sessions: typeConfig.cache_sessions,
         optional_configs: typeConfig.optional_configs,
     };

--- a/packages/transformers/src/pipelines.js
+++ b/packages/transformers/src/pipelines.js
@@ -134,6 +134,7 @@ export async function pipeline(
     const expected_files = await get_pipeline_files(task, model, {
         device,
         dtype,
+        model_file_name,
     });
 
     /** @type {import('./utils/core.js').FilesLoadingMap} */

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -47,7 +47,7 @@ export { MAX_EXTERNAL_DATA_CHUNKS } from './hub/constants.js';
  * @typedef {Object} ModelSpecificPretrainedOptions Options for loading a pretrained model.
  * @property {string} [subfolder='onnx'] In case the relevant files are located inside a subfolder of the model repo on huggingface.co,
  * you can specify the folder name here.
- * @property {string} [model_file_name=null] If specified, load the model with this name (excluding the dtype and .onnx suffixes). Currently only valid for encoder- or decoder-only models.
+ * @property {string|Record<string, string>} [model_file_name=null] If specified, load the model with this name (excluding the dtype and .onnx suffixes). For multi-session models, pass a mapping from session or default file names to custom file names.
  * @property {import("./devices.js").DeviceType|Record<string, import("./devices.js").DeviceType>} [device=null] The device to run the model on. If not specified, the device will be chosen from the environment settings.
  * @property {import("./dtypes.js").DataType|Record<string, import("./dtypes.js").DataType>} [dtype=null] The data type to use for the model. If not specified, the data type will be chosen from the environment settings.
  * @property {ExternalData|Record<string, ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).

--- a/packages/transformers/src/utils/model_registry/ModelRegistry.js
+++ b/packages/transformers/src/utils/model_registry/ModelRegistry.js
@@ -124,7 +124,7 @@ export class ModelRegistry {
      * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
-     * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string|Record<string, string>} [options.model_file_name=null] - Override model file names (excluding .onnx suffix)
      * @param {boolean} [options.include_tokenizer=true] - Whether to check for tokenizer files
      * @param {boolean} [options.include_processor=true] - Whether to check for processor files
      * @returns {Promise<string[]>} Array of file paths
@@ -147,7 +147,7 @@ export class ModelRegistry {
      * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
-     * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string|Record<string, string>} [options.model_file_name=null] - Override model file names (excluding .onnx suffix)
      * @returns {Promise<string[]>} Array of file paths
      *
      * @example
@@ -166,7 +166,7 @@ export class ModelRegistry {
      * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
      * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
      * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
-     * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string|Record<string, string>} [options.model_file_name=null] - Override model file names (excluding .onnx suffix)
      * @returns {Promise<string[]>} Array of model file paths
      *
      * @example
@@ -215,7 +215,7 @@ export class ModelRegistry {
      * @param {string} modelId - The model id (e.g., "onnx-community/all-MiniLM-L6-v2-ONNX")
      * @param {Object} [options] - Optional parameters
      * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
-     * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+     * @param {string|Record<string, string>} [options.model_file_name=null] - Override model file names (excluding .onnx suffix)
      * @param {string} [options.revision='main'] - Model revision
      * @param {string} [options.cache_dir=null] - Custom cache directory
      * @param {boolean} [options.local_files_only=false] - Only check local files

--- a/packages/transformers/src/utils/model_registry/get_available_dtypes.js
+++ b/packages/transformers/src/utils/model_registry/get_available_dtypes.js
@@ -25,7 +25,7 @@ const CONCRETE_DTYPES = Object.keys(DEFAULT_DTYPE_SUFFIX_MAPPING);
  * @param {string} modelId The model id (e.g., "onnx-community/all-MiniLM-L6-v2-ONNX")
  * @param {Object} [options] Optional parameters
  * @param {PretrainedConfig} [options.config=null] Pre-loaded model config (optional, will be fetched if not provided)
- * @param {string} [options.model_file_name=null] Override the model file name (excluding .onnx suffix)
+ * @param {string|Record<string, string>} [options.model_file_name=null] Override model file names (excluding .onnx suffix)
  * @param {string} [options.revision='main'] Model revision
  * @param {string} [options.cache_dir=null] Custom cache directory
  * @param {boolean} [options.local_files_only=false] Only check local files

--- a/packages/transformers/src/utils/model_registry/get_files.js
+++ b/packages/transformers/src/utils/model_registry/get_files.js
@@ -11,7 +11,7 @@ import { get_processor_files } from './get_processor_files.js';
  * @param {import('../../configs.js').PretrainedConfig} [options.config=null] Pre-loaded model config (optional, will be fetched if not provided)
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] Override dtype (use this if passing dtype to pipeline)
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] Override device (use this if passing device to pipeline)
- * @param {string|null} [options.model_file_name=null|null] Override the model file name (excluding .onnx suffix)
+ * @param {string|Record<string, string>|null} [options.model_file_name=null|null] Override model file names (excluding .onnx suffix)
  * @param {boolean} [options.include_tokenizer=true] Whether to check for tokenizer files (set to false for vision-only models)
  * @param {boolean} [options.include_processor=true] Whether to check for processor files
  * @returns {Promise<string[]>} Array of file paths that will be loaded

--- a/packages/transformers/src/utils/model_registry/get_model_files.js
+++ b/packages/transformers/src/utils/model_registry/get_model_files.js
@@ -54,7 +54,7 @@ export function get_config(
  * @param {import('../../configs.js').PretrainedConfig} [options.config=null] Pre-loaded model config (optional, will be fetched if not provided)
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] Override dtype (use this if passing dtype to pipeline)
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] Override device (use this if passing device to pipeline)
- * @param {string} [options.model_file_name=null] Override the model file name (excluding .onnx suffix).
+ * @param {string|Record<string, string>} [options.model_file_name=null] Override model file names (excluding .onnx suffix).
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  */
 export async function get_model_files(

--- a/packages/transformers/src/utils/model_registry/get_pipeline_files.js
+++ b/packages/transformers/src/utils/model_registry/get_pipeline_files.js
@@ -1,7 +1,7 @@
 import { get_files } from './get_files.js';
 import { get_config } from './get_model_files.js';
 import { resolve_model_type } from './resolve_model_type.js';
-import { getTextOnlySessions } from '../../models/session_config.js';
+import { getSessionsConfig, getTextOnlySessions } from '../../models/session_config.js';
 import { SUPPORTED_TASKS, TASK_ALIASES } from '../../pipelines/index.js';
 
 /**
@@ -15,7 +15,7 @@ import { SUPPORTED_TASKS, TASK_ALIASES } from '../../pipelines/index.js';
  * @param {import('../../configs.js').PretrainedConfig} [options.config=null] - Pre-loaded config
  * @param {import('../dtypes.js').DataType|Record<string, import('../dtypes.js').DataType>} [options.dtype=null] - Override dtype
  * @param {import('../devices.js').DeviceType|Record<string, import('../devices.js').DeviceType>} [options.device=null] - Override device
- * @param {string} [options.model_file_name=null] - Override the model file name (excluding .onnx suffix)
+ * @param {string|Record<string, string>} [options.model_file_name=null] - Override model file names (excluding .onnx suffix)
  * @returns {Promise<string[]>} Array of file paths that will be loaded
  * @throws {Error} If the task is not supported
  */
@@ -53,7 +53,8 @@ export async function get_pipeline_files(task, modelId, options = {}) {
         const textOnlySessions = getTextOnlySessions(modelType);
 
         if (textOnlySessions) {
-            const allowedPrefixes = Object.values(textOnlySessions).map((s) => `onnx/${s}`);
+            const { sessions } = getSessionsConfig(modelType, config, { ...options, textOnly: true });
+            const allowedPrefixes = Object.values(sessions).map((s) => `onnx/${s}`);
             return files.filter((f) => !f.startsWith('onnx/') || allowedPrefixes.some((p) => f.startsWith(p)));
         }
     }

--- a/packages/transformers/tests/utils/model_registry.test.js
+++ b/packages/transformers/tests/utils/model_registry.test.js
@@ -11,6 +11,7 @@ await import("../../src/models/registry.js");
 
 // Dynamic import after mock setup (required for ESM)
 const { get_available_dtypes } = await import("../../src/utils/model_registry/get_available_dtypes.js");
+const { get_model_files } = await import("../../src/utils/model_registry/get_model_files.js");
 
 // A minimal config that mimics a BERT-like encoder-only model
 const ENCODER_ONLY_CONFIG = {
@@ -179,5 +180,20 @@ describe("get_available_dtypes", () => {
     for (const dtype of dtypes) {
       expect(validDtypes).toContain(dtype);
     }
+  });
+});
+
+describe("get_model_files", () => {
+  it("should support custom file names for seq2seq models", async () => {
+    const files = await get_model_files("test/model", {
+      config: SEQ2SEQ_CONFIG,
+      dtype: "fp32",
+      model_file_name: {
+        encoder_model: "custom_encoder",
+        decoder_model_merged: "custom_decoder",
+      },
+    });
+
+    expect(files).toEqual(["config.json", "onnx/custom_encoder.onnx", "onnx/custom_decoder.onnx", "generation_config.json"]);
   });
 });

--- a/packages/transformers/tests/utils/session_config.test.js
+++ b/packages/transformers/tests/utils/session_config.test.js
@@ -1,0 +1,48 @@
+import { getSessionsConfig, MODEL_TYPES } from "../../src/models/session_config.js";
+
+describe("model file name overrides", () => {
+  it("applies file-name mappings to multi-session models", () => {
+    const { sessions } = getSessionsConfig(
+      MODEL_TYPES.Seq2Seq,
+      {},
+      {
+        model_file_name: {
+          encoder_model: "custom_encoder",
+          decoder_model_merged: "custom_decoder",
+        },
+      },
+    );
+
+    expect(sessions).toEqual({
+      model: "custom_encoder",
+      decoder_model_merged: "custom_decoder",
+    });
+  });
+
+  it("accepts runtime session names and preserves unspecified defaults", () => {
+    const { sessions } = getSessionsConfig(
+      MODEL_TYPES.Seq2Seq,
+      {},
+      {
+        model_file_name: { model: "custom_encoder" },
+      },
+    );
+
+    expect(sessions).toEqual({
+      model: "custom_encoder",
+      decoder_model_merged: "decoder_model_merged",
+    });
+  });
+
+  it("keeps string overrides working for single-session models", () => {
+    const { sessions } = getSessionsConfig(
+      MODEL_TYPES.DecoderOnly,
+      {},
+      {
+        model_file_name: "custom_model",
+      },
+    );
+
+    expect(sessions).toEqual({ model: "custom_model" });
+  });
+});


### PR DESCRIPTION
Closes #1754.

`model_file_name` was only applied by single-session model configurations, so
encoder-decoder and other multi-session models always fell back to their
hard-coded file names.

This adds object mappings for multi-session models while preserving string
overrides for single-session models:

```js
model_file_name: {
  encoder_model: "custom_encoder",
  decoder_model_merged: "custom_decoder",
}
```

The resolved session map is now shared by the runtime loader, model registry,
dtype discovery, and pipeline progress-file discovery. Mapping keys may use
either the runtime session name or its default file name; unspecified sessions
retain their defaults.

Validation:

- Added unit coverage for mapped, partial, and existing string overrides
- Added a file-registry regression test for Seq2Seq models
- Ran isolated runtime-loader and file-registry assertions for the custom paths
- Ran syntax checks and Prettier checks over all changed JavaScript files
