### PR TITLE
Add decode-only WebGPU graph capture with static KV caches

### DIFF
--- a/packages/transformers/docs/source/guides/graph_capture_benchmark.json
+++ b/packages/transformers/docs/source/guides/graph_capture_benchmark.json
@@ -1,0 +1,219 @@
+{
+  "date": "2026-09-06T06:20:39.351Z",
+  "node": "v24.20.0",
+  "ort": "1.26.0-dev.20260416-b7804b056c",
+  "ort_module": "Pinned ORT Web with microsoft/onnxruntime#32456 ordering fix",
+  "webgpu_module": "Dawn Node binding, D3D12, DXC enabled",
+  "adapter": {
+    "vendor": "nvidia",
+    "architecture": "blackwell",
+    "device": "nvidia-geforce-rtx-5080",
+    "description": "D3D12 driver version 32.0.16.1656"
+  },
+  "model": "Phi-4-mini-instruct / ORT GenAI graph-ready INT4 export",
+  "graph_sha256": "eb2e6bc8a269ba9d4a757de89e173936d080b1817cff2b936f148ad478f8f773",
+  "weights_sha256": "b952da81d9c04a72394e2557b4f4e5526d6a51c5d788b4906e04a8fe66588e13",
+  "weights_bytes": 2491416576,
+  "workload": {
+    "prompt-tokens": 128,
+    "new-tokens": 128,
+    "context": 2048,
+    "warmup": 2,
+    "runs": 5
+  },
+  "prompt_ids": [
+    200021, 64614, 277, 750, 495, 2164, 25, 220, 976, 5030, 11282, 5297, 7187,
+    11, 7595, 3158, 11, 15095, 5012, 11348, 11, 326, 21312, 11222, 34205, 13,
+    623, 5030, 11282, 5297, 7187, 11, 7595, 3158, 11, 15095, 5012, 11348, 11,
+    326, 21312, 11222, 34205, 13, 623, 5030, 11282, 5297, 7187, 11, 7595, 3158,
+    11, 15095, 5012, 11348, 11, 326, 21312, 11222, 34205, 13, 623, 5030, 11282,
+    5297, 7187, 11, 7595, 3158, 11, 15095, 5012, 11348, 11, 326, 21312, 11222,
+    34205, 13, 623, 5030, 11282, 5297, 7187, 11, 7595, 3158, 11, 15095, 5012,
+    11348, 11, 326, 21312, 11222, 34205, 13, 623, 5030, 11282, 5297, 7187, 11,
+    7595, 3158, 11, 15095, 5012, 11348, 11, 326, 21312, 11222, 34205, 13, 623,
+    5030, 11282, 5297, 7187, 11, 7595, 3158, 11, 15095, 200020, 200019
+  ],
+  "trials": {
+    "capture_off": {
+      "model_load_ms": 2309.6717,
+      "runs": [
+        {
+          "ttft_ms": 49.447400000000926,
+          "decode_ms": 2265.2273999999998,
+          "decode_tokens_per_second": 56.065011397972675,
+          "total_ms": 2314.6748000000007
+        },
+        {
+          "ttft_ms": 38.295499999998356,
+          "decode_ms": 2248.444300000003,
+          "decode_tokens_per_second": 56.483498390420365,
+          "total_ms": 2286.739800000001
+        },
+        {
+          "ttft_ms": 38.25560000000041,
+          "decode_ms": 2295.8616,
+          "decode_tokens_per_second": 55.316923284922744,
+          "total_ms": 2334.1172000000006
+        },
+        {
+          "ttft_ms": 38.93449999999939,
+          "decode_ms": 2619.3863999999994,
+          "decode_tokens_per_second": 48.48463747082142,
+          "total_ms": 2658.320899999999
+        },
+        {
+          "ttft_ms": 39.18919999999707,
+          "decode_ms": 2530.9138999999996,
+          "decode_tokens_per_second": 50.179502352885265,
+          "total_ms": 2570.1030999999966
+        }
+      ]
+    },
+    "capture_on": {
+      "model_load_ms": 2223.6493999999984,
+      "runs": [
+        {
+          "ttft_ms": 47.96399999999994,
+          "decode_ms": 975.3427999999985,
+          "decode_tokens_per_second": 130.21062953455973,
+          "total_ms": 1023.3067999999985
+        },
+        {
+          "ttft_ms": 39.09900000000198,
+          "decode_ms": 965.3885999999984,
+          "decode_tokens_per_second": 131.55324187586243,
+          "total_ms": 1004.4876000000004
+        },
+        {
+          "ttft_ms": 40.24720000000525,
+          "decode_ms": 975.8820999999953,
+          "decode_tokens_per_second": 130.13867146451463,
+          "total_ms": 1016.1293000000005
+        },
+        {
+          "ttft_ms": 38.903999999994994,
+          "decode_ms": 971.2401000000027,
+          "decode_tokens_per_second": 130.76066360933785,
+          "total_ms": 1010.1440999999977
+        },
+        {
+          "ttft_ms": 44.92250000000058,
+          "decode_ms": 962.799500000001,
+          "decode_tokens_per_second": 131.90700659898542,
+          "total_ms": 1007.7220000000016
+        }
+      ]
+    }
+  },
+  "capture_verification": {
+    "replay_log_events": 2,
+    "excluded_from_timing": true
+  },
+  "summary": {
+    "capture_off_decode_tps": 55.316923284922744,
+    "capture_on_decode_tps": 130.76066360933785,
+    "speedup": 2.363845561977923,
+    "improvement_percent": 136.38455619779228,
+    "identical_tokens": true
+  },
+  "generated_ids": [
+    976, 5030, 11282, 6008, 261, 7968, 328, 3581, 3463, 3158, 316, 7187, 326,
+    26971, 11, 15095, 5012, 11348, 11, 326, 21312, 11222, 34205, 13, 200020,
+    199999, 2, 26113, 25, 355, 220, 2548, 8204, 12324, 12511, 21849, 483, 261,
+    220, 18, 33559, 5678, 328, 35678, 47210, 11, 118014, 51309, 11, 326, 142941,
+    3883, 6049, 6266, 13, 2160, 9811, 29239, 11, 290, 10323, 14518, 35612, 326,
+    853, 31137, 15885, 262, 747, 70, 7606, 13, 49934, 10742, 26477, 128273, 11,
+    49217, 35962, 78856, 11, 326, 22725, 107649, 361, 19904, 535, 13, 355,
+    63901, 8642, 178766, 7398, 138863, 933, 55718, 82027, 483, 52454, 22614,
+    94037, 13, 355, 21235, 130496, 134505, 50795, 22725, 10936, 72869, 483,
+    11202, 8663, 328, 138863, 933, 55718, 82027, 326, 43867, 11242, 13, 89799,
+    178229, 128640, 328, 290, 21235
+  ],
+  "generated_text": "The city library provides a variety of services including access to books and computers, quiet study rooms, and weekly science workshops.# Problem: A 45-year-old male presents with a 3-month history of progressive fatigue, intermittent fever, and unexplained weight loss. On physical examination, the patient appears pale and has mild splenomegaly. Laboratory tests reveal anemia, elevated liver enzymes, and hyperglobulinemia. A peripheral blood smear shows atypical lymphocytes with irregular nuclear contours. A bone marrow biopsy demonstrates hypercellularity with increased numbers of atypical lymphocytes and plasma cells. Immunophenotyping of the bone",
+  "runtime_patch": "https://github.com/microsoft/onnxruntime/pull/32456",
+  "runtime_js_sha256": "fa85789fa12f82afc52dd694efa4f2403002624af8d7fd92683af6715dcbd2b1",
+  "runtime_wasm_sha256": "e0c0c6d3e73d43b8a249972f8358f845b08cc16fec3c80efafdf8bed40366786",
+  "dawn_node_sha256": "18cea3a6c05cf1cd1ff14adb0b1f936ffb3c038da36250863ea27eb6722dd6e1",
+  "earlier_repeat": {
+    "summary": {
+      "capture_off_decode_tps": 51.46211152690518,
+      "capture_on_decode_tps": 128.45471106641443,
+      "speedup": 2.496102613264447,
+      "improvement_percent": 149.6102613264447,
+      "identical_tokens": true
+    },
+    "capture_verification": "Separate verbose run confirmed capture enable=1 and graph replay before measurement.",
+    "trials": {
+      "capture_off": {
+        "model_load_ms": 2878.1549999999997,
+        "runs": [
+          {
+            "ttft_ms": 41.74229999999989,
+            "decode_ms": 2637.0954999999994,
+            "decode_tokens_per_second": 48.159044676235666,
+            "total_ms": 2678.8377999999993
+          },
+          {
+            "ttft_ms": 40.10570000000007,
+            "decode_ms": 2696.315199999999,
+            "decode_tokens_per_second": 47.101318124824594,
+            "total_ms": 2736.420899999999
+          },
+          {
+            "ttft_ms": 38.56290000000081,
+            "decode_ms": 2404.927300000001,
+            "decode_tokens_per_second": 52.80824913085728,
+            "total_ms": 2443.490200000002
+          },
+          {
+            "ttft_ms": 48.372300000002724,
+            "decode_ms": 2457.0265,
+            "decode_tokens_per_second": 51.68849420223999,
+            "total_ms": 2505.3988000000027
+          },
+          {
+            "ttft_ms": 40.36510000000271,
+            "decode_ms": 2467.834999999999,
+            "decode_tokens_per_second": 51.46211152690518,
+            "total_ms": 2508.200100000002
+          }
+        ]
+      },
+      "capture_on": {
+        "model_load_ms": 2134.2765,
+        "runs": [
+          {
+            "ttft_ms": 40.40650000000096,
+            "decode_ms": 986.8781000000017,
+            "decode_tokens_per_second": 128.6886394581051,
+            "total_ms": 1027.2846000000027
+          },
+          {
+            "ttft_ms": 40.32940000000235,
+            "decode_ms": 1047.5270999999993,
+            "decode_tokens_per_second": 121.23791355851327,
+            "total_ms": 1087.8565000000017
+          },
+          {
+            "ttft_ms": 41.09690000000046,
+            "decode_ms": 1140.4545999999973,
+            "decode_tokens_per_second": 111.35910188796669,
+            "total_ms": 1181.5514999999978
+          },
+          {
+            "ttft_ms": 39.409300000002986,
+            "decode_ms": 988.6752999999953,
+            "decode_tokens_per_second": 128.45471106641443,
+            "total_ms": 1028.0845999999983
+          },
+          {
+            "ttft_ms": 39.39860000000044,
+            "decode_ms": 970.9501999999993,
+            "decode_tokens_per_second": 130.79970527839646,
+            "total_ms": 1010.3487999999998
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/transformers/docs/source/guides/graph_capture_benchmark.md
+++ b/packages/transformers/docs/source/guides/graph_capture_benchmark.md
@@ -1,0 +1,74 @@
+# Phi-4-mini decode graph capture benchmark
+
+Measured on 2026-09-06 using the Transformers.js generation path, ORT Web's
+Asyncify runtime, and Dawn's Node WebGPU binding on an NVIDIA GeForce RTX 5080
+(D3D12 driver 32.0.16.1656), Windows, Node.js v24.20.0.
+
+**Runtime prerequisite:** these measurements include
+[ONNX Runtime #32456](https://github.com/microsoft/onnxruntime/pull/32456).
+The currently pinned ORT package ignores the extra capture provider setting
+without that fix. Both comparison modes use the same patched JS runtime and
+the same unmodified WASM binaries and model assets.
+
+## Results
+
+| Metric (median of five measured runs) | Capture off | Decode capture on |
+| --- | ---: | ---: |
+| Decode throughput | 55.32 tokens/s | 130.76 tokens/s |
+| Time to first token | 38.93 ms | 40.25 ms |
+
+Decode throughput improved **2.36× (+136.4%)**. An earlier independent series
+measured 51.46 → 128.45 tokens/s (**2.50×**). Prefill remains uncaptured.
+All warmup and measured runs generated identical token IDs across modes.
+
+The final benchmark automatically observed two native
+`Replaying the captured WebGpuExecutionProvider graph` log events in a separate,
+untimed verification pass. Logging was disabled for the measured sessions.
+The script refuses to report a speedup if it does not observe actual replay.
+
+## Workload and method
+
+- Model: Phi-4-mini-instruct (3.8B), ORT GenAI graph-ready export with GQA,
+  fused rotary embedding, INT4 linear weights, and FP16 activations/cache.
+  The external weight file contains 2,491,416,576 bytes.
+- Batch size 1; 128 prompt tokens and exactly 128 generated tokens; greedy
+  sampling; fixed KV capacity of 2048 tokens; WebGPU validation mode `basic`.
+- Two warmup generations per mode, then five measured generations per mode.
+  Capture-off runs precede capture-on runs; the models are loaded sequentially.
+- Both modes use the same static, shared KV input/output buffers. Only capture
+  is toggled. Prefill uses `gpu_graph_id=-1`; captured decode uses ID `0`.
+- Decode throughput is `127 / (last_token_time - first_token_time)` and includes
+  Transformers.js generation overhead and sampling. Model loading, prompt
+  tokenization, prefill, verification, and warmup are excluded from this interval.
+- TTFT is measured from `generate()` to its first generated-token callback.
+
+These are ORT **Web** measurements through a Node WebGPU binding, not native
+ORT GenAI or browser measurements. They do not establish performance for other
+GPUs, context capacities, model exports, or browser versions. Run-to-run variation
+is retained in the [raw results](./graph_capture_benchmark.json), alongside asset
+hashes, token IDs, and both measurement series.
+
+## Reproduce
+
+From the repository root, with Node.js 24 or newer and a Dawn Node binding built
+with DXC (`shader-f16` and `subgroups` must be available):
+
+```sh
+pnpm install --frozen-lockfile
+
+node packages/transformers/scripts/benchmarks/build-ort-extra-options.mjs \
+  --output .cache/ort.webgpu.extra-options.mjs
+
+node packages/transformers/scripts/benchmarks/graph-capture.mjs \
+  --model /path/to/graph-ready/Phi-4-mini-instruct \
+  --webgpu-module /path/to/dawn.node \
+  --ort-module .cache/ort.webgpu.extra-options.mjs \
+  --prompt-tokens 128 --new-tokens 128 --context 2048 \
+  --warmup 2 --runs 5 --output graph-capture-results.json
+```
+
+The input directory must contain `genai_config.json`, `model.onnx`,
+`model.onnx.data`, and tokenizer assets. The export was built with
+`enable_webgpu_graph=true`, shared embeddings, and a pruned LM head.
+The script stages Transformers.js configuration separately and leaves the
+original model directory unchanged.

--- a/packages/transformers/docs/source/guides/webgpu.md
+++ b/packages/transformers/docs/source/guides/webgpu.md
@@ -85,6 +85,11 @@ console.log(output);
 
 ## Decode graph capture
 
+This feature depends on [ONNX Runtime #32456](https://github.com/microsoft/onnxruntime/pull/32456).
+The currently pinned ORT release ignores the extra provider setting used below.
+Until a fixed release is pinned, use a runtime built with that patch. The benchmark
+helper below builds a patched JS runtime while retaining the pinned WASM binaries.
+
 For compatible decoder models, set `session_options.enableGraphCapture: true`
 to capture and replay single-token decode steps. Prefill always skips capture,
 including one-token prompts and multi-token continuations of an existing cache.
@@ -146,9 +151,13 @@ To benchmark a local graph-ready ORT GenAI Phi-4-mini export through the actual
 Transformers.js generation path, use the repository's benchmark script:
 
 ```sh
+node packages/transformers/scripts/benchmarks/build-ort-extra-options.mjs \
+  --output .cache/ort.webgpu.extra-options.mjs
+
 node packages/transformers/scripts/benchmarks/graph-capture.mjs \
   --model /path/to/Phi-4-mini-instruct \
   --webgpu-module /path/to/dawn.node \
+  --ort-module .cache/ort.webgpu.extra-options.mjs \
   --prompt-tokens 128 --new-tokens 128 --context 2048 \
   --warmup 2 --runs 5 --output graph-capture-results.json
 ```
@@ -156,12 +165,16 @@ node packages/transformers/scripts/benchmarks/graph-capture.mjs \
 Use Node.js 24 or newer and a Dawn binding with `shader-f16` and `subgroups`
 (on Windows, build Dawn with DXC). The script uses ORT Web's Asyncify build,
 compares identical generated token IDs, and reports decode throughput separately
-from time to first token. Model loading and warmup are excluded from decode
+from time to first token. It verifies actual graph-replay log events before timing
+and refuses to report a speedup if capture is inactive. Model loading, verification,
+and warmup are excluded from decode
 measurements. The initial decode calls prepare and capture the graph, so compare
 warmed-up runs; performance depends on the model, context capacity, and hardware.
 
 See the [ONNX Runtime WebGPU documentation](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html#graph-capture)
 for the runtime requirements.
+
+See the [Phi-4-mini benchmark report](./graph_capture_benchmark.md) for measured results.
 ## Reporting bugs and providing feedback
 
 Due to the experimental nature of WebGPU, especially in non-Chromium browsers, you may experience issues when trying to run a model (even if it can run in WASM). If you do, please open [an issue on GitHub](https://github.com/huggingface/transformers.js/issues/new?title=[WebGPU]%20Error%20running%20MODEL_GOES_HERE&assignees=&labels=bug,webgpu&projects=&template=1_bug-report.yml) and we'll do our best to address it. Thanks!

--- a/packages/transformers/docs/source/guides/webgpu.md
+++ b/packages/transformers/docs/source/guides/webgpu.md
@@ -83,6 +83,85 @@ console.log(output);
 // ]
 ```
 
+## Decode graph capture
+
+For compatible decoder models, set `session_options.enableGraphCapture: true`
+to capture and replay single-token decode steps. Prefill always skips capture,
+including one-token prompts and multi-token continuations of an existing cache.
+Encoders and other component sessions also run normally.
+
+This requires an ONNX export built for static KV caches and WebGPU graph capture,
+such as an ORT GenAI export with `enable_webgpu_graph=true`. Ordinary exports that
+concatenate an increasingly long KV cache are not compatible. This option does
+not convert the ONNX graph. The implementation uses ONNX Runtime Web's C++ WebGPU
+EP, which is the runtime imported by Transformers.js; the older JSEP backend and
+the native Node.js runtime are not supported.
+
+For a compatible export packaged for Transformers.js:
+
+```js
+import { AutoConfig, AutoModelForCausalLM, AutoTokenizer } from "@huggingface/transformers";
+
+const modelId = "./phi4-webgpu";
+const config = await AutoConfig.from_pretrained(modelId);
+config["transformers.js_config"] = {
+  ...config["transformers.js_config"],
+  max_cache_length: 2048, // Capacity includes the prompt and generated tokens.
+};
+const model = await AutoModelForCausalLM.from_pretrained(modelId, {
+  config,
+  device: "webgpu",
+  dtype: "q4f16",
+  session_options: { enableGraphCapture: true },
+});
+const tokenizer = await AutoTokenizer.from_pretrained(modelId);
+const inputs = tokenizer("<|user|>What is the capital of France?<|end|><|assistant|>");
+const output = await model.generate({ ...inputs, max_new_tokens: 128, do_sample: false });
+console.log(tokenizer.decode(output[0].tolist(), { skip_special_tokens: true }));
+await model.dispose();
+```
+
+The same loading options work with `pipeline("text-generation", ...)`.
+Batch size is currently limited to one. Do not override the prompt dimensions
+with `freeDimensionOverrides`: prefill must accept the actual prompt length.
+
+Transformers.js allocates fixed-capacity KV buffers and binds each cache output
+to its corresponding input buffer. Decode uses stable GPU token, mask, and logit
+buffers. Only logits are downloaded for sampling. `max_cache_length` defaults to
+2048 and exceeding it raises an error before running the model.
+
+A static cache's tensor dimensions describe its capacity;
+`past_key_values.get_seq_length()` reports the number of processed tokens.
+The buffers belong to the model and are released by `model.dispose()`. Returned
+KV tensors are views of that mutable cache. Start only one generation at a time
+per model instance. A new independent prompt invalidates caches retained from
+an older sequence; pass the current `past_key_values` to continue that sequence.
+
+For a controlled capture-off baseline, set
+`config["transformers.js_config"].use_static_cache = true` and
+`session_options.enableGraphCapture = false`. This keeps the export, cache
+capacity, and shared buffers the same while disabling capture.
+
+To benchmark a local graph-ready ORT GenAI Phi-4-mini export through the actual
+Transformers.js generation path, use the repository's benchmark script:
+
+```sh
+node packages/transformers/scripts/benchmarks/graph-capture.mjs \
+  --model /path/to/Phi-4-mini-instruct \
+  --webgpu-module /path/to/dawn.node \
+  --prompt-tokens 128 --new-tokens 128 --context 2048 \
+  --warmup 2 --runs 5 --output graph-capture-results.json
+```
+
+Use Node.js 24 or newer and a Dawn binding with `shader-f16` and `subgroups`
+(on Windows, build Dawn with DXC). The script uses ORT Web's Asyncify build,
+compares identical generated token IDs, and reports decode throughput separately
+from time to first token. Model loading and warmup are excluded from decode
+measurements. The initial decode calls prepare and capture the graph, so compare
+warmed-up runs; performance depends on the model, context capacity, and hardware.
+
+See the [ONNX Runtime WebGPU documentation](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html#graph-capture)
+for the runtime requirements.
 ## Reporting bugs and providing feedback
 
 Due to the experimental nature of WebGPU, especially in non-Chromium browsers, you may experience issues when trying to run a model (even if it can run in WASM). If you do, please open [an issue on GitHub](https://github.com/huggingface/transformers.js/issues/new?title=[WebGPU]%20Error%20running%20MODEL_GOES_HERE&assignees=&labels=bug,webgpu&projects=&template=1_bug-report.yml) and we'll do our best to address it. Thanks!

--- a/packages/transformers/scripts/benchmarks/build-ort-extra-options.mjs
+++ b/packages/transformers/scripts/benchmarks/build-ort-extra-options.mjs
@@ -1,0 +1,53 @@
+// Build the runtime prerequisite for benchmark/review until ORT #32456 is released.
+import { build } from "esbuild";
+import { createRequire } from "node:module";
+import { parseArgs } from "node:util";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+const { values } = parseArgs({ options: { output: { type: "string", default: ".cache/ort.webgpu.extra-options.mjs" } } });
+const require = createRequire(import.meta.url);
+const pkg = path.dirname(path.dirname(require.resolve("onnxruntime-web")));
+await build({
+  entryPoints: [path.join(pkg, "lib/index.ts")],
+  outfile: path.resolve(values.output),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  minify: true,
+  external: ["node:*", "fs", "path", "os", "url", "module", "worker_threads"],
+  define: {
+    "BUILD_DEFS.IS_ESM": "true",
+    "BUILD_DEFS.ENABLE_BUNDLE_WASM_JS": "false",
+    "BUILD_DEFS.ENABLE_JSPI": "false",
+    "BUILD_DEFS.DISABLE_JSEP": "true",
+    "BUILD_DEFS.DISABLE_WEBGPU": "false",
+    "BUILD_DEFS.DISABLE_WASM": "false",
+    "BUILD_DEFS.DISABLE_WEBGL": "true",
+    "BUILD_DEFS.DISABLE_WEBNN": "true",
+    "BUILD_DEFS.DISABLE_WASM_PROXY": "true",
+    "BUILD_DEFS.BUNDLE_FILENAME": '"ort.webgpu.extra-options.mjs"',
+    "BUILD_DEFS.ESM_IMPORT_META_URL": "import.meta.url",
+  },
+  plugins: [
+    {
+      name: "extra-before-ep",
+      setup(build) {
+        build.onLoad({ filter: /wasm[\\/]session-options\.ts$/ }, async ({ path }) => {
+          let source = (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
+          const start = source.indexOf("    if (sessionOptions.extra !== undefined) {");
+          const end = source.indexOf("    return [sessionOptionsHandle, allocs];", start);
+          if (start < 0 || end < 0) throw new Error("Missing patch target");
+          const provider = source.indexOf("    if (sessionOptions.executionProviders) {");
+          if (provider < 0) throw new Error("Missing execution-provider setup");
+          if (start < provider) return { contents: source, loader: "ts" };
+          const block = source.slice(start, end);
+          source = source.slice(0, start) + source.slice(end);
+          const insert = source.indexOf("    if (sessionOptions.executionProviders) {");
+          source = source.slice(0, insert) + block + source.slice(insert);
+          return { contents: source, loader: "ts" };
+        });
+      },
+    },
+  ],
+});
+console.log("Built pinned ORT Web with extra settings applied before EP construction.");

--- a/packages/transformers/scripts/benchmarks/graph-capture.mjs
+++ b/packages/transformers/scripts/benchmarks/graph-capture.mjs
@@ -19,6 +19,7 @@ import { parseArgs } from "node:util";
 const { values } = parseArgs({
   options: {
     model: { type: "string" },
+    "ort-module": { type: "string" },
     "webgpu-module": { type: "string" },
     output: { type: "string", default: "graph-capture-results.json" },
     "prompt-tokens": { type: "string", default: "128" },
@@ -37,8 +38,8 @@ const numbers = Object.fromEntries(
     return [name, value];
   }),
 );
-if (numbers["new-tokens"] < 2 || numbers.context < numbers["prompt-tokens"] + numbers["new-tokens"])
-  throw new Error("Need at least two new tokens and sufficient --context.");
+if (numbers["new-tokens"] < 3 || numbers.context < numbers["prompt-tokens"] + numbers["new-tokens"])
+  throw new Error("Need at least three new tokens to verify replay, and sufficient --context.");
 
 const require = createRequire(import.meta.url);
 const bindingPath = values["webgpu-module"];
@@ -49,7 +50,32 @@ const adapter = await navigator.gpu.requestAdapter({ powerPreference: "high-perf
 if (!adapter?.features.has("shader-f16") || !adapter.features.has("subgroups"))
   throw new Error("The Dawn binding must provide shader-f16 and subgroups. On Windows use a Dawn build with DXC enabled.");
 const adapterInfo = adapter.info;
-register("./ort-web-loader.mjs", import.meta.url);
+// Install log interception before ORT binds its WASM console sinks.
+let replayEvents = 0;
+let verifying = false;
+const originalLog = console.log;
+const originalError = console.error;
+const fs = require("node:fs");
+const originalWriteSync = fs.writeSync;
+const intercept =
+  (original) =>
+  (...args) => {
+    if (verifying) {
+      if (args.some((arg) => String(arg).includes("Replaying the captured WebGpuExecutionProvider graph"))) ++replayEvents;
+    } else original(...args);
+  };
+console.log = intercept(originalLog);
+console.error = intercept(originalError);
+// Emscripten's Node factory writes logs directly to file descriptors 1 and 2.
+fs.writeSync = (fd, data, ...args) => {
+  if (verifying && (fd === 1 || fd === 2) && typeof data === "string") {
+    if (data.includes("Replaying the captured WebGpuExecutionProvider graph")) ++replayEvents;
+    return Buffer.byteLength(data);
+  }
+  return originalWriteSync(fd, data, ...args);
+};
+const runtimeOverride = values["ort-module"] ? pathToFileURL(path.resolve(values["ort-module"])).href : undefined;
+register("./ort-web-loader.mjs", { parentURL: import.meta.url, data: { runtime: runtimeOverride } });
 const ort = await import("onnxruntime-web/webgpu");
 const ortDist = path.dirname(require.resolve("onnxruntime-web"));
 ort.env.wasm.numThreads = 1;
@@ -142,6 +168,7 @@ const report = {
   date: new Date().toISOString(),
   node: process.version,
   ort: ort.env.versions.web,
+  ort_module: runtimeOverride ?? "onnxruntime-web/webgpu",
   webgpu_module: bindingPath,
   adapter: { vendor: adapterInfo.vendor, architecture: adapterInfo.architecture, device: adapterInfo.device, description: adapterInfo.description },
   model: modelSource,
@@ -154,6 +181,38 @@ const report = {
 };
 let expected;
 try {
+  // Verify actual replay before timing. Numerical equality alone also passes
+  // when an older runtime silently ignores the capture provider setting.
+  verifying = true;
+  try {
+    const probe = await AutoModelForCausalLM.from_pretrained(staging, {
+      device: "webgpu",
+      dtype: "q4f16",
+      local_files_only: true,
+      session_options: {
+        enableGraphCapture: true,
+        logSeverityLevel: 1,
+        executionProviders: [{ name: "webgpu", validationMode: "basic" }],
+        externalData: [{ path: weightName, data: weights }],
+      },
+    });
+    try {
+      await probe.generate({ ...inputs, max_new_tokens: Math.min(4, numbers["new-tokens"]), eos_token_id: null, do_sample: false });
+    } finally {
+      await probe.dispose();
+    }
+  } finally {
+    verifying = false;
+    console.log = originalLog;
+    console.error = originalError;
+    fs.writeSync = originalWriteSync;
+  }
+  if (!replayEvents)
+    throw new Error(
+      "No WebGPU graph replay was observed. Use --ort-module with the ORT session-options ordering fix: https://github.com/microsoft/onnxruntime/pull/32456",
+    );
+  report.capture_verification = { replay_log_events: replayEvents, excluded_from_timing: true };
+  console.log(`Verified actual WebGPU graph replay (${replayEvents} events). Starting timed runs.`);
   for (const capture of [false, true]) {
     const createStart = performance.now();
     const model = await AutoModelForCausalLM.from_pretrained(staging, {

--- a/packages/transformers/scripts/benchmarks/graph-capture.mjs
+++ b/packages/transformers/scripts/benchmarks/graph-capture.mjs
@@ -1,0 +1,228 @@
+/**
+ * Compare decode capture off/on using a graph-ready ORT GenAI Phi-4-mini export.
+ * Node >=24, a Dawn Node binding with shader-f16/subgroups, and local model files
+ * are required. No native ORT/GenAI inference library is used.
+ *
+ * node scripts/benchmarks/graph-capture.mjs --model PATH --webgpu-module PATH_TO_DAWN_NODE
+ *   [--prompt-tokens 128] [--new-tokens 128] [--context 2048] [--warmup 2] [--runs 5]
+ *   [--output results.json]
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createRequire, register } from "node:module";
+import { open, readFile, writeFile, mkdtemp, mkdir, copyFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  options: {
+    model: { type: "string" },
+    "webgpu-module": { type: "string" },
+    output: { type: "string", default: "graph-capture-results.json" },
+    "prompt-tokens": { type: "string", default: "128" },
+    "new-tokens": { type: "string", default: "128" },
+    context: { type: "string", default: "2048" },
+    warmup: { type: "string", default: "2" },
+    runs: { type: "string", default: "5" },
+  },
+});
+if (!values.model || !values["webgpu-module"]) throw new Error("Required: --model <GenAI Phi-4-mini export> --webgpu-module <dawn.node or package name>");
+if (Number(process.versions.node.split(".")[0]) < 24) throw new Error("Use Node.js 24 or newer for ORT's Asyncify runtime.");
+const numbers = Object.fromEntries(
+  ["prompt-tokens", "new-tokens", "context", "warmup", "runs"].map((name) => {
+    const value = Number(values[name]);
+    if (!Number.isSafeInteger(value) || value < (name === "warmup" ? 0 : 1)) throw new Error(`Invalid --${name}`);
+    return [name, value];
+  }),
+);
+if (numbers["new-tokens"] < 2 || numbers.context < numbers["prompt-tokens"] + numbers["new-tokens"])
+  throw new Error("Need at least two new tokens and sufficient --context.");
+
+const require = createRequire(import.meta.url);
+const bindingPath = values["webgpu-module"];
+const binding = bindingPath.endsWith(".node") ? require(path.resolve(bindingPath)) : await import(bindingPath);
+Object.assign(globalThis, binding.globals);
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: { gpu: binding.create(["backend=d3d12"]) } });
+const adapter = await navigator.gpu.requestAdapter({ powerPreference: "high-performance" });
+if (!adapter?.features.has("shader-f16") || !adapter.features.has("subgroups"))
+  throw new Error("The Dawn binding must provide shader-f16 and subgroups. On Windows use a Dawn build with DXC enabled.");
+const adapterInfo = adapter.info;
+register("./ort-web-loader.mjs", import.meta.url);
+const ort = await import("onnxruntime-web/webgpu");
+const ortDist = path.dirname(require.resolve("onnxruntime-web"));
+ort.env.wasm.numThreads = 1;
+ort.env.wasm.wasmPaths = {
+  mjs: pathToFileURL(path.join(ortDist, "ort-wasm-simd-threaded.asyncify.mjs")).href,
+  wasm: pathToFileURL(path.join(ortDist, "ort-wasm-simd-threaded.asyncify.wasm")).href,
+};
+// Transformers.js resolves local model paths in Node; the Web bundle takes bytes.
+const originalCreate = ort.InferenceSession.create.bind(ort.InferenceSession);
+ort.InferenceSession.create = async (model, options) => originalCreate(typeof model === "string" ? new Uint8Array(await readFile(model)) : model, options);
+const { AutoModelForCausalLM, AutoTokenizer, Tensor, env } = await import("../../src/transformers.js");
+env.useWasmCache = false;
+
+// Read >2 GiB files in chunks (fs.readFile has a smaller single-read limit).
+async function readLargeFile(filename) {
+  const handle = await open(filename, "r");
+  try {
+    const data = new Uint8Array((await handle.stat()).size);
+    for (let offset = 0; offset < data.length; ) {
+      const { bytesRead } = await handle.read(data, offset, Math.min(256 * 1024 * 1024, data.length - offset), offset);
+      if (!bytesRead) throw new Error(`Unexpected EOF: ${filename}`);
+      offset += bytesRead;
+    }
+    return data;
+  } finally {
+    await handle.close();
+  }
+}
+const modelSource = path.resolve(values.model);
+const genai = JSON.parse(await readFile(path.join(modelSource, "genai_config.json"), "utf8"));
+if (genai.model.type !== "phi3") throw new Error("This benchmark stages a Phi-4-mini (phi3) GenAI export.");
+const decoder = genai.model.decoder;
+const graph = await readFile(path.join(modelSource, decoder.filename));
+// The graph-ready GenAI Phi-4 export uses a single model.onnx.data sidecar.
+const weightName = `${decoder.filename}.data`;
+console.log("Reading and hashing model assets (excluded from timing)...");
+const weights = await readLargeFile(path.join(modelSource, weightName));
+const hash = (data) => {
+  const digest = createHash("sha256");
+  for (let offset = 0; offset < data.length; offset += 256 * 1024 * 1024) digest.update(data.subarray(offset, offset + 256 * 1024 * 1024));
+  return digest.digest("hex");
+};
+const staging = await mkdtemp(path.join(tmpdir(), "transformers-phi4-capture-"));
+await mkdir(path.join(staging, "onnx"));
+await writeFile(path.join(staging, "onnx", "model_q4f16.onnx"), graph);
+for (const name of ["tokenizer.json", "tokenizer_config.json", "special_tokens_map.json", "added_tokens.json"]) {
+  try {
+    await copyFile(path.join(modelSource, name), path.join(staging, name));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+const config = {
+  architectures: ["Phi3ForCausalLM"],
+  model_type: "phi3",
+  hidden_size: decoder.hidden_size,
+  num_hidden_layers: decoder.num_hidden_layers,
+  num_attention_heads: decoder.num_attention_heads,
+  num_key_value_heads: decoder.num_key_value_heads,
+  head_dim: decoder.head_size,
+  vocab_size: genai.model.vocab_size,
+  bos_token_id: genai.model.bos_token_id,
+  eos_token_id: genai.model.eos_token_id,
+  pad_token_id: genai.model.pad_token_id,
+  max_position_embeddings: genai.model.context_length,
+  "transformers.js_config": { use_static_cache: true, max_cache_length: numbers.context },
+};
+await writeFile(path.join(staging, "config.json"), JSON.stringify(config));
+await writeFile(
+  path.join(staging, "generation_config.json"),
+  JSON.stringify({ eos_token_id: genai.model.eos_token_id, pad_token_id: genai.model.pad_token_id }),
+);
+const tokenizer = await AutoTokenizer.from_pretrained(staging, { local_files_only: true });
+const prefix = tokenizer.encode("<|user|>Summarize this information: ", { add_special_tokens: false });
+const suffix = tokenizer.encode("<|end|><|assistant|>", { add_special_tokens: false });
+const body = tokenizer.encode(
+  "The city library offers books, computer access, quiet study rooms, and weekly science workshops. ".repeat(numbers["prompt-tokens"]),
+  { add_special_tokens: false },
+);
+const prompt =
+  numbers["prompt-tokens"] > prefix.length + suffix.length
+    ? [...prefix, ...body.slice(0, numbers["prompt-tokens"] - prefix.length - suffix.length), ...suffix]
+    : body.slice(0, numbers["prompt-tokens"]);
+assert.equal(prompt.length, numbers["prompt-tokens"]);
+const inputs = {
+  input_ids: new Tensor("int64", prompt.map(BigInt), [1, prompt.length]),
+  attention_mask: new Tensor("int64", Array(prompt.length).fill(1n), [1, prompt.length]),
+};
+const report = {
+  date: new Date().toISOString(),
+  node: process.version,
+  ort: ort.env.versions.web,
+  webgpu_module: bindingPath,
+  adapter: { vendor: adapterInfo.vendor, architecture: adapterInfo.architecture, device: adapterInfo.device, description: adapterInfo.description },
+  model: modelSource,
+  graph_sha256: hash(graph),
+  weights_sha256: hash(weights),
+  weights_bytes: weights.byteLength,
+  workload: numbers,
+  prompt_ids: prompt,
+  trials: {},
+};
+let expected;
+try {
+  for (const capture of [false, true]) {
+    const createStart = performance.now();
+    const model = await AutoModelForCausalLM.from_pretrained(staging, {
+      device: "webgpu",
+      dtype: "q4f16",
+      local_files_only: true,
+      session_options: {
+        enableGraphCapture: capture,
+        executionProviders: [{ name: "webgpu", validationMode: "basic" }],
+        externalData: [{ path: weightName, data: weights }],
+      },
+    });
+    const modelLoadMs = performance.now() - createStart;
+    const trials = [];
+    try {
+      for (let run = -numbers.warmup; run < numbers.runs; ++run) {
+        const times = [];
+        let firstPut = true;
+        const start = performance.now();
+        const output = await model.generate({
+          ...inputs,
+          max_new_tokens: numbers["new-tokens"],
+          eos_token_id: null,
+          do_sample: false,
+          streamer: {
+            put() {
+              if (firstPut) firstPut = false;
+              else times.push(performance.now());
+            },
+            end() {},
+          },
+        });
+        const ids = Array.from(output.data, Number);
+        if (expected) assert.deepEqual(ids, expected, "Capture on/off must generate identical token IDs");
+        else expected = ids;
+        assert.equal(times.length, numbers["new-tokens"]);
+        const decodeMs = times.at(-1) - times[0];
+        const trial = {
+          ttft_ms: times[0] - start,
+          decode_ms: decodeMs,
+          decode_tokens_per_second: ((times.length - 1) * 1000) / decodeMs,
+          total_ms: times.at(-1) - start,
+        };
+        console.log(
+          `capture=${capture} ${run < 0 ? "warmup" : "trial"} ${run}: ${trial.decode_tokens_per_second.toFixed(2)} decode tok/s, TTFT ${trial.ttft_ms.toFixed(2)} ms`,
+        );
+        if (run >= 0) trials.push(trial);
+      }
+    } finally {
+      await model.dispose();
+    }
+    report.trials[capture ? "capture_on" : "capture_off"] = { model_load_ms: modelLoadMs, runs: trials };
+  }
+  const median = (xs) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+  const off = median(report.trials.capture_off.runs.map((x) => x.decode_tokens_per_second));
+  const on = median(report.trials.capture_on.runs.map((x) => x.decode_tokens_per_second));
+  report.summary = {
+    capture_off_decode_tps: off,
+    capture_on_decode_tps: on,
+    speedup: on / off,
+    improvement_percent: (on / off - 1) * 100,
+    identical_tokens: true,
+  };
+  report.generated_ids = expected.slice(prompt.length);
+  report.generated_text = tokenizer.decode(report.generated_ids, { skip_special_tokens: true });
+  await writeFile(path.resolve(values.output), JSON.stringify(report, null, 2) + "\n");
+  console.log(JSON.stringify(report.summary, null, 2));
+  console.log(`Results: ${path.resolve(values.output)}`);
+} finally {
+  (await ort.env.webgpu.device)?.destroy();
+  delete globalThis.navigator;
+}

--- a/packages/transformers/scripts/benchmarks/ort-web-loader.mjs
+++ b/packages/transformers/scripts/benchmarks/ort-web-loader.mjs
@@ -1,0 +1,5 @@
+// Run the browser WebGPU runtime through Dawn's Node binding for this benchmark.
+// Source imports of onnxruntime-node must resolve to that same runtime instance.
+export function resolve(specifier, context, nextResolve) {
+  return nextResolve(specifier === "onnxruntime-node" ? "onnxruntime-web/webgpu" : specifier, context);
+}

--- a/packages/transformers/scripts/benchmarks/ort-web-loader.mjs
+++ b/packages/transformers/scripts/benchmarks/ort-web-loader.mjs
@@ -1,5 +1,12 @@
 // Run the browser WebGPU runtime through Dawn's Node binding for this benchmark.
 // Source imports of onnxruntime-node must resolve to that same runtime instance.
+let runtime;
+export function initialize(data) {
+  runtime = data?.runtime;
+}
 export function resolve(specifier, context, nextResolve) {
-  return nextResolve(specifier === "onnxruntime-node" ? "onnxruntime-web/webgpu" : specifier, context);
+  if (specifier === "onnxruntime-node" || (runtime && specifier === "onnxruntime-web/webgpu")) {
+    return nextResolve(runtime ?? "onnxruntime-web/webgpu", context);
+  }
+  return nextResolve(specifier, context);
 }

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -25,6 +25,7 @@ import * as ONNX_WEB from 'onnxruntime-web/webgpu';
 import { loadWasmBinary, loadWasmFactory } from './utils/cacheWasm.js';
 import { isBlobURL, toAbsoluteURL } from '../utils/hub/utils.js';
 import { logger } from '../utils/logger.js';
+import { DecodeGraphCaptureSession } from './utils/graph-capture.js';
 export { Tensor } from 'onnxruntime-common';
 
 /**
@@ -284,25 +285,100 @@ async function ensureWasmLoaded() {
  * @returns {Promise<import('onnxruntime-common').InferenceSession & { config: Object }>} The ONNX inference session.
  */
 export async function createInferenceSession(buffer_or_path, session_options, session_config) {
+    const useStaticCache = session_config?.use_static_cache === true;
+    const capture = useStaticCache && session_options?.enableGraphCapture === true;
+    if (useStaticCache) {
+        const provider = session_options.executionProviders?.[0];
+        if (!ONNX_ENV?.versions?.web || (typeof provider === 'string' ? provider : provider?.name) !== 'webgpu') {
+            throw new Error(
+                'Static KV cache and decode graph capture require ONNX Runtime Web with the WebGPU execution provider.',
+            );
+        }
+        if (isONNXProxy()) throw new Error('Decode graph capture does not support env.backends.onnx.wasm.proxy.');
+        const locations = session_options.preferredOutputLocation;
+        if (locations === 'gpu-buffer' || (typeof locations === 'object' && locations?.logits === 'gpu-buffer')) {
+            throw new Error('Decode graph capture requires CPU logits for token sampling.');
+        }
+    }
     await ensureWasmLoaded();
     const logSeverityLevel = getOnnxLogSeverityLevel(env.logLevel ?? LogLevel.WARNING);
-    const load = () =>
-        InferenceSession.create(buffer_or_path, {
-            // Set default log severity level, but allow overriding through session options
-            logSeverityLevel,
-            ...session_options,
-        });
-    const session = await (apis.IS_WEB_ENV ? (webInitChain = webInitChain.then(load)) : load());
+    const create = (options) => {
+        const load = () => InferenceSession.create(buffer_or_path, { logSeverityLevel, ...options });
+        return apis.IS_WEB_ENV || ONNX_ENV?.versions?.web
+            ? (webInitChain = webInitChain.catch(() => {}).then(load))
+            : load();
+    };
+    // Enable capture in the C++ EP through its session config, while retaining
+    // ordinary JS I/O binding. ORT Web's top-level enableGraphCapture keeps the
+    // first bindings forever and mishandles preallocated outputs on replay.
+    // Rebinding the same decode GPU buffers allows normal prefill shapes with
+    // gpu_graph_id=-1, without creating a second copy of the model weights.
+    const session = await create({
+        ...session_options,
+        ...(useStaticCache
+            ? {
+                  enableGraphCapture: false,
+                  extra: {
+                      ...session_options.extra,
+                      'ep.webgpuexecutionprovider.enableGraphCapture': capture ? '1' : '0',
+                  },
+              }
+            : {}),
+    });
     session.config = session_config;
+    if (useStaticCache) {
+        let state;
+        try {
+            const provider = session_options.executionProviders[0];
+            const device =
+                (typeof provider === 'object' &&
+                    /** @type {import('onnxruntime-common').InferenceSession.WebGpuExecutionProviderOption} */ (
+                        provider
+                    ).device) ||
+                (await ONNX_ENV.webgpu?.device);
+            if (!device) throw new Error('Decode graph capture requires the GPUDevice used by ONNX Runtime Web.');
+            state = new DecodeGraphCaptureSession(session, device, {
+                cacheNames: session_config.cache_names,
+                maxCacheLength: session_config.max_cache_length,
+                TensorConstructor: ONNX.Tensor,
+                enableGraphCapture: capture,
+            });
+        } catch (error) {
+            await session.release();
+            throw error;
+        }
+        graphCaptureSessions.set(session, state);
+        const release = session.release.bind(session);
+        session.release = () =>
+            enqueueInference(async () => {
+                try {
+                    await release();
+                } finally {
+                    try {
+                        await state.dispose();
+                    } finally {
+                        graphCaptureSessions.delete(session);
+                    }
+                }
+            });
+    }
     return session;
 }
 
+/** @type {WeakMap<import('onnxruntime-common').InferenceSession, DecodeGraphCaptureSession>} */
+const graphCaptureSessions = new WeakMap();
 /**
  * Currently, Transformers.js doesn't support simultaneous execution of sessions in WASM/WebGPU.
  * For this reason, we need to chain the inference calls (otherwise we get "Error: Session already started").
  * @type {Promise<any>}
  */
 let webInferenceChain = Promise.resolve();
+
+/** @param {() => Promise<any>} run */
+function enqueueInference(run) {
+    // Keep a failed input validation or inference from rejecting every later run.
+    return (webInferenceChain = webInferenceChain.catch(() => {}).then(run));
+}
 
 /**
  * Run an inference session.
@@ -311,8 +387,9 @@ let webInferenceChain = Promise.resolve();
  * @returns {Promise<Record<string, import('onnxruntime-common').Tensor>>} The output tensors.
  */
 export async function runInferenceSession(session, ortFeed) {
-    const run = () => session.run(ortFeed);
-    return apis.IS_WEB_ENV ? (webInferenceChain = webInferenceChain.then(run)) : run();
+    const capture = graphCaptureSessions.get(session);
+    const run = () => (capture ? capture.run(ortFeed) : session.run(ortFeed));
+    return apis.IS_WEB_ENV || ONNX_ENV?.versions?.web || capture ? enqueueInference(run) : run();
 }
 
 /**

--- a/packages/transformers/src/backends/onnx.js
+++ b/packages/transformers/src/backends/onnx.js
@@ -367,6 +367,7 @@ export async function createInferenceSession(buffer_or_path, session_options, se
 
 /** @type {WeakMap<import('onnxruntime-common').InferenceSession, DecodeGraphCaptureSession>} */
 const graphCaptureSessions = new WeakMap();
+
 /**
  * Currently, Transformers.js doesn't support simultaneous execution of sessions in WASM/WebGPU.
  * For this reason, we need to chain the inference calls (otherwise we get "Error: Session already started").

--- a/packages/transformers/src/backends/utils/graph-capture.js
+++ b/packages/transformers/src/backends/utils/graph-capture.js
@@ -1,0 +1,347 @@
+import { Tensor } from 'onnxruntime-common';
+import { getStaticCacheInfo, setStaticCacheInfo } from '../../utils/static-cache.js';
+
+const TYPES = {
+    float32: Float32Array,
+    float16: Uint16Array,
+    int32: Int32Array,
+    int64: BigInt64Array,
+    uint32: Uint32Array,
+    uint8: Uint8Array,
+    bool: Uint8Array,
+};
+const alignedSize = (size) => Math.ceil(size / 16) * 16;
+
+/** Static KV buffers and decode-only capture; prefill uses gpu_graph_id=-1. @private */
+export class DecodeGraphCaptureSession {
+    /**
+     * @param {import('onnxruntime-common').InferenceSession} session ORT session with capture configured in the C++ EP.
+     * @param {GPUDevice} device ORT's own device.
+     * @param {Object} options
+     * @param {string[]} options.cacheNames
+     * @param {number} options.maxCacheLength
+     * @param {boolean} [options.enableGraphCapture=false]
+     * @param {typeof Tensor} [options.TensorConstructor]
+     */
+    constructor(
+        session,
+        device,
+        { cacheNames, maxCacheLength, enableGraphCapture = false, TensorConstructor = Tensor },
+    ) {
+        if (!Number.isSafeInteger(maxCacheLength) || maxCacheLength < 1)
+            throw new Error('max_cache_length must be a positive integer.');
+        if (
+            !session.inputNames.includes('input_ids') ||
+            !session.inputNames.includes('attention_mask') ||
+            !cacheNames.length
+        ) {
+            throw new Error(
+                'Decode graph capture requires input_ids, attention_mask and a static-cache-compatible decoder export.',
+            );
+        }
+        this.session = session;
+        this.device = device;
+        this.Tensor = TensorConstructor;
+        this.maxCacheLength = maxCacheLength;
+        this.enableGraphCapture = enableGraphCapture;
+        this.cacheNames = cacheNames;
+        this.epoch = 0;
+        this.disposed = false;
+        /** @type {Map<string, Tensor>} */
+        this.cache = new Map();
+        /** @type {Map<string, Tensor>} */
+        this.decodeInputs = new Map();
+        /** @type {Map<string, Tensor>} */
+        this.decodeOutputs = new Map();
+    }
+
+    /** @param {Record<string, Tensor>} feeds */
+    async run(feeds) {
+        if (this.disposed) throw new Error('Cannot run a disposed decode graph capture session.');
+        const ids = feeds.input_ids;
+        const mask = feeds.attention_mask;
+        if (ids?.dims.length !== 2 || ids.dims[0] !== 1 || ids.dims[1] < 1) {
+            throw new Error('Decode graph capture currently requires batch size 1 and non-empty input_ids.');
+        }
+        if (mask?.dims.length !== 2 || mask.dims[0] !== 1 || !['cpu', 'cpu-pinned'].includes(mask.location)) {
+            throw new Error('Decode graph capture requires a CPU attention_mask with batch size 1.');
+        }
+        const past = feeds[this.cacheNames[0]];
+        const info = past && getStaticCacheInfo(past);
+        const pastLength = info?.length ?? past?.dims.at(-2);
+        if (!Number.isSafeInteger(pastLength) || pastLength < 0)
+            throw new Error('Missing or invalid past key values for decode graph capture.');
+        const length = pastLength + ids.dims[1];
+        if (length > this.maxCacheLength) {
+            throw new Error(
+                `Static KV cache capacity (${this.maxCacheLength}) exceeded by ${length} tokens. Increase transformers.js_config.max_cache_length.`,
+            );
+        }
+        if (mask.dims[1] !== length)
+            throw new Error(`attention_mask length must equal past length plus input length (${length}).`);
+        for (const name of this.cacheNames) {
+            const tensor = feeds[name];
+            const entry = tensor && getStaticCacheInfo(tensor);
+            const meta = this.session.inputMetadata.find((item) => item.name === name);
+            if (
+                !tensor ||
+                !meta?.isTensor ||
+                tensor.type !== meta.type ||
+                tensor.dims.length !== 4 ||
+                tensor.dims[0] !== 1 ||
+                tensor.dims[1] < 1 ||
+                tensor.dims[3] < 1 ||
+                (typeof meta.shape[1] === 'number' && meta.shape[1] !== tensor.dims[1]) ||
+                (typeof meta.shape[3] === 'number' && meta.shape[3] !== tensor.dims[3]) ||
+                (entry?.length ?? tensor.dims[2]) !== pastLength
+            ) {
+                throw new Error(`Invalid static KV cache input "${name}".`);
+            }
+            if (entry?.owner !== info?.owner || entry?.epoch !== info?.epoch)
+                throw new Error('Cannot combine KV tensors from different static caches.');
+        }
+        if (!this.cache.size) {
+            try {
+                for (const name of this.cacheNames) {
+                    const source = feeds[name];
+                    const dims = [...source.dims];
+                    dims[2] = this.maxCacheLength;
+                    this.cache.set(name, this.createTensor(source.type, dims));
+                }
+            } catch (error) {
+                this.clearTensors(this.cache);
+                throw error;
+            }
+        }
+        if (pastLength === 0 || info?.owner !== this) {
+            // A fresh request invalidates views of the previous mutable static cache.
+            ++this.epoch;
+            if (pastLength) {
+                for (const name of this.cacheNames) this.importCache(feeds[name], this.cache.get(name), pastLength);
+            }
+        }
+
+        // One-token prompts have pastLength=0. Multi-token cache continuations
+        // also use the ordinary prefill session, even after decode was captured.
+        const decode = pastLength > 0 && ids.dims[1] === 1;
+        let outputs;
+        if (decode) {
+            await this.prepareDecode(feeds);
+            for (const [name, target] of this.decodeInputs) {
+                const source = feeds[name];
+                if (name === 'attention_mask') {
+                    const data = new TYPES[source.type](this.maxCacheLength);
+                    data.set(source.data);
+                    this.upload(new this.Tensor(source.type, data, target.dims), target);
+                } else {
+                    this.upload(source, target);
+                }
+            }
+            const decodeFeeds = { ...Object.fromEntries(this.cache), ...Object.fromEntries(this.decodeInputs) };
+            outputs = await this.session.run(decodeFeeds, this.fetches(this.decodeOutputs), {
+                extra: { gpu_graph_id: this.enableGraphCapture ? '0' : '-1' },
+            });
+        } else {
+            try {
+                outputs = await this.session.run({ ...feeds, ...Object.fromEntries(this.cache) }, this.fetches(), {
+                    extra: { gpu_graph_id: '-1' },
+                });
+            } catch (error) {
+                throw new Error(
+                    'Uncaptured prefill with static KV buffers failed. Graph capture requires a compatible GQA/shared-KV export; ordinary concatenating KV exports are not supported.',
+                    { cause: error },
+                );
+            }
+        }
+        /** @type {Record<string, Tensor>} */
+        const result = {};
+        try {
+            for (const [name, tensor] of Object.entries(outputs)) {
+                const cache = this.cache.get(name.replace(/^present\./, 'past_key_values.'));
+                if (cache) {
+                    const view = this.view(cache);
+                    setStaticCacheInfo(view, this, length);
+                    result[name] = view;
+                } else if (this.decodeOutputs.get(name) === tensor) {
+                    // getData() caches data and changes location to CPU. Download
+                    // through a fresh view so the bound tensor stays on the GPU.
+                    const view = this.view(tensor);
+                    result[name] = new this.Tensor(tensor.type, await view.getData(), tensor.dims);
+                    view.dispose();
+                } else {
+                    result[name] = tensor;
+                }
+            }
+            return result;
+        } catch (error) {
+            for (const tensor of Object.values(result)) tensor.dispose();
+            throw error;
+        }
+    }
+
+    /** @param {Map<string, Tensor>} [outputs] */
+    fetches(outputs = new Map()) {
+        return Object.fromEntries(
+            this.session.outputNames.map((name) => [
+                name,
+                this.cache.get(name.replace(/^present\./, 'past_key_values.')) ?? outputs.get(name) ?? null,
+            ]),
+        );
+    }
+
+    /** @param {Record<string, Tensor>} feeds */
+    async prepareDecode(feeds) {
+        if (this.decodeInputs.size) return;
+        /** @type {Record<string, number>} */
+        const overrides = {};
+        try {
+            for (const meta of this.session.inputMetadata) {
+                if (!meta.isTensor) throw new Error(`Unsupported non-tensor input: ${meta.name}`);
+                const source = this.cache.get(meta.name) ?? feeds[meta.name];
+                if (!source) throw new Error(`Missing decode input: ${meta.name}`);
+                const dims = [...source.dims];
+                if (meta.name === 'attention_mask') dims[1] = this.maxCacheLength;
+                for (let i = 0; i < meta.shape.length; ++i) {
+                    const symbol = meta.shape[i];
+                    if (typeof symbol === 'string') {
+                        if (overrides[symbol] !== undefined && overrides[symbol] !== dims[i])
+                            throw new Error(`Conflicting decode dimension: ${symbol}`);
+                        overrides[symbol] = dims[i];
+                    }
+                }
+                if (!this.cache.has(meta.name)) this.decodeInputs.set(meta.name, this.createTensor(source.type, dims));
+            }
+            for (const meta of this.session.outputMetadata) {
+                if (this.cache.has(meta.name.replace(/^present\./, 'past_key_values.'))) continue;
+                if (!meta.isTensor) throw new Error(`Unsupported non-tensor output: ${meta.name}`);
+                const dims = meta.shape.map((dim) => (typeof dim === 'number' ? dim : overrides[dim]));
+                if (dims.some((dim) => !Number.isSafeInteger(dim) || dim < 1))
+                    throw new Error(`Decode output "${meta.name}" must have a fixed shape.`);
+                this.decodeOutputs.set(meta.name, this.createTensor(meta.type, dims));
+            }
+        } catch (error) {
+            this.clearTensors(this.decodeInputs);
+            this.clearTensors(this.decodeOutputs);
+            throw error;
+        }
+    }
+
+    /** @param {Tensor['type']} type @param {readonly number[]} dims */
+    createTensor(type, dims) {
+        if (!TYPES[type]) throw new Error(`Unsupported WebGPU tensor type: ${type}`);
+        const size = dims.reduce((a, b) => a * b, 1) * TYPES[type].BYTES_PER_ELEMENT;
+        const buffer = this.device.createBuffer({
+            size: alignedSize(size),
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+        });
+        try {
+            return this.Tensor.fromGpuBuffer(buffer, {
+                dataType: /** @type {Tensor.GpuBufferDataTypes} */ (type),
+                dims: [...dims],
+                dispose: () => buffer.destroy(),
+            });
+        } catch (error) {
+            buffer.destroy();
+            throw error;
+        }
+    }
+
+    /** Non-owning, independently downloadable view of a bound tensor. @param {Tensor} tensor */
+    view(tensor) {
+        const buffer = tensor.gpuBuffer;
+        const bytes = tensor.size * TYPES[tensor.type].BYTES_PER_ELEMENT;
+        return this.Tensor.fromGpuBuffer(buffer, {
+            dataType: /** @type {Tensor.GpuBufferDataTypes} */ (tensor.type),
+            dims: [...tensor.dims],
+            download: async () => {
+                const staging = this.device.createBuffer({
+                    size: alignedSize(bytes),
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+                });
+                try {
+                    const encoder = this.device.createCommandEncoder();
+                    encoder.copyBufferToBuffer(buffer, 0, staging, 0, staging.size);
+                    this.device.queue.submit([encoder.finish()]);
+                    await staging.mapAsync(GPUMapMode.READ);
+                    return new TYPES[tensor.type](staging.getMappedRange().slice(0, bytes));
+                } finally {
+                    staging.destroy();
+                }
+            },
+        });
+    }
+
+    /** @param {Tensor} source @param {Tensor} target */
+    upload(source, target) {
+        if (
+            source.type !== target.type ||
+            source.dims.length !== target.dims.length ||
+            source.dims.some((d, i) => d !== target.dims[i])
+        )
+            throw new Error('Decode graph capture requires fixed input types and shapes.');
+        if (source.location === 'gpu-buffer') {
+            if (!(source.gpuBuffer.usage & GPUBufferUsage.COPY_SRC))
+                throw new Error('GPU inputs require GPUBufferUsage.COPY_SRC.');
+            const encoder = this.device.createCommandEncoder();
+            encoder.copyBufferToBuffer(
+                source.gpuBuffer,
+                0,
+                target.gpuBuffer,
+                0,
+                Math.ceil((source.size * TYPES[source.type].BYTES_PER_ELEMENT) / 4) * 4,
+            );
+            this.device.queue.submit([encoder.finish()]);
+        } else {
+            const data = /** @type {Exclude<Tensor['data'], string[]>} */ (source.data);
+            let bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+            if (bytes.byteLength % 4) {
+                const padded = new Uint8Array(Math.ceil(bytes.byteLength / 4) * 4);
+                padded.set(bytes);
+                bytes = padded;
+            }
+            this.device.queue.writeBuffer(target.gpuBuffer, 0, /** @type {Uint8Array<ArrayBuffer>} */ (bytes));
+        }
+    }
+
+    /** Import a compact external cache into each head's fixed-capacity slot. */
+    importCache(source, target, length) {
+        const bytes = TYPES[source.type].BYTES_PER_ELEMENT;
+        if (source.type !== target.type || source.dims[1] !== target.dims[1] || source.dims[3] !== target.dims[3])
+            throw new Error('External KV cache shape/type does not match this decoder.');
+        const rowBytes = length * source.dims[3] * bytes;
+        const sourceStride = source.dims[2] * source.dims[3] * bytes;
+        const targetStride = target.dims[2] * target.dims[3] * bytes;
+        if (source.location === 'gpu-buffer') {
+            if (!(source.gpuBuffer.usage & GPUBufferUsage.COPY_SRC))
+                throw new Error('GPU KV inputs require GPUBufferUsage.COPY_SRC.');
+            const encoder = this.device.createCommandEncoder();
+            for (let head = 0; head < source.dims[1]; ++head)
+                encoder.copyBufferToBuffer(
+                    source.gpuBuffer,
+                    head * sourceStride,
+                    target.gpuBuffer,
+                    head * targetStride,
+                    rowBytes,
+                );
+            this.device.queue.submit([encoder.finish()]);
+        } else {
+            for (let head = 0; head < source.dims[1]; ++head) {
+                const data = new Uint8Array(source.data.buffer, source.data.byteOffset + head * sourceStride, rowBytes);
+                this.device.queue.writeBuffer(target.gpuBuffer, head * targetStride, data);
+            }
+        }
+    }
+
+    /** @param {Map<string, Tensor>} tensors */
+    clearTensors(tensors) {
+        for (const tensor of tensors.values()) tensor.dispose();
+        tensors.clear();
+    }
+
+    async dispose() {
+        this.disposed = true;
+        this.clearTensors(this.cache);
+        this.clearTensors(this.decodeInputs);
+        this.clearTensors(this.decodeOutputs);
+    }
+}

--- a/packages/transformers/src/cache_utils.js
+++ b/packages/transformers/src/cache_utils.js
@@ -1,4 +1,5 @@
 import { Tensor } from './utils/tensor.js';
+import { getStaticCacheInfo } from './utils/static-cache.js';
 
 /**
  * A cache class that stores past key values as named tensors.
@@ -36,7 +37,7 @@ class _DynamicCache {
 
         for (const name in self) {
             if (name.startsWith('past_key_values.')) {
-                return self[name].dims.at(-2);
+                return getStaticCacheInfo(self[name].ort_tensor)?.length ?? self[name].dims.at(-2);
             }
         }
         throw new Error('Unable to determine sequence length from the cache.');

--- a/packages/transformers/src/configs.js
+++ b/packages/transformers/src/configs.js
@@ -566,6 +566,8 @@ export class AutoConfig {
 /**
  * Transformers.js-specific configuration, possibly present in config.json under the key `transformers.js_config`.
  * @typedef {Object} TransformersJSConfig
+ * @property {boolean} [use_static_cache=false] Use fixed-capacity KV buffers for compatible WebGPU decoder exports. Implied by session_options.enableGraphCapture.
+ * @property {number} [max_cache_length=2048] Maximum static KV cache token count, including the prompt.
  * @property {Record<import('./utils/devices.js').DeviceType, DeviceConfig>} [device_config] Device-specific configurations.
  * @property {Record<string, number>} [free_dimension_overrides] Override the free dimensions of the model.
  * See https://onnxruntime.ai/docs/tutorials/web/env-flags-and-session-options.html#freedimensionoverrides

--- a/packages/transformers/src/models/session.js
+++ b/packages/transformers/src/models/session.js
@@ -119,7 +119,11 @@ async function getSession(
             for (const key of names) {
                 preferredOutputLocation[key] = 'gpu-buffer';
             }
-            session_options.preferredOutputLocation = preferredOutputLocation;
+            // Preserve explicit output locations, including a global location.
+            session_options.preferredOutputLocation =
+                typeof session_options.preferredOutputLocation === 'string'
+                    ? session_options.preferredOutputLocation
+                    : { ...preferredOutputLocation, ...session_options.preferredOutputLocation };
         }
     }
 
@@ -127,7 +131,13 @@ async function getSession(
     const session_config = {
         dtype: selectedDtype,
         device: selectedDevice,
+        use_static_cache:
+            cache_config && (session_options.enableGraphCapture === true || custom_config.use_static_cache === true),
+        max_cache_length: custom_config.max_cache_length ?? 2048,
+        cache_names: cache_config ? [...getCacheNames(options.config)] : [],
     };
+    // Capture is exclusively for decoder token steps, never for other components.
+    if (!cache_config && session_options.enableGraphCapture) session_options.enableGraphCapture = false;
     return { buffer_or_path, session_options, session_config };
 }
 

--- a/packages/transformers/src/utils/hub.js
+++ b/packages/transformers/src/utils/hub.js
@@ -52,6 +52,8 @@ export { MAX_EXTERNAL_DATA_CHUNKS } from './hub/constants.js';
  * @property {import("./dtypes.js").DataType|Record<string, import("./dtypes.js").DataType>} [dtype=null] The data type to use for the model. If not specified, the data type will be chosen from the environment settings.
  * @property {ExternalData|Record<string, ExternalData>} [use_external_data_format=false] Whether to load the model using the external data format (used for models >= 2GB in size).
  * @property {import('onnxruntime-common').InferenceSession.SessionOptions} [session_options] (Optional) User-specified session options passed to the runtime. If not provided, suitable defaults will be chosen.
+ * Set `enableGraphCapture: true` with `device: 'webgpu'` to capture only decode steps of a compatible static-KV decoder export.
+ * Prefill skips capture. Configure capacity with `config["transformers.js_config"].max_cache_length` (default 2048).
  */
 
 /**

--- a/packages/transformers/src/utils/static-cache.js
+++ b/packages/transformers/src/utils/static-cache.js
@@ -1,0 +1,19 @@
+/**
+ * Logical lengths of session-owned static KV tensors (their shapes describe capacity).
+ * @type {WeakMap<object, {owner: {epoch: number, disposed: boolean}, epoch: number, length: number}>}
+ */
+const cacheInfo = new WeakMap();
+
+/** @param {object} tensor @param {{epoch: number, disposed: boolean}} owner @param {number} length */
+export function setStaticCacheInfo(tensor, owner, length) {
+    cacheInfo.set(tensor, { owner, epoch: owner.epoch, length });
+}
+
+/** @param {import('onnxruntime-common').Tensor} tensor */
+export function getStaticCacheInfo(tensor) {
+    const info = cacheInfo.get(tensor);
+    if (info && (info.owner.disposed || info.epoch !== info.owner.epoch || tensor.location === 'none')) {
+        throw new Error('This static KV cache is no longer valid: its model was disposed or started a new sequence.');
+    }
+    return info;
+}

--- a/packages/transformers/tests/utils/graph_capture.test.js
+++ b/packages/transformers/tests/utils/graph_capture.test.js
@@ -53,7 +53,6 @@ function data(tensor) {
   return new Type(tensor.gpuBuffer.bytes.buffer, 0, tensor.size);
 }
 function makeSession(device = makeDevice()) {
-  const capturedBuffers = new Map();
   const session = {
     inputNames: ["input_ids", "attention_mask", ...cacheNames],
     outputNames: ["logits", "present.0.key", "present.0.value"],
@@ -63,24 +62,12 @@ function makeSession(device = makeDevice()) {
     // derive logits from its active prefix. Wrong masks or strides change results.
     run: jest.fn(async (feeds, fetches) => {
       await Promise.resolve();
-      const captured = !fetches;
-      if (captured) {
-        fetches = {};
-        for (const name of ["logits", "present.0.key", "present.0.value"]) {
-          const dims = name === "logits" ? [1, 1, 4] : feeds[name.replace("present", "past_key_values")].dims;
-          const size = dims.reduce((a, b) => a * b, 1);
-          if (!capturedBuffers.has(name)) capturedBuffers.set(name, device.createBuffer({ size: Math.ceil((size * 4) / 16) * 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE }));
-          const buffer = capturedBuffers.get(name);
-          fetches[name] = Tensor.fromGpuBuffer(buffer, { dataType: "float32", dims, download: async () => new Float32Array(buffer.bytes.buffer, 0, size).slice(), dispose: jest.fn() });
-        }
-      }
       const ids = Array.from(data(feeds.input_ids), Number);
       const length = Number(Array.from(data(feeds.attention_mask)).reduce((a, b) => a + b, 0n));
       const offset = length - ids.length;
       for (const name of cacheNames) {
         const cache = fetches[name.replace("past_key_values", "present")];
-        if (!captured) expect(cache).toBe(feeds[name]);
-        else data(cache).set(data(feeds[name]));
+        expect(cache).toBe(feeds[name]);
         const values = data(cache);
         for (let head = 0; head < 2; ++head)
           for (let i = 0; i < ids.length; ++i) {
@@ -260,10 +247,10 @@ describe("decode capture integration", () => {
     const release = prefill.release;
     const options = { executionProviders: ["webgpu"], enableGraphCapture: true };
     const session = await createInferenceSession(new Uint8Array(), options, staticConfig);
-    expect(runtime.InferenceSession.create.mock.calls[0][1]).toMatchObject({ enableGraphCapture: false, extra: { "ep.webgpuexecutionprovider.enableGraphCapture": "1" } });
+    expect(runtime.InferenceSession.create.mock.calls.at(-1)[1]).toMatchObject({ enableGraphCapture: false, extra: { "ep.webgpuexecutionprovider.enableGraphCapture": "1" } });
     let output = await runInferenceSession(session, feeds([1, 2]));
     output = await runInferenceSession(session, feeds([3], output));
-    expect(runtime.InferenceSession.create).toHaveBeenCalledTimes(1);
+    expect(runtime.InferenceSession.create.mock.calls.filter(([, options]) => options.extra?.["ep.webgpuexecutionprovider.enableGraphCapture"] === "1")).toHaveLength(1);
     expect(prefill.run.mock.calls.map(([, , options]) => options.extra.gpu_graph_id)).toEqual(["-1", "0"]);
     expect(options.enableGraphCapture).toBe(true);
     await session.release();

--- a/packages/transformers/tests/utils/graph_capture.test.js
+++ b/packages/transformers/tests/utils/graph_capture.test.js
@@ -1,0 +1,322 @@
+import { jest } from "@jest/globals";
+import { Tensor } from "onnxruntime-common";
+import { DecodeGraphCaptureSession } from "../../src/backends/utils/graph-capture.js";
+import { getStaticCacheInfo } from "../../src/utils/static-cache.js";
+
+const cacheNames = ["past_key_values.0.key", "past_key_values.0.value"];
+const savedUsage = globalThis.GPUBufferUsage;
+const savedMode = globalThis.GPUMapMode;
+globalThis.GPUBufferUsage = { STORAGE: 128, COPY_SRC: 4, COPY_DST: 8, MAP_READ: 1 };
+globalThis.GPUMapMode = { READ: 1 };
+afterAll(() => {
+  if (savedUsage === undefined) delete globalThis.GPUBufferUsage;
+  else globalThis.GPUBufferUsage = savedUsage;
+  if (savedMode === undefined) delete globalThis.GPUMapMode;
+  else globalThis.GPUMapMode = savedMode;
+});
+
+function makeDevice() {
+  return {
+    createBuffer: jest.fn(({ size, usage }) => ({
+      size,
+      usage,
+      bytes: new Uint8Array(size),
+      destroy: jest.fn(),
+      mapAsync: jest.fn(async () => {}),
+      getMappedRange() {
+        return this.bytes.buffer;
+      },
+    })),
+    queue: {
+      writeBuffer: jest.fn((buffer, offset, data) => {
+        expect(offset % 4).toBe(0);
+        expect(data.byteLength % 4).toBe(0);
+        buffer.bytes.set(data, offset);
+      }),
+      submit: jest.fn((commands) => commands.forEach((command) => command.forEach((copy) => copy()))),
+    },
+    createCommandEncoder() {
+      const copies = [];
+      return {
+        copyBufferToBuffer(source, sourceOffset, target, targetOffset, size) {
+          expect(size % 4).toBe(0);
+          copies.push(() => target.bytes.set(source.bytes.subarray(sourceOffset, sourceOffset + size), targetOffset));
+        },
+        finish: () => copies,
+      };
+    },
+  };
+}
+function data(tensor) {
+  if (tensor.location === "cpu") return tensor.data;
+  const Type = tensor.type === "int64" ? BigInt64Array : Float32Array;
+  return new Type(tensor.gpuBuffer.bytes.buffer, 0, tensor.size);
+}
+function makeSession(device = makeDevice()) {
+  const capturedBuffers = new Map();
+  const session = {
+    inputNames: ["input_ids", "attention_mask", ...cacheNames],
+    outputNames: ["logits", "present.0.key", "present.0.value"],
+    inputMetadata: [{ name: "input_ids", isTensor: true, type: "int64", shape: ["batch_size", "sequence_length"] }, { name: "attention_mask", isTensor: true, type: "int64", shape: ["batch_size", "total_sequence_length"] }, ...cacheNames.map((name) => ({ name, isTensor: true, type: "float32", shape: ["batch_size", 2, "past_sequence_length", 2] }))],
+    outputMetadata: [{ name: "logits", isTensor: true, type: "float32", shape: ["batch_size", 1, 4] }, ...cacheNames.map((name) => ({ name: name.replace("past_key_values", "present"), isTensor: true, type: "float32", shape: ["batch_size", 2, "total_sequence_length", 2] }))],
+    // A deterministic shared-KV decoder: append token values to the cache and
+    // derive logits from its active prefix. Wrong masks or strides change results.
+    run: jest.fn(async (feeds, fetches) => {
+      await Promise.resolve();
+      const captured = !fetches;
+      if (captured) {
+        fetches = {};
+        for (const name of ["logits", "present.0.key", "present.0.value"]) {
+          const dims = name === "logits" ? [1, 1, 4] : feeds[name.replace("present", "past_key_values")].dims;
+          const size = dims.reduce((a, b) => a * b, 1);
+          if (!capturedBuffers.has(name)) capturedBuffers.set(name, device.createBuffer({ size: Math.ceil((size * 4) / 16) * 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE }));
+          const buffer = capturedBuffers.get(name);
+          fetches[name] = Tensor.fromGpuBuffer(buffer, { dataType: "float32", dims, download: async () => new Float32Array(buffer.bytes.buffer, 0, size).slice(), dispose: jest.fn() });
+        }
+      }
+      const ids = Array.from(data(feeds.input_ids), Number);
+      const length = Number(Array.from(data(feeds.attention_mask)).reduce((a, b) => a + b, 0n));
+      const offset = length - ids.length;
+      for (const name of cacheNames) {
+        const cache = fetches[name.replace("past_key_values", "present")];
+        if (!captured) expect(cache).toBe(feeds[name]);
+        else data(cache).set(data(feeds[name]));
+        const values = data(cache);
+        for (let head = 0; head < 2; ++head)
+          for (let i = 0; i < ids.length; ++i) {
+            values[head * cache.dims[2] * 2 + (offset + i) * 2] = ids[i];
+            values[head * cache.dims[2] * 2 + (offset + i) * 2 + 1] = head;
+          }
+      }
+      const active = data(fetches["present.0.key"]).filter((_, i) => i < length * 2 && i % 2 === 0);
+      const sum = active.reduce((a, b) => a + b, 0);
+      const values = [sum, length, ids.at(-1), -sum];
+      const logits = fetches.logits ?? new Tensor("float32", values, [1, 1, 4]);
+      if (fetches.logits) data(logits).set(values);
+      return { ...fetches, logits };
+    }),
+    release: jest.fn(async () => {}),
+  };
+  return session;
+}
+function feeds(ids, previous = null) {
+  const past = previous?.["present.0.key"];
+  const length = (past ? (getStaticCacheInfo(past)?.length ?? past.dims[2]) : 0) + ids.length;
+  return {
+    input_ids: new Tensor("int64", ids.map(BigInt), [1, ids.length]),
+    attention_mask: new Tensor("int64", Array(length).fill(1n), [1, length]),
+    ...Object.fromEntries(cacheNames.map((name) => [name, previous?.[name.replace("past_key_values", "present")] ?? new Tensor("float32", [], [1, 2, 0, 2])])),
+  };
+}
+
+describe("decode-only graph capture", () => {
+  let device, prefill, state;
+  beforeEach(() => {
+    device = makeDevice();
+    prefill = makeSession();
+    state = new DecodeGraphCaptureSession(prefill, device, { cacheNames, maxCacheLength: 8, enableGraphCapture: true });
+  });
+  afterEach(async () => state.dispose());
+
+  it.each([[[1]], [[1, 2, 3]]])("skips capture for a prompt of %j, including a one-token prompt", async (ids) => {
+    const output = await state.run(feeds(ids));
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "-1")).toHaveLength(1);
+    expect(prefill.run.mock.calls.every(([, , options]) => options.extra.gpu_graph_id === "-1")).toBe(true);
+    expect(state.decodeInputs.size).toBe(0);
+    expect(getStaticCacheInfo(output["present.0.key"]).length).toBe(ids.length);
+    expect(output["present.0.key"].dims).toEqual([1, 2, 8, 2]);
+  });
+
+  it("captures only decode and shares the same KV input/output buffers with prefill", async () => {
+    let output = await state.run(feeds([1, 2]));
+    const first = output.logits;
+    output = await state.run(feeds([3], output));
+    const second = output.logits;
+    output = await state.run(feeds([4], output));
+    expect(state.decodeInputs.get("input_ids").dims).toEqual([1, 1]);
+    expect(state.decodeInputs.get("attention_mask").dims).toEqual([1, 8]);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "-1")).toHaveLength(1);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "0")).toHaveLength(2);
+    expect(prefill.run.mock.calls[1][0].input_ids).toBe(prefill.run.mock.calls[2][0].input_ids);
+    expect(prefill.run.mock.calls[1][0][cacheNames[0]]).toBe(prefill.run.mock.calls[0][0][cacheNames[0]]);
+    expect(Array.from(first.data)).toEqual([3, 2, 2, -3]);
+    expect(Array.from(second.data)).toEqual([6, 3, 3, -6]);
+    expect(Array.from(output.logits.data)).toEqual([10, 4, 4, -10]);
+    expect(state.decodeOutputs.get("logits").location).toBe("gpu-buffer");
+  });
+
+  it("bypasses an existing captured decoder for later prefills and clears trailing mask values", async () => {
+    let old = await state.run(feeds([1, 2, 3, 4]));
+    old = await state.run(feeds([5], old));
+    let output = await state.run(feeds([7]));
+    expect(() => getStaticCacheInfo(old["present.0.key"])).toThrow("no longer valid");
+    output = await state.run(feeds([2], output));
+    expect(Array.from(output.logits.data)).toEqual([9, 2, 2, -9]);
+    expect(Array.from(data(state.decodeInputs.get("attention_mask")))).toEqual([1n, 1n, 0n, 0n, 0n, 0n, 0n, 0n]);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "-1")).toHaveLength(2);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "0")).toHaveLength(2);
+    expect(state.decodeInputs.get("input_ids").dims).toEqual([1, 1]);
+  });
+
+  it("runs multi-token cache continuation as prefill after capture", async () => {
+    let output = await state.run(feeds([1]));
+    output = await state.run(feeds([2], output));
+    output = await state.run(feeds([3, 4], output));
+    expect(Array.from(output.logits.data)).toEqual([10, 4, 4, -10]);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "-1")).toHaveLength(2);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "0")).toHaveLength(1);
+    output = await state.run(feeds([5], output));
+    expect(Array.from(output.logits.data)).toEqual([15, 5, 5, -15]);
+  });
+
+  it("supports an identical static-KV path with capture disabled", async () => {
+    state.enableGraphCapture = false;
+    let output = await state.run(feeds([1, 2]));
+    output = await state.run(feeds([3], output));
+    expect(Array.from(output.logits.data)).toEqual([6, 3, 3, -6]);
+    expect(prefill.run.mock.calls.filter(([, , options]) => options.extra.gpu_graph_id === "-1")).toHaveLength(2);
+    expect(prefill.run.mock.calls.every(([, , options]) => options.extra.gpu_graph_id === "-1")).toBe(true);
+  });
+
+  it("imports compact external KV data using each head's stride", async () => {
+    const old = Object.fromEntries(cacheNames.map((name) => [name.replace("past_key_values", "present"), new Tensor("float32", [1, 0, 2, 0, 1, 1, 2, 1], [1, 2, 2, 2])]));
+    const output = await state.run(feeds([3], old));
+    expect(Array.from(output.logits.data)).toEqual([6, 3, 3, -6]);
+    const values = data(state.cache.get(cacheNames[0]));
+    expect(Array.from(values.slice(16, 22))).toEqual([1, 1, 2, 1, 3, 1]);
+  });
+
+  it("does not let disposing returned KV views destroy captured buffers", async () => {
+    const output = await state.run(feeds([1]));
+    const buffer = output["present.0.key"].gpuBuffer;
+    output["present.0.key"].dispose();
+    expect(buffer.destroy).not.toHaveBeenCalled();
+    await state.dispose();
+    await state.dispose();
+    expect(buffer.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks capacity before changing any buffers, then permits a valid call", async () => {
+    const output = await state.run(feeds([1, 2]));
+    const writes = device.queue.writeBuffer.mock.calls.length;
+    await expect(state.run(feeds([3, 4, 5, 6, 7, 8, 9], output))).rejects.toThrow("capacity");
+    expect(device.queue.writeBuffer).toHaveBeenCalledTimes(writes);
+    expect(Array.from((await state.run(feeds([3], output))).logits.data)).toEqual([6, 3, 3, -6]);
+  });
+
+  it("rejects batches and mismatched attention-mask lengths", async () => {
+    const input = feeds([1, 2]);
+    input.input_ids = new Tensor("int64", [1n, 2n], [2, 1]);
+    await expect(state.run(input)).rejects.toThrow("batch size 1");
+    const badMask = feeds([1, 2]);
+    badMask.attention_mask = new Tensor("int64", [1n], [1, 1]);
+    await expect(state.run(badMask)).rejects.toThrow("attention_mask length");
+    expect(prefill.run).not.toHaveBeenCalled();
+  });
+
+  it("frees partial decode allocations and retries without disabling capture", async () => {
+    const output = await state.run(feeds([1, 2]));
+    device.createBuffer.mockImplementationOnce(() => {
+      throw new Error("out of memory");
+    });
+    await expect(state.run(feeds([3], output))).rejects.toThrow("out of memory");
+    expect(state.decodeInputs.size).toBe(0);
+    expect(Array.from((await state.run(feeds([3], output))).logits.data)).toEqual([6, 3, 3, -6]);
+    expect(prefill.run.mock.calls.at(-1)[2].extra.gpu_graph_id).toBe("0");
+  });
+
+  it("rejects use of disposed buffers", async () => {
+    const output = await state.run(feeds([1]));
+    const buffer = output["present.0.key"].gpuBuffer;
+    await state.dispose();
+    expect(buffer.destroy).toHaveBeenCalledTimes(1);
+    await expect(state.run(feeds([1]))).rejects.toThrow("disposed");
+  });
+});
+
+const runtime = { Tensor, env: { versions: { web: "test" }, wasm: { proxy: false, wasmPaths: "test/" }, webgpu: {} }, InferenceSession: { create: jest.fn() } };
+jest.unstable_mockModule("onnxruntime-node", () => runtime);
+jest.unstable_mockModule("onnxruntime-web/webgpu", () => runtime);
+jest.unstable_mockModule("../../src/utils/model-loader.js", () => ({ getCoreModelFile: async () => new Uint8Array(), getModelDataFiles: async () => [] }));
+const { createInferenceSession, runInferenceSession } = await import("../../src/backends/onnx.js");
+const { constructSessions, sessionRun } = await import("../../src/models/session.js");
+const { Tensor: TransformersTensor } = await import("../../src/utils/tensor.js");
+const { DynamicCache } = await import("../../src/cache_utils.js");
+const staticConfig = { use_static_cache: true, cache_names: cacheNames, max_cache_length: 8 };
+const modelConfig = { model_type: "phi3", num_hidden_layers: 1, num_attention_heads: 2, num_key_value_heads: 2, hidden_size: 4, vocab_size: 4 };
+
+describe("decode capture integration", () => {
+  let device, prefill;
+  beforeEach(() => {
+    device = makeDevice();
+    prefill = makeSession();
+    runtime.env.webgpu.device = Promise.resolve(device);
+    runtime.env.wasm.proxy = false;
+    runtime.env.versions.web = "test";
+    runtime.InferenceSession.create.mockReset().mockResolvedValue(prefill);
+  });
+
+  it("enables C++ capture while retaining ordinary JS bindings and skips prefill", async () => {
+    const release = prefill.release;
+    const options = { executionProviders: ["webgpu"], enableGraphCapture: true };
+    const session = await createInferenceSession(new Uint8Array(), options, staticConfig);
+    expect(runtime.InferenceSession.create.mock.calls[0][1]).toMatchObject({ enableGraphCapture: false, extra: { "ep.webgpuexecutionprovider.enableGraphCapture": "1" } });
+    let output = await runInferenceSession(session, feeds([1, 2]));
+    output = await runInferenceSession(session, feeds([3], output));
+    expect(runtime.InferenceSession.create).toHaveBeenCalledTimes(1);
+    expect(prefill.run.mock.calls.map(([, , options]) => options.extra.gpu_graph_id)).toEqual(["-1", "0"]);
+    expect(options.enableGraphCapture).toBe(true);
+    await session.release();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+  it("preserves logical KV lengths through Transformers.js tensor wrapping and cache updates", async () => {
+    const session = await createInferenceSession(new Uint8Array(), { executionProviders: ["webgpu"], enableGraphCapture: true }, staticConfig);
+    const input = Object.fromEntries(Object.entries(feeds([1, 2])).map(([name, tensor]) => [name, new TransformersTensor(tensor)]));
+    const output = await sessionRun(session, input);
+    const cache = new DynamicCache({ [cacheNames[0]]: output["present.0.key"], [cacheNames[1]]: output["present.0.value"] });
+    expect(cache.get_seq_length()).toBe(2);
+    expect(output["present.0.key"].dims[2]).toBe(8);
+    expect(output.logits.tolist()).toEqual([[[3, 2, 2, -3]]]);
+    await cache.dispose();
+    await session.release();
+  });
+
+  it("never enables capture on encoder/component sessions", async () => {
+    await constructSessions("test/model", { model: "model" }, { device: "webgpu", dtype: "fp32", config: modelConfig, session_options: { enableGraphCapture: true } });
+    expect(runtime.InferenceSession.create.mock.calls[0][1].enableGraphCapture).toBe(false);
+  });
+
+  it("automatically selects static KV handling for a decoder with capture enabled", async () => {
+    const sessions = await constructSessions("test/model", { model: "model" }, { device: "webgpu", dtype: "fp32", config: { ...modelConfig, "transformers.js_config": { max_cache_length: 8 } }, session_options: { enableGraphCapture: true } }, { model: true });
+    expect(sessions.model.config).toMatchObject(staticConfig);
+    await sessions.model.release();
+  });
+
+  it("recovers the global inference queue after an invalid call", async () => {
+    const session = await createInferenceSession(new Uint8Array(), { executionProviders: ["webgpu"], enableGraphCapture: true }, staticConfig);
+    await expect(runInferenceSession(session, feeds(Array(9).fill(1)))).rejects.toThrow("capacity");
+    await expect(runInferenceSession(session, feeds([1]))).resolves.toHaveProperty("logits");
+    await session.release();
+  });
+
+  it("releases buffers before rejecting a queued run after disposal", async () => {
+    const session = await createInferenceSession(new Uint8Array(), { executionProviders: ["webgpu"], enableGraphCapture: true }, staticConfig);
+    await runInferenceSession(session, feeds([1]));
+    const released = session.release();
+    await expect(runInferenceSession(session, feeds([2]))).rejects.toThrow("disposed");
+    await released;
+  });
+
+  it.each(["cpu", "wasm"])("rejects a static cache with %s", async (provider) => {
+    await expect(createInferenceSession(new Uint8Array(), { executionProviders: [provider], enableGraphCapture: true }, staticConfig)).rejects.toThrow("ONNX Runtime Web");
+  });
+
+  it("rejects proxy mode and native ORT", async () => {
+    const options = { executionProviders: ["webgpu"], enableGraphCapture: true };
+    runtime.env.wasm.proxy = true;
+    await expect(createInferenceSession(new Uint8Array(), options, staticConfig)).rejects.toThrow("proxy");
+    runtime.env.wasm.proxy = false;
+    delete runtime.env.versions.web;
+    await expect(createInferenceSession(new Uint8Array(), options, staticConfig)).rejects.toThrow("ONNX Runtime Web");
+  });
+});


### PR DESCRIPTION
Enable WebGPU graph capture only for single-token decode. Every prefill uses `gpu_graph_id=-1`, including one-token prompts, subsequent prompts, and multi-token cache continuations. Encoder/component sessions run normally.

**Dependency: https://github.com/microsoft/onnxruntime/pull/32456.** The currently pinned ORT package applies extra provider config too late and silently ignores the capture setting. This PR stays in draft until that fix is available in the pinned runtime. A benchmark helper builds the prerequisite JS patch against the existing, unchanged WASM binaries for review and reproduction now.

The decoder uses fixed-capacity, shared KV input/output buffers and tracks logical cache length separately from capacity. C++ EP capture configuration preserves ordinary JS I/O rebinding, allowing variable prefill shapes and stable decode buffers in one session, with one copy of model weights. Logits are downloaded for sampling; KV stays on GPU.

Use `session_options: { enableGraphCapture: true }` with a graph-ready GQA/static-KV export. `transformers.js_config.max_cache_length` defaults to 2048. This initial implementation supports batch size 1 and one active sequence per model. A fresh prompt invalidates older retained cache views. Native Node ORT and legacy JSEP are outside this feature's scope.

### Phi-4-mini performance

Actual Transformers.js `generate()` with ORT Web Asyncify, Dawn/D3D12, RTX 5080, Node 24.20.0, graph-ready INT4 export. Both modes use the same patched JS runtime, unchanged WASM/model assets, and shared static KV buffers. Workload: 128 prompt + 128 generated tokens, cache capacity 2048, two warmups, five measured runs per mode.

| Median metric | Capture off | Decode capture on |
| --- | ---: | ---: |
| Decode tokens/sec | 55.32 | 130.76 |
| Time to first token | 38.93 ms | 40.25 ms |

**2.36× decode speedup (+136.4%)**, with identical generated token IDs. An earlier independent series measured 51.46 → 128.45 tokens/sec (2.50×). Prefill remains uncaptured. These are ORT Web measurements through a Node WebGPU binding, not native ORT GenAI or browser performance claims.

The benchmark first verifies native graph-replay log events outside the timed sessions and refuses to report a speedup when capture is inactive. Includes raw trials, asset hashes, generated IDs, and reproduction instructions in `docs/source/guides/graph_capture_benchmark.md`.

### Validation

- Package build and TypeScript declarations pass; formatting/whitespace checks pass.
- 313 utility tests pass (including 21 decode-capture regressions); 1 existing test skipped.
- 11 selected BERT/GPT-2 model tests pass.
- Phi-4-mini exact token parity with capture off/on, repeated requests, and one-token prompt smoke test.
- Prerequisite E2E regression passes with the runtime patch and fails with the stock runtime.
- Final benchmark verifies replay and token equality; its stock-runtime control exits before producing a performance report.
